### PR TITLE
chore: target JDK 22 for compilation, keep JDK 25 for runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Set up JDK 22
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 25
+      - name: Set up JDK 22
         uses: actions/setup-java@v4
         with:
-          java-version: '25'
+          java-version: '22'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Setup Gradle

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 25
+      - name: Set up JDK 22
         uses: actions/setup-java@v4
         with:
-          java-version: '25'
+          java-version: '22'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Setup Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
-      - name: Set up JDK 25
+      - name: Set up JDK 22
         uses: actions/setup-java@v4
         with:
-          java-version: '25'
+          java-version: '22'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Setup Gradle

--- a/README.md
+++ b/README.md
@@ -71,17 +71,13 @@ You can add multiple shortcuts targeting the same trigger script if you wish to.
 Launch the application like any other Java application:
 
 ```bash
-java -jar $HOME/speedofsound/speedofsound.jar
+java --enable-native-access=ALL-UNNAMED -jar $HOME/speedofsound/speedofsound.jar
 ```
-
-(If you see warnings about using `--enable-native-access=ALL-UNNAMED`, feel free to add it in future invocations.
-These warnings are safe to ignore: they basically mean that [Java GI](https://java-gi.org/) is accessing the
-native GTK and GNOME libraries to render the application UI.)
 
 On the first launch, two things will happen:
 
 1. **Model setup**: The built-in Whisper Tiny model is unpacked into your user data folder.
-   This is automatic and happens in the background.
+   This is automatic and the app will start faster in the future.
 2. **Permissions prompt**: The app will ask you to grant permission to type on your behalf.
    To support both X11 and Wayland desktops without requiring root access, Speed of Sound uses XDG Desktop Portals
    for keyboard input. You must approve this prompt for dictation to work.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(22)
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts
@@ -10,8 +10,9 @@ plugins {
 }
 
 kotlin {
-    // Use Java 25 (latest LTS) for compilation and runtime.
-    jvmToolchain(25)
+    // Use Java 22 (minimum required, Panama FFI finalized) for compilation.
+    // Runtime (Flatpak/Snap) uses Java 25 (latest LTS).
+    jvmToolchain(22)
 }
 
 tasks.withType<Test>().configureEach {

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -18,17 +18,17 @@ remains the recommended starting point for everyone.
 
 ## Does it work on Wayland? How about X11?
 
-Yes. Speed of Sound uses XDG Desktop Portals for keyboard input, which works on both X11 and Wayland.
-Under the hood, it uses the [Stargate library](https://github.com/zugaldia/stargate/) by the same author.
-On the first launch you will be prompted to grant the app permission to type on your behalf. You need to
-approve that prompt for dictation to work.
+Yes. Speed of Sound uses [XDG Desktop Portals](https://flatpak.github.io/xdg-desktop-portal/docs/) for keyboard input,
+which works on both X11 and Wayland. Under the hood, it uses the [Stargate library](https://github.com/zugaldia/stargate/)
+by the same author. On the first launch you will be prompted to grant the app permission to type on your behalf.
+You need to approve that prompt for dictation to work.
 
 ## Why does the app ask for permission to type on my behalf?
 
-This is the XDG Remote Desktop Portal requesting access to simulate keyboard input. It is the standard
-sandboxed mechanism for typing into other applications without requiring root or elevated privileges.
-It is also the only way to make typing work inside sandboxed packaging formats like Flatpak and Snap.
-The app cannot type anything without your explicit approval.
+This is the [XDG Remote Desktop Portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.RemoteDesktop.html)
+requesting access to simulate keyboard input. It is the standard sandboxed mechanism for typing into other
+applications without requiring root or elevated privileges. It is also the only way to make typing work inside
+sandboxed packaging formats like Flatpak and Snap. The app cannot type anything without your explicit approval.
 
 ## Which Whisper model should I use?
 
@@ -46,19 +46,21 @@ It is most useful in two ways: giving the LLM instructions (writing style, your 
 and supplying a custom vocabulary of names, companies, or technical terms that speech recognition tends to mishear.
 Whisper alone might get you 95% of the way there, polishing with the right context can close that gap.
 
-## Which microphone does the app use? Can I choose one?
+## I have multiple microphones, can I choose which one to use?
 
-The app uses your system default microphone. There is no in-app microphone selector yet, though we
-might add one. Under the hood, recording uses GStreamer with `autoaudiosrc`, which automatically detects
-the appropriate audio source to use. To change the microphone, adjust the default input device in your
-system sound settings.
+No, the app currently uses your system default microphone. There is no in-app microphone selector, though we
+might add one. Under the hood, recording uses
+[GStreamer with `autoaudiosrc`](https://gstreamer.freedesktop.org/documentation/autodetect/autoaudiosrc.html),
+which automatically detects the appropriate audio source to use. To change the microphone, adjust the default
+input device in your system sound settings.
 
 ## Why do I need to set up a trigger script for the global keyboard shortcut?
 
-The XDG Desktop Global Shortcuts Portal would allow Speed of Sound to register a global shortcut
-automatically, but it is still not widely supported across desktop environments. Until it is, the
-`trigger.sh` script provides a manual alternative that works with whatever shortcut system your
-desktop already has. We know it is awkward and plan to make this step optional once portal support improves.
+The [XDG Desktop Global Shortcuts Portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GlobalShortcuts.html)
+would allow Speed of Sound to register a global shortcut automatically, but it is still not widely supported across
+desktop environments. Until it is, the`trigger.sh` script provides a manual alternative that works with whatever
+shortcut system your desktop already has. We know it is awkward and plan to make this step optional once portal
+support improves.
 
 ## Why is the download so large?
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -24,6 +24,7 @@ BuildConfig.VERSION is generated from these sources and displayed in the About d
    git commit -m "chore: bump version to 0.2.0-dev"
    git push origin release/v0.1.0
    # Open a PR and merge it into main
+   # Note: no need to delete the branch manually — GitHub is configured to auto-delete merged branches
    ```
 
 2. Tag the merge commit on `main` and push the tag:


### PR DESCRIPTION
## Summary

- Switch Gradle toolchain and CI from JDK 25 to JDK 22, the true minimum required version (Panama FFI was finalized in Java 22 / JEP 454)
- Flatpak manifest continues to bundle `openjdk25` for runtime execution — JVM backward compatibility means JDK 25 runs JDK 22 bytecode without issue
- Enable Git LFS in CI checkout steps
- Minor documentation improvements (hyperlinks, wording, launch command fix)

## Test plan

- [x] `make build` passes locally with JDK 22 toolchain
- [ ] CI build passes on GitHub Actions with `java-version: '22'`