### PR TITLE
Add GStreamer recorder with device selection and improved UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Speed of Sound
 
-Speed of Sound (SOS) provides voice typing for any Linux desktop application, powered by state-of-the-art speech recognition models, both local and cloud-based.
+Speed of Sound provides voice typing for any Linux desktop application, powered by state-of-the-art speech recognition models, both local and cloud-based.
 <div align="center">
-  <img src="assets/sos-listening.png" alt="SOS Screenshot">
+  <img src="assets/sos-listening.png" alt="Speed of Sound Screenshot">
 </div>
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Choose how to activate voice input:
 
 For manual shortcuts and joystick setup, see the [trigger configuration guide](docs/trigger.md).
 
+Once activated, you can cancel the recording by pressing **Escape**. Recording will automatically stop after 60 seconds (configurable in `config.toml`, see below).
+
 ## Configuration
 
 Speed of Sound uses a `config.toml` file for all settings. Start by copying the example configuration:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ cp config.example.toml config.toml
 
 The default configuration uses a local Whisper server for privacy-focused speech recognition. For additional providers and configuration options, see the [configuration documentation](docs/config.md).
 
+### ⚠️ Wayland Compatibility
+
+Wayland has stricter security restrictions than X11 for keyboard event simulation, which is required for voice typing functionality.
+
+Speed of Sound automatically detects your display server and selects the appropriate typing backend. On Wayland, we use `ydotool` instead of traditional X11 tools like `xdotool` or AT-SPI. However, `ydotool` may require additional configuration.
+
+**Troubleshooting**: If you see speech being transcribed but not typed into applications, see the [typist backend configuration guide](docs/advanced.md#typist-backend-selection). 
+
 ## Reporting Issues
 
 If you encounter any bugs, have feature requests, or need help with Speed of Sound, please open an issue on this repository:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# Documentation
+
+Welcome to the Speed of Sound documentation. This directory contains detailed guides and configuration information to help you get the most out of the application.
+
+## Configuration Guides
+
+### Core Configuration
+- **[Configuration](config.md)** - Main configuration file setup and common settings
+- **[Advanced Configuration](advanced.md)** - Typist backend selection and joystick/gamepad control
+
+### Activation Methods
+- **[Trigger Methods](trigger.md)** - Keyboard shortcuts and joystick activation options
+
+## Speech Recognition Providers
+
+Speed of Sound supports multiple speech recognition providers, both local and cloud-based:
+
+### Local Providers
+- **[Whisper](whisper.md)** - Local Whisper server (default, privacy-focused)
+- **[NVIDIA Riva](nvidia.md)** - NVIDIA Riva local speech recognition
+
+### Cloud Providers
+- **[NVIDIA NIM](nvidia.md)** - NVIDIA NIM cloud service
+- **[Google Gemini](google.md)** - Google Speech-to-Text
+- **[OpenAI](openai.md)** - OpenAI GPT-4o and Whisper API
+- **[ElevenLabs](elevenlabs.md)** - ElevenLabs Speech-to-Text
+
+## Getting Started
+
+1. Start with the **[Configuration](config.md)** guide to set up your basic settings
+2. Choose your preferred speech recognition provider from the list above
+3. Set up activation methods using the **[Trigger Methods](trigger.md)** guide
+4. For advanced features, see **[Advanced Configuration](advanced.md)**
+
+## Need Help?
+
+If you encounter issues or need additional help, please [report an issue](https://github.com/zugaldia/speedofsound/issues) on the main repository.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -42,6 +42,26 @@ You should see "Hello World" typed in the current terminal window, confirming th
 
 ## Recording Settings
 
+### Recorder Backend Selection
+
+Speed of Sound supports multiple audio recording backends. By default, it uses GStreamer, which provides robust audio handling and is well-integrated with the Linux desktop environment.
+
+This setting is optional and normally you wouldn't need to change it:
+
+```toml
+recorder_backend = "gstreamer"
+```
+
+Available backends:
+- `"gstreamer"` - GStreamer-based recording (default)
+- `"pyaudio"` - PyAudio-based recording (fallback option)
+
+If you encounter audio recording issues, you can switch to PyAudio for troubleshooting:
+
+```toml
+recorder_backend = "pyaudio"
+```
+
 ### Recording Timeout
 
 By default, recordings automatically stop after 60 seconds to prevent indefinitely long recordings. You can customize this timeout:

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -23,3 +23,35 @@ Available backends:
 
 - [`xdotool`](https://github.com/jordansissel/xdotool) - tends to work out of the box
 - [`ydotool`](https://github.com/ReimuNotMoe/ydotool) - may require additional user permissions for input access
+
+Due to Wayland's security model, `ydotool` requires elevated permissions to access input devices. One solution is to set the setuid bit, allowing any user to run it with the necessary privileges:
+
+```bash
+sudo chmod +s $(which ydotool)
+```
+
+**Security Note**: Setting the setuid bit should be done carefully and intentionally, as it grants elevated privileges to all users on the system. The instructions here are provided as a guide, but ultimately it is the user's responsibility to configure their system appropriately for their security requirements.
+
+**Test the configuration**:
+
+```bash
+ydotool type "Hello World"
+```
+
+You should see "Hello World" typed in the current terminal window, confirming that `ydotool` is working correctly.
+
+## Joystick/Gamepad Control
+
+If you have one or more joysticks connected to your system, you can use them to start and stop the app. You can also use left and right buttons to switch the input language.
+
+This section is optional:
+
+```toml
+joystick_id = 0
+joystick_language_left = "en"
+joystick_language_right = "es"
+```
+
+- `joystick_id`: Joystick device ID (as detected by PyGame)
+- `joystick_language_left`: Language for left joystick button
+- `joystick_language_right`: Language for right joystick button

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -40,6 +40,18 @@ ydotool type "Hello World"
 
 You should see "Hello World" typed in the current terminal window, confirming that `ydotool` is working correctly.
 
+## Recording Settings
+
+### Recording Timeout
+
+By default, recordings automatically stop after 60 seconds to prevent indefinitely long recordings. You can customize this timeout:
+
+```toml
+recording_timeout_seconds = 60
+```
+
+- `recording_timeout_seconds`: Maximum recording duration in seconds (default: 60, range: 1-300)
+
 ## Joystick/Gamepad Control
 
 If you have one or more joysticks connected to your system, you can use them to start and stop the app. You can also use left and right buttons to switch the input language.

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,9 +6,11 @@ Speed of Sound uses a TOML configuration file located at `config.toml` in the pr
 cp config.example.toml config.toml
 ```
 
-It shows the basic settings needed to set up the application with Whisper as the Speech-to-Text backend. 
+This shows the basic settings needed to set up the application with Whisper as the speech-to-text backend. 
 
 ## General Settings
+
+This document describes common settings you likely want to tweak. For other settings like joystick integration or typing backend configuration, see [`advanced.md`](advanced.md).
 
 ### Language Configuration
 
@@ -28,20 +30,6 @@ microphone_id = -1
 
 - `microphone_id`: Audio input device ID. Use `-1` for system default, or specify a device ID
 
-### Joystick/Gamepad Control
-
-This section is optional:
-
-```toml
-joystick_id = 0
-joystick_language_left = "en"
-joystick_language_right = "es"
-```
-
-- `joystick_id`: Joystick device ID (as detected by PyGame)
-- `joystick_language_left`: Language for left joystick button
-- `joystick_language_right`: Language for right joystick button
-
 ### Transcriber Selection
 
 ```toml
@@ -53,7 +41,7 @@ Choose your transcription provider:
 - `"nvidia_riva"` - NVIDIA Riva (local)
 - `"nvidia_nim"` - NVIDIA NIM (cloud)
 - `"google"` - Google Gemini (cloud)
-- `"openai"` - OpenAI GTP-4o and Whisper API (cloud)
+- `"openai"` - OpenAI GPT-4o and Whisper API (cloud)
 - `"elevenlabs"` - ElevenLabs Speech-to-Text (cloud)
 - `"race"` - Run multiple providers simultaneously (hybrid)
 
@@ -71,7 +59,7 @@ Each transcription provider has its own configuration section. For detailed setu
 ## Configuration Tips
 
 1. **Start Simple**: Begin with the default Whisper configuration for local processing
-2. **Multiple Providers**: You can enable multiple providers and use the "race" transcriber to run them simultaneously. This is helpful with cloud providers that have frequent outages or latency issues to ensure you always get a fast response. However, this transcriber is not limited to cloud - you can mix and match local and cloud providers
+2. **Multiple Providers**: Enable multiple providers and use the "race" transcriber to run them simultaneously. This ensures fast responses when cloud providers experience outages or latency issues. You can mix and match both local and cloud providers
 3. **Language Detection**: Enable `language_auto` for automatic language detection, or set a specific language for better performance
 
 ## Example Configurations

--- a/docs/trigger.md
+++ b/docs/trigger.md
@@ -1,6 +1,6 @@
 # Trigger Methods
 
-Besides the GNOME Shell Extension, Speed of Sound (SOS) provides two additional methods to activate voice input, each designed for different use cases and accessibility needs. Once activated, the application will capture your voice, transcribe it using your configured AI model, and type the result into the currently active window.
+Besides the GNOME Shell Extension, Speed of Sound provides two additional methods to activate voice input, each designed for different use cases and accessibility needs. Once activated, the application will capture your voice, transcribe it using your configured AI model, and type the result into the currently active window.
 
 ## Keyboard Shortcut
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,6 +1,6 @@
 # Speed of Sound GNOME Shell Extension
 
-This GNOME Shell extension provides a top bar indicator for the Speed of Sound (SOS) application.
+This GNOME Shell extension provides a top bar indicator for the Speed of Sound application.
 
 ## About top bar icons
 
@@ -8,9 +8,9 @@ As it turns out, top bar icons are a controversial topic in Linux these days :-)
 
 There is [a specification](https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/) but there's no consensus around it. This recent [discussion thread](https://gitlab.freedesktop.org/xdg/xdg-specs/-/issues/205) provides a good summary of where things stand. [This video](https://www.youtube.com/watch?v=02nFos3iHlo) also does a good job explaining the longer story and context.
 
-You can use SOS without a top bar icon, but we believe its usability improves significantly with one. This is because SOS isn't your typical desktop application: it runs in the background, its window only appears when triggered, and it needs to interact with any other application on your desktop. In other words, a top bar icon is the right pattern for this use case.
+You can use Speed of Sound without a top bar icon, but we believe its usability improves significantly with one. This is because Speed of Sound isn't your typical desktop application: it runs in the background, its window only appears when triggered, and it needs to interact with any other application on your desktop. In other words, a top bar icon is the right pattern for this use case.
 
-GNOME Shell extensions are currently the recommended way to add icons to the top bar, which is exactly what this extension does. Most of SOS' logic remains in the main application—this extension is minimal by design. It provides a visual color-coded indicator showing the application's status, surfaces error messages through desktop notifications, and offers basic interactions with the background application.
+GNOME Shell extensions are currently the recommended way to add icons to the top bar, which is exactly what this extension does. Most of Speed of Sound's logic remains in the main application—this extension is minimal by design. It provides a visual color-coded indicator showing the application's status, surfaces error messages through desktop notifications, and offers basic interactions with the background application.
 
 ## Features
 

--- a/speedofsound/application.py
+++ b/speedofsound/application.py
@@ -5,6 +5,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 gi.require_version("Atspi", "2.0")
+gi.require_version("Gst", "1.0")
 from gi.repository import Adw, Gio  # type: ignore  # noqa: E402
 
 from speedofsound.constants import APPLICATION_ID, LOG_FILE  # noqa: E402

--- a/speedofsound/models.py
+++ b/speedofsound/models.py
@@ -53,6 +53,11 @@ class TypistBackend(StrEnum):
     ATSPI = "atspi"
 
 
+class RecorderBackend(StrEnum):
+    PYAUDIO = "pyaudio"
+    GSTREAMER = "gstreamer"
+
+
 class NvidiaRivaConfig(BaseModel):
     """NVIDIA Riva transcriber configuration."""
 
@@ -122,6 +127,9 @@ class AppConfig(BaseModel):
 
     # Transcriber settings
     transcriber: str = TranscriberType.WHISPER.value
+
+    # Recorder settings
+    recorder_backend: str = RecorderBackend.GSTREAMER.value
 
     # Typist settings
     typist_backend: Optional[str] = None

--- a/speedofsound/models.py
+++ b/speedofsound/models.py
@@ -114,7 +114,7 @@ class AppConfig(BaseModel):
     language_auto: bool = True
     language: str = DEFAULT_LANGUAGE.id
 
-    microphone_id: int = -1
+    microphone_id: Optional[int] = None
 
     # Optional: This is the ID of the joystick as detected by PyGame.
     # The id argument must be a value from 0 to pygame.joystick.get_count() - 1.

--- a/speedofsound/models.py
+++ b/speedofsound/models.py
@@ -237,7 +237,7 @@ class RecorderRequest(BaseRequest):
     rate: int = 16000
     channels: int = 1
     sample_width: int = 2
-    input_device: Optional[int] = None
+    microphone_id: Optional[int] = None
     frames_per_buffer: int = 1024
 
 

--- a/speedofsound/models.py
+++ b/speedofsound/models.py
@@ -5,7 +5,7 @@ from enum import IntEnum, StrEnum
 from typing import Optional
 
 from gi.repository import GObject  # type: ignore
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from speedofsound.utils import get_uuid
 
@@ -116,6 +116,9 @@ class AppConfig(BaseModel):
     joystick_id: Optional[int] = None
     joystick_language_left: str = LANGUAGE_ENGLISH.id
     joystick_language_right: str = LANGUAGE_SPANISH.id
+
+    # Recording settings
+    recording_timeout_seconds: int = Field(default=60, ge=1, le=300)
 
     # Transcriber settings
     transcriber: str = TranscriberType.WHISPER.value

--- a/speedofsound/services/orchestrator/orchestrator_service.py
+++ b/speedofsound/services/orchestrator/orchestrator_service.py
@@ -53,6 +53,7 @@ class OrchestratorService(BaseService):
         self._stage = OrchestratorStage.INITIALIZING
         self._configuration_service = configuration_service
         self._queued_typing: Optional[TypistRequest] = None
+        self._recording_cancelled = False
 
         self._control = control_service
         self._control.connect(CONTROL_EVENT_SIGNAL, self._on_control_event)
@@ -116,6 +117,7 @@ class OrchestratorService(BaseService):
             return
         self._send_event(OrchestratorStage.RECORDING, "Listening...")
         self._queued_typing = None
+        self._recording_cancelled = False
         self._recorder.start_recording()
 
     def _action_stop(self) -> None:
@@ -127,6 +129,12 @@ class OrchestratorService(BaseService):
     def action_type(self) -> None:
         if self._queued_typing:
             self._typist.type_async(self._queued_typing)
+
+    def cancel_recording(self) -> None:
+        if self._stage == OrchestratorStage.RECORDING:
+            self._logger.info("Canceling recording...")
+            self._recording_cancelled = True
+            self._recorder.stop_recording()
 
     #
     # Private API
@@ -159,6 +167,11 @@ class OrchestratorService(BaseService):
                     message=recorder_response.message,
                     success=recorder_response.success,
                 )
+
+            # If recording was cancelled, skip transcription and go directly to ready
+            if self._recording_cancelled:
+                self._recording_cancelled = False
+                return self._send_event(OrchestratorStage.READY)
 
             self._send_event(OrchestratorStage.TRANSCRIBING, "Transcribing...")
             self._transcriber.transcribe_async(

--- a/speedofsound/services/recorder/base_recorder.py
+++ b/speedofsound/services/recorder/base_recorder.py
@@ -1,0 +1,50 @@
+import audioop
+import typing
+from abc import ABC, abstractmethod
+
+from speedofsound.models import MicrophoneDevice, RecorderRequest
+from speedofsound.services.base_provider import BaseProvider
+
+
+class BaseRecorder(BaseProvider, ABC):
+    def __init__(self, provider_name: str):
+        super().__init__(provider_name=provider_name)
+        self._volume_callback = None
+        self._max_rms = 0.0
+        self._sample_width = None
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        pass
+
+    @abstractmethod
+    def get_input_devices(self) -> typing.List[MicrophoneDevice]:
+        pass
+
+    @abstractmethod
+    def is_recording(self) -> bool:
+        pass
+
+    @abstractmethod
+    def start_recording(self, recorder_request: RecorderRequest) -> None:
+        pass
+
+    @abstractmethod
+    def stop_recording(self) -> bytes:
+        pass
+
+    def set_volume_callback(self, callback) -> None:
+        """Set callback function to receive volume level updates."""
+        self._volume_callback = callback
+
+    def _calculate_rms_volume(self, audio_data: bytes) -> None:
+        """Calculate RMS volume from audio data, normalized to 0.0-1.0."""
+        if not self._volume_callback or not self._sample_width:
+            return
+        try:
+            rms = audioop.rms(audio_data, self._sample_width)
+            self._max_rms = max(self._max_rms, rms)
+            rms_normalized = rms / self._max_rms if self._max_rms > 0 else 0.0
+            self._volume_callback(rms_normalized)
+        except Exception as e:
+            self._logger.error(f"Error calculating RMS volume: {e}")

--- a/speedofsound/services/recorder/gstreamer_recorder.py
+++ b/speedofsound/services/recorder/gstreamer_recorder.py
@@ -1,0 +1,109 @@
+import threading
+from typing import List, Optional
+
+from gi.repository import Gst  # type: ignore
+
+from speedofsound.models import MicrophoneDevice, RecorderRequest
+from speedofsound.services.recorder.base_recorder import BaseRecorder
+
+
+class GStreamerRecorder(BaseRecorder):
+    def __init__(self) -> None:
+        super().__init__(provider_name="gstreamer")
+        Gst.init()
+        self._pipeline: Optional[Gst.Pipeline] = None
+        self._appsink: Optional[Gst.Element] = None
+        self._audio_data: List[bytes] = []
+        self._is_recording: bool = False
+        self._recording_lock: threading.Lock = threading.Lock()
+        self._logger.info(f"GStreamer recorder v{Gst.version_string()} initialized.")
+
+    def shutdown(self) -> None:
+        self._logger.info("Shutting down.")
+        with self._recording_lock:
+            if self._pipeline:
+                self._pipeline.set_state(Gst.State.NULL)
+                self._pipeline = None
+
+    def get_input_devices(self) -> List[MicrophoneDevice]:
+        devices = []
+        monitor = Gst.DeviceMonitor.new()
+        monitor.add_filter("Audio/Source", None)
+        monitor.start()
+        for device in monitor.get_devices():
+            device_class = device.get_device_class()
+            if "Audio/Source" in device_class:
+                display_name = device.get_display_name()
+                device_name = device.get_properties().get_string("device.path")
+                if not device_name:
+                    device_name = display_name
+                devices.append(MicrophoneDevice(id=len(devices), name=device_name))
+
+        monitor.stop()
+        return devices
+
+    def is_recording(self) -> bool:
+        with self._recording_lock:
+            return self._is_recording
+
+    def start_recording(self, recorder_request: RecorderRequest) -> None:
+        self._logger.info(f"Recorder request: {recorder_request}")
+
+        with self._recording_lock:
+            if self._is_recording:
+                self._logger.warning("Already recording, stopping current recording")
+                self._stop_recording_internal()
+
+            self._audio_data = []
+            self._sample_width = recorder_request.sample_width
+
+            # Create pipeline
+            format_map = {1: "S8", 2: "S16LE", 4: "S32LE"}
+            audio_format = format_map.get(recorder_request.sample_width, "S16LE")
+            pipeline_str = (
+                f"pulsesrc ! "
+                f"audio/x-raw,format={audio_format},"
+                f"channels={recorder_request.channels},"
+                f"rate={recorder_request.rate} ! "
+                f"appsink name=sink emit-signals=true"
+            )
+
+            self._pipeline = Gst.parse_launch(pipeline_str)
+            self._appsink = self._pipeline.get_by_name("sink")
+
+            # Connect to new-sample signal
+            self._appsink.connect("new-sample", self._on_new_sample)
+
+            # Start pipeline
+            self._pipeline.set_state(Gst.State.PLAYING)
+            self._is_recording = True
+
+    def stop_recording(self) -> bytes:
+        with self._recording_lock:
+            return self._stop_recording_internal()
+
+    def _stop_recording_internal(self) -> bytes:
+        self._logger.info("Stopping.")
+
+        if self._pipeline:
+            self._pipeline.set_state(Gst.State.NULL)
+            self._pipeline = None
+            self._appsink = None
+
+        self._is_recording = False
+        audio_data = b"".join(self._audio_data)
+        self._audio_data = []
+
+        return audio_data
+
+    def _on_new_sample(self, appsink: Gst.Element) -> Gst.FlowReturn:
+        sample = appsink.emit("pull-sample")
+        if sample:
+            buffer = sample.get_buffer()
+            success, map_info = buffer.map(Gst.MapFlags.READ)
+            if success:
+                audio_chunk = map_info.data
+                self._audio_data.append(audio_chunk)
+                self._calculate_rms_volume(audio_chunk)
+                buffer.unmap(map_info)
+        return Gst.FlowReturn.OK

--- a/speedofsound/services/recorder/gstreamer_recorder.py
+++ b/speedofsound/services/recorder/gstreamer_recorder.py
@@ -61,11 +61,12 @@ class GStreamerRecorder(BaseRecorder):
 
             try:
                 # Custom device ID
-                if recorder_request.input_device is not None:
+                if recorder_request.microphone_id is not None:
                     all_devices = self.get_input_devices()
-                    device_name = all_devices[recorder_request.input_device].name
-                    self._logger.info(f"Using device: {device_name}")
-                    device_param = f"device={device_name} "
+                    if 0 <= recorder_request.microphone_id < len(all_devices):
+                        device_name = all_devices[recorder_request.microphone_id].name
+                        self._logger.info(f"Using device: {device_name}")
+                        device_param = f"device={device_name} "
             except Exception as e:
                 self._logger.error(f"Error getting device name: {e}")
 

--- a/speedofsound/services/recorder/gstreamer_recorder.py
+++ b/speedofsound/services/recorder/gstreamer_recorder.py
@@ -24,6 +24,8 @@ class GStreamerRecorder(BaseRecorder):
             if self._pipeline:
                 self._pipeline.set_state(Gst.State.NULL)
                 self._pipeline = None
+            self._appsink = None
+            self._audio_data.clear()
 
     def get_input_devices(self) -> List[MicrophoneDevice]:
         devices = []

--- a/speedofsound/services/recorder/gstreamer_recorder.py
+++ b/speedofsound/services/recorder/gstreamer_recorder.py
@@ -11,6 +11,7 @@ class GStreamerRecorder(BaseRecorder):
     def __init__(self) -> None:
         super().__init__(provider_name="gstreamer")
         Gst.init()
+        self._devices: List[MicrophoneDevice] = []
         self._pipeline: Optional[Gst.Pipeline] = None
         self._appsink: Optional[Gst.Element] = None
         self._audio_data: List[bytes] = []
@@ -28,7 +29,8 @@ class GStreamerRecorder(BaseRecorder):
             self._audio_data.clear()
 
     def get_input_devices(self) -> List[MicrophoneDevice]:
-        devices = []
+        if self._devices:
+            return self._devices
         monitor = Gst.DeviceMonitor.new()
         monitor.add_filter("Audio/Source", None)
         monitor.start()
@@ -42,9 +44,10 @@ class GStreamerRecorder(BaseRecorder):
                     device_name = device.get_properties().get_string("alsa.id")
                 if not device_name:
                     device_name = device.get_display_name()
-                devices.append(MicrophoneDevice(id=len(devices), name=device_name))
+                device_id = len(self._devices)
+                self._devices.append(MicrophoneDevice(id=device_id, name=device_name))
         monitor.stop()
-        return devices
+        return self._devices
 
     def is_recording(self) -> bool:
         with self._recording_lock:

--- a/speedofsound/services/recorder/gstreamer_recorder.py
+++ b/speedofsound/services/recorder/gstreamer_recorder.py
@@ -33,12 +33,14 @@ class GStreamerRecorder(BaseRecorder):
         for device in monitor.get_devices():
             device_class = device.get_device_class()
             if "Audio/Source" in device_class:
-                display_name = device.get_display_name()
-                device_name = device.get_properties().get_string("device.path")
+                device_name = device.get_properties().get_string("node.name")
                 if not device_name:
-                    device_name = display_name
+                    device_name = device.get_properties().get_string("node.description")
+                if not device_name:
+                    device_name = device.get_properties().get_string("alsa.id")
+                if not device_name:
+                    device_name = device.get_display_name()
                 devices.append(MicrophoneDevice(id=len(devices), name=device_name))
-
         monitor.stop()
         return devices
 
@@ -48,20 +50,27 @@ class GStreamerRecorder(BaseRecorder):
 
     def start_recording(self, recorder_request: RecorderRequest) -> None:
         self._logger.info(f"Recorder request: {recorder_request}")
-
         with self._recording_lock:
-            if self._is_recording:
-                self._logger.warning("Already recording, stopping current recording")
-                self._stop_recording_internal()
-
             self._audio_data = []
             self._sample_width = recorder_request.sample_width
 
             # Create pipeline
             format_map = {1: "S8", 2: "S16LE", 4: "S32LE"}
             audio_format = format_map.get(recorder_request.sample_width, "S16LE")
+            device_param = ""
+
+            try:
+                # Custom device ID
+                if recorder_request.input_device is not None:
+                    all_devices = self.get_input_devices()
+                    device_name = all_devices[recorder_request.input_device].name
+                    self._logger.info(f"Using device: {device_name}")
+                    device_param = f"device={device_name} "
+            except Exception as e:
+                self._logger.error(f"Error getting device name: {e}")
+
             pipeline_str = (
-                f"pulsesrc ! "
+                f"pulsesrc {device_param}! "
                 f"audio/x-raw,format={audio_format},"
                 f"channels={recorder_request.channels},"
                 f"rate={recorder_request.rate} ! "

--- a/speedofsound/services/recorder/gstreamer_recorder.py
+++ b/speedofsound/services/recorder/gstreamer_recorder.py
@@ -67,6 +67,11 @@ class GStreamerRecorder(BaseRecorder):
                         device_name = all_devices[recorder_request.microphone_id].name
                         self._logger.info(f"Using device: {device_name}")
                         device_param = f"device={device_name} "
+                    else:
+                        self._logger.error(
+                            f"Invalid device ID {recorder_request.microphone_id}. "
+                            f"Using default device."
+                        )
             except Exception as e:
                 self._logger.error(f"Error getting device name: {e}")
 

--- a/speedofsound/services/recorder/pyaudio_recorder.py
+++ b/speedofsound/services/recorder/pyaudio_recorder.py
@@ -10,6 +10,7 @@ from speedofsound.services.recorder.base_recorder import BaseRecorder
 class PyAudioRecorder(BaseRecorder):
     def __init__(self) -> None:
         super().__init__(provider_name="pyaudio")
+        self._devices: List[MicrophoneDevice] = []
         self._audio = pyaudio.PyAudio()
         self._stream: Optional[pyaudio.Stream] = None
         self._audio_data: List[bytes] = []
@@ -26,18 +27,15 @@ class PyAudioRecorder(BaseRecorder):
         self._audio_data.clear()
 
     def get_input_devices(self) -> List[MicrophoneDevice]:
-        devices = []
+        if self._devices:
+            return self._devices
         for i in range(self._audio.get_device_count()):
             device = self._audio.get_device_info_by_index(i)
             if device["maxInputChannels"] > 0:
-                devices.append(
-                    MicrophoneDevice(
-                        id=device["index"],
-                        name=device["name"],
-                    )
+                self._devices.append(
+                    MicrophoneDevice(id=device["index"], name=device["name"])
                 )
-
-        return devices
+        return self._devices
 
     def is_recording(self) -> bool:
         return self._stream is not None and self._stream.is_active()

--- a/speedofsound/services/recorder/pyaudio_recorder.py
+++ b/speedofsound/services/recorder/pyaudio_recorder.py
@@ -1,34 +1,30 @@
-import audioop
-import typing
 from concurrent.futures import ThreadPoolExecutor
+from typing import List, Optional, Tuple, Any
 
 import pyaudio
 
 from speedofsound.models import MicrophoneDevice, RecorderRequest
-from speedofsound.services.base_provider import BaseProvider
+from speedofsound.services.recorder.base_recorder import BaseRecorder
 
 
-class PyAudioRecorder(BaseProvider):
-    def __init__(self):
+class PyAudioRecorder(BaseRecorder):
+    def __init__(self) -> None:
         super().__init__(provider_name="pyaudio")
         self._audio = pyaudio.PyAudio()
-        self._stream = None
-        self._frames = []
-        self._volume_callback = None
-        self._max_rms = 0.0
-        self._buffer_count = 0
+        self._stream: Optional[pyaudio.Stream] = None
+        self._frames: List[bytes] = []
+        self._buffer_count: int = 0
         self._executor = ThreadPoolExecutor()
-        self._sample_width = None
         self._logger.info(f"PyAudio recorder v{pyaudio.__version__} initialized.")
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         self._logger.info("Shutting down.")
         if self._stream:
             self._stream.stop_stream()
             self._stream.close()
         self._audio.terminate()
 
-    def get_input_devices(self) -> typing.List[MicrophoneDevice]:
+    def get_input_devices(self) -> List[MicrophoneDevice]:
         devices = []
         for i in range(self._audio.get_device_count()):
             device = self._audio.get_device_info_by_index(i)
@@ -44,10 +40,6 @@ class PyAudioRecorder(BaseProvider):
 
     def is_recording(self) -> bool:
         return self._stream is not None and self._stream.is_active()
-
-    def set_volume_callback(self, callback):
-        """Set callback function to receive volume level updates."""
-        self._volume_callback = callback
 
     def start_recording(self, recorder_request: RecorderRequest) -> None:
         self._logger.info(f"Recorder request: {recorder_request}")
@@ -73,23 +65,12 @@ class PyAudioRecorder(BaseProvider):
             stream_callback=self._stream_callback,
         )
 
-    def _stream_callback(self, in_data, frame_count, time_info, status):
+    def _stream_callback(
+        self, in_data: bytes, frame_count: int, time_info: Any, status: int
+    ) -> Tuple[None, int]:
         self._frames.append(in_data)
         self._executor.submit(self._calculate_rms_volume, in_data)
         return (None, pyaudio.paContinue)
-
-    def _calculate_rms_volume(self, audio_data: bytes):
-        """Calculate RMS volume from audio data, normalized to 0.0-1.0."""
-        if not self._volume_callback or not self._sample_width:
-            return 0.0
-        try:
-            rms = audioop.rms(audio_data, self._sample_width)
-            self._max_rms = max(self._max_rms, rms)
-            rms_normalized = rms / self._max_rms if self._max_rms > 0 else 0.0
-            self._volume_callback(rms_normalized)
-        except Exception as e:
-            self._logger.error(f"Error calculating RMS volume: {e}")
-            return 0.0
 
     def stop_recording(self) -> bytes:
         self._logger.info("Stopping.")

--- a/speedofsound/services/recorder/pyaudio_recorder.py
+++ b/speedofsound/services/recorder/pyaudio_recorder.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Optional, Tuple, Any
+from typing import Any, List, Optional, Tuple
 
 import pyaudio
 
@@ -12,7 +12,7 @@ class PyAudioRecorder(BaseRecorder):
         super().__init__(provider_name="pyaudio")
         self._audio = pyaudio.PyAudio()
         self._stream: Optional[pyaudio.Stream] = None
-        self._frames: List[bytes] = []
+        self._audio_data: List[bytes] = []
         self._buffer_count: int = 0
         self._executor = ThreadPoolExecutor()
         self._logger.info(f"PyAudio recorder v{pyaudio.__version__} initialized.")
@@ -23,6 +23,7 @@ class PyAudioRecorder(BaseRecorder):
             self._stream.stop_stream()
             self._stream.close()
         self._audio.terminate()
+        self._audio_data.clear()
 
     def get_input_devices(self) -> List[MicrophoneDevice]:
         devices = []
@@ -51,7 +52,7 @@ class PyAudioRecorder(BaseRecorder):
             else None
         )
 
-        self._frames = []
+        self._audio_data = []
         self._buffer_count = 0
         self._sample_width = recorder_request.sample_width
         self._stream = self._audio.open(
@@ -68,7 +69,7 @@ class PyAudioRecorder(BaseRecorder):
     def _stream_callback(
         self, in_data: bytes, frame_count: int, time_info: Any, status: int
     ) -> Tuple[None, int]:
-        self._frames.append(in_data)
+        self._audio_data.append(in_data)
         self._executor.submit(self._calculate_rms_volume, in_data)
         return (None, pyaudio.paContinue)
 
@@ -78,4 +79,4 @@ class PyAudioRecorder(BaseRecorder):
             self._stream.stop_stream()
             self._stream.close()
         self._stream = None
-        return b"".join(self._frames)
+        return b"".join(self._audio_data)

--- a/speedofsound/services/recorder/pyaudio_recorder.py
+++ b/speedofsound/services/recorder/pyaudio_recorder.py
@@ -45,9 +45,9 @@ class PyAudioRecorder(BaseRecorder):
         self._logger.info(f"Recorder request: {recorder_request}")
         format = self._audio.get_format_from_width(recorder_request.sample_width)
         input_device_index = (
-            recorder_request.input_device
-            if recorder_request.input_device is not None
-            and recorder_request.input_device >= 0
+            recorder_request.microphone_id
+            if recorder_request.microphone_id is not None
+            and recorder_request.microphone_id >= 0
             else None
         )
 

--- a/speedofsound/services/recorder/recorder_service.py
+++ b/speedofsound/services/recorder/recorder_service.py
@@ -24,10 +24,8 @@ class RecorderService(BaseService):
         super().__init__(service_name=self.SERVICE_NAME)
         self._configuration = configuration_service
         self._recorder: BaseRecorder = self._create_recorder()
-
-        # devices = self._recorder.get_input_devices()
-        # self._logger.info(f"Available input devices: {devices}")
-
+        devices = self._recorder.get_input_devices()
+        self._logger.info(f"Available input devices: {devices}")
         self._recorder.set_volume_callback(self._on_volume_level)
         self._timeout_id: int | None = None
         self._logger.info("Initialized.")

--- a/speedofsound/services/recorder/recorder_service.py
+++ b/speedofsound/services/recorder/recorder_service.py
@@ -1,4 +1,4 @@
-from gi.repository import GObject  # type: ignore
+from gi.repository import GObject, GLib  # type: ignore
 
 from speedofsound.constants import RECORDER_RESPONSE_SIGNAL, VOLUME_LEVEL_SIGNAL
 from speedofsound.models import RecorderRequest, RecorderResponse
@@ -23,10 +23,28 @@ class RecorderService(BaseService):
         self._configuration = configuration_service
         self._recorder = PyAudioRecorder()
         self._recorder.set_volume_callback(self._on_volume_level)
+        self._timeout_id: int | None = None
         self._logger.info("Initialized.")
 
     def shutdown(self):
+        self._cancel_timeout()
         self._recorder.shutdown()
+
+    def _cancel_timeout(self):
+        """Cancel the recording timeout if active."""
+        if self._timeout_id is not None:
+            GLib.source_remove(self._timeout_id)
+            self._timeout_id = None
+
+    def _on_timeout(self) -> bool:
+        """Handle recording timeout."""
+        timeout_seconds = self._configuration.config.recording_timeout_seconds
+        self._logger.info(
+            f"Recording timeout reached ({timeout_seconds} seconds), stopping recording."
+        )
+        self._timeout_id = None
+        self.stop_recording()
+        return False
 
     def _on_volume_level(self, volume: float):
         """Handle volume level updates from the recorder."""
@@ -37,11 +55,16 @@ class RecorderService(BaseService):
 
     def start_recording(self):
         try:
-            # TODO: Set a limit on the recording time
             recorder_request = RecorderRequest()
             recorder_request.input_device = self._configuration.config.microphone_id
             self._recorder.start_recording(recorder_request)
-            self._logger.info("Started recording.")
+            timeout_seconds = self._configuration.config.recording_timeout_seconds
+            self._timeout_id = GLib.timeout_add_seconds(
+                timeout_seconds, self._on_timeout
+            )
+            self._logger.info(
+                f"Started recording with {timeout_seconds}-second timeout."
+            )
         except Exception as e:
             self._logger.error(f"Error starting recording: {e}")
             response = RecorderResponse(
@@ -53,6 +76,7 @@ class RecorderService(BaseService):
 
     def stop_recording(self):
         try:
+            self._cancel_timeout()
             data = self._recorder.stop_recording()
             encoded = RecorderResponse.data_encode(data)
             recorder_result = RecorderResponse(

--- a/speedofsound/services/recorder/recorder_service.py
+++ b/speedofsound/services/recorder/recorder_service.py
@@ -71,7 +71,7 @@ class RecorderService(BaseService):
     def start_recording(self):
         try:
             recorder_request = RecorderRequest()
-            recorder_request.input_device = self._configuration.config.microphone_id
+            recorder_request.microphone_id = self._configuration.config.microphone_id
             self._recorder.start_recording(recorder_request)
             timeout_seconds = self._configuration.config.recording_timeout_seconds
             self._timeout_id = GLib.timeout_add_seconds(

--- a/speedofsound/services/recorder/recorder_service.py
+++ b/speedofsound/services/recorder/recorder_service.py
@@ -1,9 +1,11 @@
-from gi.repository import GObject, GLib  # type: ignore
+from gi.repository import GLib, GObject  # type: ignore
 
 from speedofsound.constants import RECORDER_RESPONSE_SIGNAL, VOLUME_LEVEL_SIGNAL
-from speedofsound.models import RecorderRequest, RecorderResponse
+from speedofsound.models import RecorderBackend, RecorderRequest, RecorderResponse
 from speedofsound.services.base_service import BaseService
 from speedofsound.services.configuration import ConfigurationService
+from speedofsound.services.recorder.base_recorder import BaseRecorder
+from speedofsound.services.recorder.gstreamer_recorder import GStreamerRecorder
 from speedofsound.services.recorder.pyaudio_recorder import PyAudioRecorder
 
 
@@ -21,10 +23,25 @@ class RecorderService(BaseService):
     ):
         super().__init__(service_name=self.SERVICE_NAME)
         self._configuration = configuration_service
-        self._recorder = PyAudioRecorder()
+        self._recorder: BaseRecorder = self._create_recorder()
+
+        # devices = self._recorder.get_input_devices()
+        # self._logger.info(f"Available input devices: {devices}")
+
         self._recorder.set_volume_callback(self._on_volume_level)
         self._timeout_id: int | None = None
         self._logger.info("Initialized.")
+
+    def _create_recorder(self) -> BaseRecorder:
+        backend = RecorderBackend(self._configuration.config.recorder_backend)
+        self._logger.info(f"Creating recorder with backend: {backend}")
+        if backend == RecorderBackend.GSTREAMER:
+            return GStreamerRecorder()
+        elif backend == RecorderBackend.PYAUDIO:
+            return PyAudioRecorder()
+        else:
+            self._logger.warning(f"Unknown recorder {backend}, defaulting to GStreamer")
+            return GStreamerRecorder()
 
     def shutdown(self):
         self._cancel_timeout()

--- a/speedofsound/ui/main/main_view_model.py
+++ b/speedofsound/ui/main/main_view_model.py
@@ -21,6 +21,9 @@ class MainViewModel(BaseViewModel):
     def action_type(self):
         self._orchestrator.action_type()
 
+    def cancel_recording(self):
+        self._orchestrator.cancel_recording()
+
     def _on_orchestrator_event(
         self, service: OrchestratorService, encoded: str
     ) -> None:

--- a/speedofsound/ui/main/main_window.py
+++ b/speedofsound/ui/main/main_window.py
@@ -40,6 +40,7 @@ class MainWindow(Adw.ApplicationWindow):
         toolbar_view.set_content(self._input_widget)
 
         self._view_model = view_model
+        self._was_recording = False
         self._view_model.view_state.connect(
             "notify::status-text", self._on_status_text_changed
         )
@@ -49,6 +50,11 @@ class MainWindow(Adw.ApplicationWindow):
         self._view_model.view_state.connect(
             "notify::volume-level", self._on_volume_level_changed
         )
+
+        # Add keyboard event controller for escape key
+        key_controller = Gtk.EventControllerKey()
+        key_controller.connect("key-pressed", self._on_key_pressed)
+        self.add_controller(key_controller)
 
     def _load_css(self):
         default_display = Gdk.Display.get_default()
@@ -69,15 +75,28 @@ class MainWindow(Adw.ApplicationWindow):
         orchestrator_state = self._view_model.view_state.orchestrator_state
         if orchestrator_state == OrchestratorStage.READY:
             self._input_widget.set_volume(0.0)
+            if self._was_recording:
+                self.hide()
+                self._was_recording = False
         elif orchestrator_state == OrchestratorStage.RECORDING:
+            self._was_recording = True
             self.present()
         elif orchestrator_state == OrchestratorStage.TRANSCRIBING:
             self._input_widget.set_pulsating(True)
         elif orchestrator_state == OrchestratorStage.TYPING:
             self.hide()
             self._input_widget.set_pulsating(False)
+            self._was_recording = False
             self._view_model.action_type()
 
     def _on_volume_level_changed(self, view_state, param) -> None:
         volume_level = self._view_model.view_state.volume_level
         self._input_widget.set_volume(volume_level)
+
+    def _on_key_pressed(self, controller, keyval, keycode, state) -> bool:
+        if keyval == Gdk.KEY_Escape:
+            orchestrator_state = self._view_model.view_state.orchestrator_state
+            if orchestrator_state == OrchestratorStage.RECORDING:
+                self._view_model.cancel_recording()
+                return True
+        return False


### PR DESCRIPTION
## Summary
This PR implements a GStreamer-based audio recorder with optional input device selection, along with several UX improvements:

- **GStreamer recorder implementation** - New recorder backend with robust audio handling
- **Optional input device selection** - Users can specify which microphone to use via configuration
- **Recording timeout and cancellation** - Auto-stop after 60 seconds, Escape key to cancel
- **Improved documentation** - Better organization and clarity throughout
- **Enhanced error handling** - Better device discovery and fallback mechanisms

## Key Changes

### Core Features
- Add GStreamer recorder as the new default backend (`speedofsound/services/recorder/gstreamer_recorder.py`)
- Implement optional input device selection via `RecorderRequest.input_device` 
- Add configurable recording timeout (1-300 seconds, default 60)
- Support Escape key to cancel recording mid-session

### Documentation & UX
- Replace "SOS" abbreviation with full "Speed of Sound" application name
- Reorganize documentation with clear navigation and provider guides
- Add Wayland compatibility notes and troubleshooting
- Improve configuration documentation structure

### Technical Improvements  
- Add base recorder abstraction for better extensibility
- Enhance device discovery with multiple property fallbacks
- Update configuration model consistency (`microphone_id` → `Optional[int]`)
- Add proper GStreamer initialization and resource cleanup

## Test Plan
- [x] Verify GStreamer recorder works with default audio device
- [x] Test device selection functionality when specific device configured
- [x] Confirm timeout and cancellation features work correctly
- [x] Validate linting and formatting passes
- [ ] Test on different audio setups and distributions
- [ ] Verify documentation accuracy and completeness

🤖 Generated with [Claude Code](https://claude.ai/code)