### PR TITLE
feat: settings import/export

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(project(":core"))
 
     implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinxSerialization)
     implementation(libs.log4jSlf4j2Impl)
     runtimeOnly(libs.log4jCore)
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesDialog.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesDialog.kt
@@ -4,6 +4,7 @@ import com.zugaldia.speedofsound.app.DEFAULT_PREFERENCES_DIALOG_HEIGHT
 import com.zugaldia.speedofsound.app.DEFAULT_PREFERENCES_DIALOG_WIDTH
 import com.zugaldia.speedofsound.app.screens.preferences.credentials.CloudCredentialsPage
 import com.zugaldia.speedofsound.app.screens.preferences.general.GeneralPage
+import com.zugaldia.speedofsound.app.screens.preferences.importexport.ImportExportPage
 import com.zugaldia.speedofsound.app.screens.preferences.library.ModelLibraryPage
 import com.zugaldia.speedofsound.app.screens.preferences.personalization.PersonalizationPage
 import com.zugaldia.speedofsound.app.screens.preferences.text.TextModelsPage
@@ -32,6 +33,7 @@ class PreferencesDialog(private val settingsClient: SettingsClient) : Dialog() {
     private val textModelsPage: TextModelsPage
     private val modelLibraryPage: ModelLibraryPage
     private val personalizationPage: PersonalizationPage
+    private val importExportPage: ImportExportPage
 
     init {
         title = "Preferences"
@@ -48,6 +50,7 @@ class PreferencesDialog(private val settingsClient: SettingsClient) : Dialog() {
         textModelsPage = TextModelsPage(viewModel)
         modelLibraryPage = ModelLibraryPage(viewModel) { hasOperations -> operationsBanner.revealed = hasOperations }
         personalizationPage = PersonalizationPage(viewModel)
+        importExportPage = ImportExportPage(viewModel) { refreshAllPages() }
 
         stack = Stack().apply {
             hexpand = true
@@ -58,6 +61,7 @@ class PreferencesDialog(private val settingsClient: SettingsClient) : Dialog() {
             addTitled(voiceModelsPage, "voice_models", "Voice Models")
             addTitled(textModelsPage, "text_models", "Text Models")
             addTitled(personalizationPage, "personalization", "Personalization")
+            addTitled(importExportPage, "import_export", "Import / Export")
 
             // This is to make sure the voice models page includes any models the user just downloaded
             // in the library page, not only the ones that had been downloaded before.
@@ -100,6 +104,16 @@ class PreferencesDialog(private val settingsClient: SettingsClient) : Dialog() {
         onClosed {
             personalizationPage.forceSaveInstructions()
             modelLibraryPage.shutdown()
+            importExportPage.shutdown()
         }
+    }
+
+    private fun refreshAllPages() {
+        logger.info("Refreshing all preferences pages after import")
+        generalPage.refresh()
+        cloudCredentialsPage.refresh()
+        voiceModelsPage.refreshProviders()
+        textModelsPage.refreshProviders()
+        personalizationPage.refresh()
     }
 }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/credentials/CloudCredentialsPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/credentials/CloudCredentialsPage.kt
@@ -71,13 +71,19 @@ class CloudCredentialsPage(private val viewModel: PreferencesViewModel) : Prefer
         }
 
         add(credentialsGroup)
-        loadInitialCredentials()
+        loadCredentials()
     }
 
-    private fun loadInitialCredentials() {
+    private fun loadCredentials() {
         val credentials = viewModel.getCredentials()
         credentials.sortedBy { it.name.lowercase() }.forEach { credential -> addCredentialToUI(credential) }
         updatePlaceholderVisibility()
+    }
+
+    fun refresh() {
+        logger.info("Refreshing cloud credentials")
+        credentialsListBox.removeAll()
+        loadCredentials()
     }
 
     private fun showAddCredentialDialog() {

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
@@ -5,18 +5,21 @@ import org.gnome.adw.PreferencesGroup
 import org.gnome.adw.PreferencesPage
 
 class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage() {
+    private val primaryComboRow: LanguageComboRow
+    private val secondaryComboRow: LanguageComboRow
+
     init {
         title = "General"
         iconName = "preferences-system-symbolic"
 
-        val primaryComboRow = LanguageComboRow(
+        primaryComboRow = LanguageComboRow(
             rowTitle = "Primary Language",
             rowSubtitle = "Used by default for speech recognition",
             getLanguage = { viewModel.getDefaultLanguage() },
             setLanguage = { viewModel.setDefaultLanguage(it) }
         )
 
-        val secondaryComboRow = LanguageComboRow(
+        secondaryComboRow = LanguageComboRow(
             rowTitle = "Secondary Language",
             rowSubtitle = "Optional language to switch to (right Shift key)",
             getLanguage = { viewModel.getSecondaryLanguage() },
@@ -36,5 +39,10 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
         // Set up notifications after all widgets are initialized
         primaryComboRow.setupNotifications()
         secondaryComboRow.setupNotifications()
+    }
+
+    fun refresh() {
+        primaryComboRow.refresh()
+        secondaryComboRow.refresh()
     }
 }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/importexport/ImportExportManager.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/importexport/ImportExportManager.kt
@@ -1,0 +1,101 @@
+package com.zugaldia.speedofsound.app.screens.preferences.importexport
+
+import com.zugaldia.speedofsound.app.screens.preferences.PreferencesViewModel
+import com.zugaldia.speedofsound.core.APPLICATION_SHORT
+import com.zugaldia.speedofsound.core.desktop.settings.SUPPORTED_LOCAL_ASR_MODELS
+import com.zugaldia.speedofsound.core.desktop.settings.SettingsExport
+import com.zugaldia.speedofsound.core.getDataDir
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+
+data class ImportResult(
+    val filePath: String,
+    val credentialsAdded: Int = 0,
+    val voiceProvidersAdded: Int = 0,
+    val textProvidersAdded: Int = 0,
+    val vocabularyWordsAdded: Int = 0
+)
+
+class ImportExportManager(private val viewModel: PreferencesViewModel) {
+    private val logger = LoggerFactory.getLogger(ImportExportManager::class.java)
+
+    private val prettyJson = Json {
+        prettyPrint = true
+        ignoreUnknownKeys = true
+    }
+
+    fun export(): Result<String> = runCatching {
+        // We do not export anything that is instance-specific (e.g., portal token). That
+        // also includes built-in voice models, which we filter out below.
+        val exportData = SettingsExport(
+            defaultLanguage = viewModel.getDefaultLanguage(),
+            secondaryLanguage = viewModel.getSecondaryLanguage(),
+            credentials = viewModel.getCredentials(),
+            voiceModelProviders = viewModel.getVoiceModelProviders()
+                .filter { it.id !in SUPPORTED_LOCAL_ASR_MODELS.keys },
+            textModelProviders = viewModel.getTextModelProviders(),
+            customContext = viewModel.getCustomContext(),
+            customVocabulary = viewModel.getCustomVocabulary()
+        )
+
+        val outputFile = getDataDir().resolve(EXPORT_FILENAME).toFile()
+        outputFile.writeText(prettyJson.encodeToString(exportData))
+        logger.info("Exported settings to: ${outputFile.absolutePath}")
+        outputFile.absolutePath
+    }
+
+    fun importSettings(): Result<ImportResult> = runCatching {
+        val inputFile = getDataDir().resolve(EXPORT_FILENAME).toFile()
+        check(inputFile.exists()) { "Export file not found: ${inputFile.absolutePath}" }
+
+        val exportData = prettyJson.decodeFromString<SettingsExport>(inputFile.readText())
+        if (exportData.version != 1) {
+            throw IllegalStateException("Unsupported export version: ${exportData.version}")
+        }
+
+        viewModel.setDefaultLanguage(exportData.defaultLanguage)
+        viewModel.setSecondaryLanguage(exportData.secondaryLanguage)
+        viewModel.setCustomContext(exportData.customContext)
+
+        val existingCredentials = viewModel.getCredentials()
+        val existingCredentialIds = existingCredentials.map { it.id }.toSet()
+        val newCredentials = exportData.credentials.filter { it.id !in existingCredentialIds }
+        if (newCredentials.isNotEmpty()) {
+            viewModel.setCredentials(existingCredentials + newCredentials)
+        }
+
+        val existingVoiceProviders = viewModel.getVoiceModelProviders()
+        val existingVoiceIds = existingVoiceProviders.map { it.id }.toSet()
+        val newVoiceProviders = exportData.voiceModelProviders.filter { it.id !in existingVoiceIds }
+        if (newVoiceProviders.isNotEmpty()) {
+            viewModel.setVoiceModelProviders(existingVoiceProviders + newVoiceProviders)
+        }
+
+        val existingTextProviders = viewModel.getTextModelProviders()
+        val existingTextIds = existingTextProviders.map { it.id }.toSet()
+        val newTextProviders = exportData.textModelProviders.filter { it.id !in existingTextIds }
+        if (newTextProviders.isNotEmpty()) {
+            viewModel.setTextModelProviders(existingTextProviders + newTextProviders)
+        }
+
+        val existingVocabulary = viewModel.getCustomVocabulary()
+        val existingVocabSet = existingVocabulary.toSet()
+        val newVocabWords = exportData.customVocabulary.filter { it !in existingVocabSet }
+        if (newVocabWords.isNotEmpty()) {
+            viewModel.setCustomVocabulary(existingVocabulary + newVocabWords)
+        }
+
+        logger.info("Imported settings from: ${inputFile.absolutePath}")
+        ImportResult(
+            filePath = inputFile.absolutePath,
+            credentialsAdded = newCredentials.size,
+            voiceProvidersAdded = newVoiceProviders.size,
+            textProvidersAdded = newTextProviders.size,
+            vocabularyWordsAdded = newVocabWords.size
+        )
+    }
+
+    companion object {
+        const val EXPORT_FILENAME = "$APPLICATION_SHORT-preferences.json"
+    }
+}

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/importexport/ImportExportPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/importexport/ImportExportPage.kt
@@ -1,0 +1,147 @@
+package com.zugaldia.speedofsound.app.screens.preferences.importexport
+
+import com.zugaldia.speedofsound.app.screens.preferences.PreferencesViewModel
+import com.zugaldia.speedofsound.core.getDataDir
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import org.gnome.adw.ActionRow
+import org.gnome.adw.PreferencesGroup
+import org.gnome.adw.PreferencesPage
+import org.gnome.glib.GLib
+import org.gnome.gtk.Align
+import org.gnome.gtk.Button
+import org.gnome.gtk.Label
+
+class ImportExportPage(viewModel: PreferencesViewModel, private val onImportSuccess: () -> Unit) : PreferencesPage() {
+    private val manager = ImportExportManager(viewModel)
+    private val pageScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val statusLabel: Label
+    private val exportButton: Button
+    private val importButton: Button
+
+    init {
+        title = "Import / Export"
+        iconName = "document-send-symbolic"
+
+        val exportFilePath = getDataDir().resolve(ImportExportManager.EXPORT_FILENAME)
+
+        exportButton = Button.withLabel("Export").apply {
+            valign = Align.CENTER
+        }
+
+        val exportRow = ActionRow().apply {
+            title = "Export Preferences"
+            subtitle = "File: $exportFilePath"
+            addSuffix(exportButton)
+        }
+
+        val exportGroup = PreferencesGroup().apply {
+            title = "Export"
+            description = "Export your preferences to a file. Use it as a backup or to transfer your " +
+                    "configuration to a different machine."
+            add(exportRow)
+        }
+
+        importButton = Button.withLabel("Import").apply {
+            valign = Align.CENTER
+        }
+
+        val importRow = ActionRow().apply {
+            title = "Import Preferences"
+            subtitle = "File: $exportFilePath"
+            addSuffix(importButton)
+        }
+
+        val importGroup = PreferencesGroup().apply {
+            title = "Import"
+            description = "Import preferences from a file. Items such as credentials, " +
+                    "providers, and vocabulary are added to your existing ones. " +
+                    "Some items such as language and custom context will be replaced."
+            add(importRow)
+        }
+
+        statusLabel = Label("").apply {
+            selectable = true
+            wrap = true
+            halign = Align.CENTER
+            valign = Align.CENTER
+            hexpand = true
+            vexpand = true
+            visible = false
+        }
+
+        val statusGroup = PreferencesGroup().apply {
+            add(statusLabel)
+        }
+
+        add(exportGroup)
+        add(importGroup)
+        add(statusGroup)
+
+        exportButton.onClicked { onExportClicked() }
+        importButton.onClicked { onImportClicked() }
+    }
+
+    private fun onExportClicked() {
+        setButtonsEnabled(false)
+        pageScope.launch {
+            val result = manager.export()
+            GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
+                setButtonsEnabled(true)
+                result.fold(
+                    onSuccess = { filePath -> showStatus("Exported to: $filePath") },
+                    onFailure = { error -> showStatus("Export failed: ${error.message}") }
+                )
+                false
+            }
+        }
+    }
+
+    private fun onImportClicked() {
+        setButtonsEnabled(false)
+        pageScope.launch {
+            val result = manager.importSettings()
+            GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
+                setButtonsEnabled(true)
+                result.fold(
+                    onSuccess = { importResult ->
+                        showStatus(buildImportSummary(importResult))
+                        onImportSuccess()
+                    },
+                    onFailure = { error -> showStatus("Import failed: ${error.message}") }
+                )
+                false
+            }
+        }
+    }
+
+    fun shutdown() {
+        pageScope.cancel()
+    }
+
+    private fun setButtonsEnabled(enabled: Boolean) {
+        exportButton.sensitive = enabled
+        importButton.sensitive = enabled
+    }
+
+    private fun showStatus(message: String) {
+        statusLabel.label = message
+        statusLabel.visible = true
+    }
+
+    private fun buildImportSummary(result: ImportResult): String {
+        val parts = mutableListOf<String>()
+        if (result.credentialsAdded > 0) parts.add("${result.credentialsAdded} credential(s)")
+        if (result.voiceProvidersAdded > 0) parts.add("${result.voiceProvidersAdded} voice provider(s)")
+        if (result.textProvidersAdded > 0) parts.add("${result.textProvidersAdded} text provider(s)")
+        if (result.vocabularyWordsAdded > 0) parts.add("${result.vocabularyWordsAdded} vocabulary word(s)")
+        return if (parts.isEmpty()) {
+            "Import complete. No new items to add."
+        } else {
+            "Imported: ${parts.joinToString(", ")}."
+        }
+    }
+}

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/library/ModelLibraryPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/library/ModelLibraryPage.kt
@@ -59,14 +59,8 @@ class ModelLibraryPage(
     }
 
     private fun refreshModels() {
-        // Clear existing rows. We should investigate a better approach, I believe this is the root cause for some
-        // (java:2230969): Gtk-CRITICAL **: 07:20:05.435: gtk_widget_get_can_focus: assertion 'GTK_IS_WIDGET (widget)'
-        // that we're seeing when downloading/deleting a model (although everything seems to work).
         modelRows.clear()
-        while (modelsListBox.firstChild != null) {
-            modelsListBox.remove(modelsListBox.firstChild)
-        }
-
+        modelsListBox.removeAll()
         SUPPORTED_LOCAL_ASR_MODELS.values
             .sortedBy { it.dataSizeMegabytes }
             .forEach { model ->

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/personalization/PersonalizationPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/personalization/PersonalizationPage.kt
@@ -38,6 +38,7 @@ class PersonalizationPage(private val viewModel: PreferencesViewModel) : Prefere
     private val vocabularyListBox: ListBox
     private val instructionsTextView: TextView
     private var saveInstructionsCounter: Int = 0
+    private var isRefreshing = false
 
     init {
         title = "Personalization"
@@ -98,19 +99,31 @@ class PersonalizationPage(private val viewModel: PreferencesViewModel) : Prefere
         add(instructionsGroup)
         add(vocabularyGroup)
 
-        loadInitialValues()
+        loadValues()
         instructionsTextView.buffer.onChanged {
+            if (isRefreshing) return@onChanged
             enforceTextLimit()
             scheduleSaveInstructions()
         }
     }
 
-    private fun loadInitialValues() {
+    private fun loadValues() {
         val instructions = viewModel.getCustomContext()
         instructionsTextView.buffer.setText(instructions, -1)
 
         val vocabulary = viewModel.getCustomVocabulary()
         vocabulary.sortedWith(String.CASE_INSENSITIVE_ORDER).forEach { word -> addVocabularyWordToUI(word) }
+    }
+
+    fun refresh() {
+        logger.info("Refreshing personalization settings")
+        isRefreshing = true
+        try {
+            vocabularyListBox.removeAll()
+            loadValues()
+        } finally {
+            isRefreshing = false
+        }
     }
 
     /**

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/text/TextModelsPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/text/TextModelsPage.kt
@@ -93,11 +93,17 @@ class TextModelsPage(private val viewModel: PreferencesViewModel) : PreferencesP
 
         add(textProcessingGroup)
         add(providersGroup)
-        loadInitialProviders()
+        loadProviders()
         setupNotifications()
     }
 
-    private fun loadInitialProviders() {
+    fun refreshProviders() {
+        logger.info("Refreshing text model providers")
+        providersListBox.removeAll()
+        loadProviders()
+    }
+
+    private fun loadProviders() {
         val providers = viewModel.getTextModelProviders()
         providers.sortedBy { it.name.lowercase() }.forEach { provider -> addProviderToUI(provider) }
         activeProviderComboRow.updateProviders(providers)

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/voice/VoiceModelsPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/voice/VoiceModelsPage.kt
@@ -70,10 +70,8 @@ class VoiceModelsPage(private val viewModel: PreferencesViewModel) : Preferences
     }
 
     fun refreshProviders() {
-        logger.info("Loading voice model providers")
-        while (providersListBox.firstChild != null) {
-            providersListBox.remove(providersListBox.firstChild)
-        }
+        logger.info("Refreshing voice model providers")
+        providersListBox.removeAll()
 
         val providers = viewModel.getVoiceModelProviders()
         providers.sortedBy { it.name.lowercase() }.forEach { provider -> addProviderToUI(provider) }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsModels.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsModels.kt
@@ -55,3 +55,19 @@ data class TextModelProviderSetting(
     val credentialId: String? = null,
     val baseUrl: String? = null
 ) : SelectableProviderSetting
+
+/**
+ * A serializable snapshot of all exportable user preferences.
+ * Instance-specific settings (portal token, selected provider IDs, text processing toggle) are excluded.
+ */
+@Serializable
+data class SettingsExport(
+    val version: Int = 1,
+    val defaultLanguage: String,
+    val secondaryLanguage: String,
+    val credentials: List<CredentialSetting>,
+    val voiceModelProviders: List<VoiceModelProviderSetting>,
+    val textModelProviders: List<TextModelProviderSetting>,
+    val customContext: String,
+    val customVocabulary: List<String>
+)

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/AsrPluginOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/AsrPluginOptions.kt
@@ -4,6 +4,7 @@ import com.zugaldia.speedofsound.core.Language
 import com.zugaldia.speedofsound.core.models.voice.VoiceModel
 import com.zugaldia.speedofsound.core.plugins.AppPluginOptions
 import com.zugaldia.speedofsound.core.plugins.SelectableProvider
+import kotlinx.serialization.Serializable
 
 /**
  * Supported ASR providers.
@@ -11,6 +12,7 @@ import com.zugaldia.speedofsound.core.plugins.SelectableProvider
  * @param displayName Human-readable name for the provider
  * @param isLocallyManaged Whether the provider uses models managed in the model library
  */
+@Serializable
 enum class AsrProvider(
     override val displayName: String,
     val isLocallyManaged: Boolean

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/llm/LlmPluginOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/llm/LlmPluginOptions.kt
@@ -3,10 +3,12 @@ package com.zugaldia.speedofsound.core.plugins.llm
 import com.zugaldia.speedofsound.core.models.text.TextModel
 import com.zugaldia.speedofsound.core.plugins.AppPluginOptions
 import com.zugaldia.speedofsound.core.plugins.SelectableProvider
+import kotlinx.serialization.Serializable
 
 /**
  * Supported LLM providers.
  */
+@Serializable
 enum class LlmProvider(override val displayName: String) : SelectableProvider {
     ANTHROPIC("Anthropic"),
     GOOGLE("Google"),

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -64,8 +64,8 @@ support improves.
 
 ## Why is the download so large?
 
-The JAR is around 100 MB because it bundles the Whisper Tiny model, so the app works out of the box
-with no extra setup. Even without the model, the app would still be large because on-device AI
+The JAR is large because it bundles the ~100 MB Whisper Tiny model, so the app works out of the box
+with no extra setup. Even without the model, the app would still be large because the included on-device AI
 inference engines require native libraries that cannot be stripped out. The size is a deliberate tradeoff
 in favor of ease of use.
 
@@ -80,3 +80,18 @@ File storage follows standard desktop conventions to work correctly in Flatpak a
 Downloaded models are stored under `$SNAP_USER_COMMON` (when running as a Snap),
 or `$XDG_DATA_HOME/speedofsound` (when that variable is set), falling back to
 `$HOME/.local/share/speedofsound`.
+
+## Was this application "vibe-coded"?
+
+If you are asking whether this application was cobbled together in a couple of evenings by sending a few prompts to
+an LLM and hoping for the best, the answer is no. If you are asking whether a coding agent was used to assist during
+development, the answer is yes.
+
+Speed of Sound was built with a deliberate focus on maintainability and correctness, supported by
+a growing test suite. Any AI-generated code was reviewed before being included, if only because the author relies on
+this application for everyday use and wants all users to have the same reliable experience he expects for himself.
+In other words, any bugs or bad design decisions are the author's fault.
+
+The same is expected from any contributors to this project. You may or may not use a coding agent to contribute to
+this project, but the PR author is ultimately responsible for the quality of their contributions. Coding agents are
+not an excuse to take shortcuts. In fact, the opposite is true.


### PR DESCRIPTION
## Summary

- Adds a new **Import / Export** preferences page that lets users back up their settings to a JSON file and restore them on the same or a different machine.
- Export saves to `~/.local/share/speedofsound/speedofsound-preferences.json`; import uses an additive merge for credentials, providers, and vocabulary (skipping duplicates by ID), while language and custom context are replaced.
- Instance-specific settings (portal token, active provider selections, text processing toggle) are intentionally excluded from the export.
- Adds `refresh()` methods to all affected preference pages so the UI updates immediately after a successful import.
- Replaces manual `while`-loop child removal with `removeAll()` in `ModelLibraryPage` and `VoiceModelsPage` to avoid GTK-CRITICAL warnings.
- Adds a FAQ entry clarifying the project's position on AI-assisted development.

## Test plan

- [ ] Open Preferences → Import / Export page is visible
- [ ] Click **Export** — file is created at the expected path, status message shows the path
- [ ] Open the exported JSON and verify credentials, providers, vocabulary, and languages are present; portal token and selected provider IDs are absent
- [ ] Delete a credential and a provider, then click **Import** — deleted items are restored, existing items are not duplicated
- [ ] Verify language and custom context are replaced by the imported values
- [ ] Verify all other preference pages reflect imported values immediately (no restart required)
- [ ] Click **Import** when no export file exists — error message is shown
- [ ] Export and import on a clean profile — all settings round-trip correctly