### PR TITLE
chore: bump version to 0.2.0-dev

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 
 # Project version
-speedofsound.version=0.1.0-dev
+speedofsound.version=0.2.0-dev
 
 # - disableGioStore: When true, uses Java Properties for settings instead of GSettings.
 #   Helpful when running the shadow JAR standalone outside an installed environment


### PR DESCRIPTION
## Summary
- Bumps `speedofsound.version` in `gradle.properties` from `0.1.0-dev` to `0.2.0-dev` ahead of the v0.1.0 release tag

## Release process
After merging this PR, tag the merge commit on `main`:
```bash
git checkout main && git pull
git tag v0.1.0
git push origin v0.1.0
```