### PR TITLE
feat: first launch fixes and recorder debug improvements

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -157,10 +157,8 @@ class MainViewModel(
     private fun collectPortalsSessionState() {
         viewModelScope.launch {
             portalsSessionManager.isSessionDisconnected.collect { isDisconnected ->
-                GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
-                    state.setPortalsSessionDisconnected(isDisconnected)
-                    false // Return false for one-shot execution
-                }
+                // setPortalsSessionDisconnected does not emit a GObject signal, so no need for idleAdd
+                state.setPortalsSessionDisconnected(isDisconnected)
             }
         }
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesDialog.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesDialog.kt
@@ -13,7 +13,6 @@ import org.gnome.adw.Banner
 import org.gnome.adw.Dialog
 import org.gnome.adw.HeaderBar
 import org.gnome.adw.ToolbarView
-import org.gnome.glib.GLib
 import org.gnome.gtk.Box
 import org.gnome.gtk.Orientation
 import org.gnome.gtk.Stack
@@ -47,12 +46,7 @@ class PreferencesDialog(private val settingsClient: SettingsClient) : Dialog() {
         cloudCredentialsPage = CloudCredentialsPage(viewModel)
         voiceModelsPage = VoiceModelsPage(viewModel)
         textModelsPage = TextModelsPage(viewModel)
-        modelLibraryPage = ModelLibraryPage(viewModel) { hasOperations ->
-            GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
-                operationsBanner.revealed = hasOperations
-                false
-            }
-        }
+        modelLibraryPage = ModelLibraryPage(viewModel) { hasOperations -> operationsBanner.revealed = hasOperations }
         personalizationPage = PersonalizationPage(viewModel)
 
         stack = Stack().apply {

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/library/ModelLibraryPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/library/ModelLibraryPage.kt
@@ -59,7 +59,9 @@ class ModelLibraryPage(
     }
 
     private fun refreshModels() {
-        // Clear existing rows
+        // Clear existing rows. We should investigate a better approach, I believe this is the root cause for some
+        // (java:2230969): Gtk-CRITICAL **: 07:20:05.435: gtk_widget_get_can_focus: assertion 'GTK_IS_WIDGET (widget)'
+        // that we're seeing when downloading/deleting a model (although everything seems to work).
         modelRows.clear()
         while (modelsListBox.firstChild != null) {
             modelsListBox.remove(modelsListBox.firstChild)

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/voice/VoiceModelsPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/voice/VoiceModelsPage.kt
@@ -8,7 +8,7 @@ import com.zugaldia.speedofsound.app.STYLE_CLASS_FLAT
 import com.zugaldia.speedofsound.app.STYLE_CLASS_SUGGESTED_ACTION
 import com.zugaldia.speedofsound.app.screens.preferences.PreferencesViewModel
 import com.zugaldia.speedofsound.app.screens.preferences.shared.ActiveProviderComboRow
-import com.zugaldia.speedofsound.core.desktop.settings.DEFAULT_VOICE_MODEL_PROVIDER_ID
+import com.zugaldia.speedofsound.core.desktop.settings.SUPPORTED_LOCAL_ASR_MODELS
 import com.zugaldia.speedofsound.core.desktop.settings.VoiceModelProviderSetting
 import org.gnome.adw.ActionRow
 import org.gnome.adw.PreferencesGroup
@@ -112,7 +112,7 @@ class VoiceModelsPage(private val viewModel: PreferencesViewModel) : Preferences
         }
 
         // Delete button (only for non-default providers)
-        if (providerSetting.id != DEFAULT_VOICE_MODEL_PROVIDER_ID) {
+        if (providerSetting.id !in SUPPORTED_LOCAL_ASR_MODELS.keys) {
             val deleteButton = Button.fromIconName("user-trash-symbolic").apply {
                 addCssClass(STYLE_CLASS_FLAT)
                 valign = Align.CENTER
@@ -140,7 +140,7 @@ class VoiceModelsPage(private val viewModel: PreferencesViewModel) : Preferences
     private fun updateAddProviderButtonState() {
         val providers = viewModel.getVoiceModelProviders()
         // Subtract 1 to account for the default provider when checking the limit
-        val customProviderCount = providers.count { it.id != DEFAULT_VOICE_MODEL_PROVIDER_ID }
+        val customProviderCount = providers.count { it.id !in SUPPORTED_LOCAL_ASR_MODELS.keys }
         val atLimit = customProviderCount >= MAX_VOICE_MODEL_PROVIDERS
         addProviderButton.sensitive = !atLimit
     }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/settings/AsrProviderManager.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/settings/AsrProviderManager.kt
@@ -9,6 +9,7 @@ import com.zugaldia.speedofsound.core.plugins.asr.SherpaWhisperAsrOptions
 import com.zugaldia.speedofsound.core.plugins.asr.AsrPluginOptions
 import com.zugaldia.speedofsound.core.plugins.asr.OpenAiAsr
 import com.zugaldia.speedofsound.core.plugins.asr.OpenAiAsrOptions
+import com.zugaldia.speedofsound.core.plugins.asr.DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
 import com.zugaldia.speedofsound.core.plugins.asr.pluginIdForProvider
 import org.slf4j.LoggerFactory
 
@@ -27,15 +28,16 @@ class AsrProviderManager(
     }
 
     /**
-     * Activates the currently selected ASR provider from settings.
+     * Activates the currently selected ASR provider from settings. Invoked when the MainViewModel starts
+     * or when a new provider is selected in the settings screen (KEY_SELECTED_VOICE_MODEL_PROVIDER_ID changes).
      */
     fun activateSelectedProvider() {
         applySelectedProviderConfig(setActive = true)
     }
 
     /**
-     * Refreshes the configuration for the currently selected provider.
-     * Called when provider settings or credentials change.
+     * Refreshes the configuration for the currently selected provider. Invoked when the list of providers
+     * (KEY_VOICE_MODEL_PROVIDERS) or credentials change (KEY_CREDENTIALS).
      */
     fun refreshProviderConfiguration() {
         applySelectedProviderConfig(setActive = false)
@@ -55,9 +57,9 @@ class AsrProviderManager(
             applyAsrOptions(id, options)
             id
         } else {
-            // No provider configured yet (e.g., fresh installation with no models downloaded).
-            // Fall back to the default local ASR plugin, so it is always active.
-            logger.info("No ASR provider found for id '$selectedProviderId', falling back to default")
+            // No provider configured or a previously available provider was removed.
+            // We fall back to the default local ASR plugin and model.
+            settingsClient.setSelectedVoiceModelProviderId(DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID)
             SherpaWhisperAsr.ID
         }
 

--- a/cli/src/main/kotlin/com/zugaldia/speedofsound/cli/RecordCommand.kt
+++ b/cli/src/main/kotlin/com/zugaldia/speedofsound/cli/RecordCommand.kt
@@ -5,6 +5,7 @@ import com.zugaldia.speedofsound.core.audio.AudioInfo
 import com.zugaldia.speedofsound.core.audio.AudioManager
 import com.zugaldia.speedofsound.core.generateTmpWavFilePath
 import com.zugaldia.speedofsound.core.plugins.recorder.JvmRecorder
+import com.zugaldia.speedofsound.core.plugins.recorder.RecorderOptions
 import org.slf4j.LoggerFactory
 
 class RecordCommand : CliktCommand(name = "record") {
@@ -15,15 +16,9 @@ class RecordCommand : CliktCommand(name = "record") {
     }
 
     override fun run() {
-        val recorder = JvmRecorder()
+        val recorder = JvmRecorder(RecorderOptions(enableDebug = true))
         recorder.initialize()
         recorder.enable()
-
-        val devices = recorder.getAvailableDevices()
-        logger.info("Found ${devices.size} audio input device(s):")
-        devices.forEach { device ->
-            logger.info("- ${device.deviceId}: ${device.name} (${device.description})")
-        }
 
         logger.info("Starting 10-second recording from default device...")
         recorder.startRecording()

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
@@ -2,6 +2,7 @@ package com.zugaldia.speedofsound.core.desktop.settings
 
 import com.zugaldia.speedofsound.core.APPLICATION_SHORT
 import com.zugaldia.speedofsound.core.Language
+import com.zugaldia.speedofsound.core.plugins.asr.DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
 import com.zugaldia.speedofsound.core.plugins.asr.SUPPORTED_SHERPA_WHISPER_ASR_MODELS
 
 const val DEFAULT_PROPERTIES_FILENAME = "$APPLICATION_SHORT.properties"
@@ -32,8 +33,7 @@ const val KEY_VOICE_MODEL_PROVIDERS = "voice-model-providers"
 const val DEFAULT_VOICE_MODEL_PROVIDERS = "[]"
 
 const val KEY_SELECTED_VOICE_MODEL_PROVIDER_ID = "selected-voice-model-provider-id"
-const val DEFAULT_VOICE_MODEL_PROVIDER_ID = "default-sherpa-provider"
-const val DEFAULT_SELECTED_VOICE_MODEL_PROVIDER_ID = DEFAULT_VOICE_MODEL_PROVIDER_ID
+const val DEFAULT_SELECTED_VOICE_MODEL_PROVIDER_ID = DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
 
 // Text Models page
 

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/models/voice/IdGenerator.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/models/voice/IdGenerator.kt
@@ -1,6 +1,6 @@
 package com.zugaldia.speedofsound.core.models.voice
 
-import com.zugaldia.speedofsound.core.generateUniqueId
+import com.zugaldia.speedofsound.core.generateUniqueId as coreGenerateUniqueId
 
 /**
  * Abstraction for generating unique IDs.
@@ -14,6 +14,6 @@ interface IdGenerator {
  */
 class DefaultIdGenerator : IdGenerator {
     override fun generateUniqueId(): String {
-        return generateUniqueId()
+        return coreGenerateUniqueId()
     }
 }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/recorder/JvmRecorder.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/recorder/JvmRecorder.kt
@@ -23,6 +23,12 @@ class JvmRecorder(
     @Volatile
     private var isRecording = false
 
+    companion object {
+        const val ID = "RECORDER_JVM"
+        private const val DEFAULT_BUFFER_SIZE = 1024
+        private const val THREAD_JOIN_TIMEOUT_MS = 1000L
+    }
+
     /**
      * Returns whether a recording is currently in progress.
      */
@@ -51,10 +57,19 @@ class JvmRecorder(
             }
     }
 
-    companion object {
-        const val ID = "RECORDER_JVM"
-        private const val DEFAULT_BUFFER_SIZE = 1024
-        private const val THREAD_JOIN_TIMEOUT_MS = 1000L
+    override fun enable() {
+        super.enable()
+        val version = System.getProperty("java.version")
+        log.info("JVM recorder initialized (Java v$version).")
+        if (currentOptions.enableDebug) {
+            val devices = getAvailableDevices()
+            devices.forEach { device ->
+                log.info(
+                    "Found audio input device: id=${device.deviceId}, " +
+                        "name=${device.name}, description=${device.description}"
+                )
+            }
+        }
     }
 
     /**

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/recorder/RecorderOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/recorder/RecorderOptions.kt
@@ -8,8 +8,10 @@ import com.zugaldia.speedofsound.core.audio.AudioInfo
  * @param audioInfo Audio format configuration
  * @param computeVolumeLevel When true, the recorder will compute and emit volume level events
  *                           during recording. Default is false for performance reasons.
+ * @param enableDebug When true, enables additional debug logging during recording. Default is false.
  */
 data class RecorderOptions(
     val audioInfo: AudioInfo = AudioInfo.Default,
     val computeVolumeLevel: Boolean = false,
+    val enableDebug: Boolean = false,
 ) : RecorderPluginOptions


### PR DESCRIPTION
## Summary

- Add `enableDebug` flag to `RecorderOptions`/`RecorderPlugin`; when enabled, logs available audio input devices on `enable()` for both `JvmRecorder` and `GStreamerRecorder`
- Fix shutdown NPE in `GStreamerRecorder.cleanup()` by setting the pipeline to NULL before removing the GLib bus watch
- Fix startup NPE in `MainViewModel` by removing an unnecessary `GLib.idleAdd` wrapping a call that emits no GObject signal (concurrent writes to `Arenas`' non-thread-safe `HashMap` caused the crash)
- Improve ASR provider selection: use `DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID` as the single source of truth for the default, identify built-in providers via `SUPPORTED_LOCAL_ASR_MODELS.keys`, and persist the fallback back to settings when the stored provider ID is no longer valid

## Test plan

- [ ] Cold start the app — no NPE at startup
- [ ] Shut down the app — no NPE during shutdown
- [ ] Run the CLI `record` command — device list is printed (debug enabled by default in CLI)
- [ ] In the app, open Voice Models preferences — built-in models have no delete button; custom models do
- [ ] Remove a previously configured ASR model and restart — app falls back to the default Sherpa Whisper model without crashing