### PR TITLE
chore: bump version to 0.6.0-dev

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 
 # Project version
-speedofsound.version=0.5.0-dev
+speedofsound.version=0.6.0-dev
 
 # - disableGioStore: When true, uses Java Properties for settings instead of GSettings.
 #   Helpful when running the shadow JAR standalone outside an installed environment


### PR DESCRIPTION
Release PR for v0.5.0. Bumps the development version to 0.6.0-dev.

After merging, tag the resulting main commit with `v0.5.0` to trigger the CI release build.