### PR TITLE
chore: bump version to 0.3.0-dev

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 
 # Project version
-speedofsound.version=0.2.0-dev
+speedofsound.version=0.3.0-dev
 
 # - disableGioStore: When true, uses Java Properties for settings instead of GSettings.
 #   Helpful when running the shadow JAR standalone outside an installed environment


### PR DESCRIPTION
Release v0.2.0 prep: bumps the development version to 0.3.0-dev. The actual 0.2.0 release version will be set by CI from the git tag.