### PR TITLE
feat(core): add few-shot examples to LLM polish prompt

### DIFF
--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/director/DirectorOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/director/DirectorOptions.kt
@@ -19,8 +19,7 @@ val DEFAULT_VOCABULARY = listOf(APPLICATION_NAME, "Linux", "GNOME")
 const val DEFAULT_CONTEXT =
     "This is the raw transcription text captured from a voice dictation application on a Linux desktop."
 
-val PROMPT_TEMPLATE = """
-# Goal
+const val PROMPT_TEMPLATE = """# Goal
 You are an expert copy editor.
 Your goal is to review the following INPUT transcription to improve its quality and readability.
 
@@ -41,11 +40,21 @@ Make sure that the following terms are spelled correctly: $PROMPT_KEY_VOCABULARY
 - Do not add commentary, answers, or timestamps.
 - Preserve the same language as the INPUT.
 
+## Examples
+
+INPUT: what time is it
+OUTPUT: What time is it?
+
+INPUT: well update to the the L T S version. of the linux distribution right away.
+OUTPUT: We'll update to the LTS version of the Linux distribution right away.
+
+INPUT: Open the mail app send an email to John at example dot com and close it
+OUTPUT: Open the mail app, send an email to john@example.com, and close it.
+
 # Transcription
 LANGUAGE: $PROMPT_KEY_LANGUAGE
 INPUT: $PROMPT_KEY_INPUT
-OUTPUT:
-""".trimIndent()
+OUTPUT: """
 
 /**
  * Options for the director plugin.


### PR DESCRIPTION
## Summary

- Adds a `## Examples` section to `PROMPT_TEMPLATE` with three input/output pairs covering: basic capitalization and punctuation, spoken abbreviations (`L T S` → `LTS`) with contraction repair, and spoken email notation with run-on sentence comma insertion
- Converts `PROMPT_TEMPLATE` from `val` to `const val` and removes `.trimIndent()` in favour of an inline string
- Changes the prompt ending from `OUTPUT:\n` to `OUTPUT: ` to prime completion-style generation

## Test plan

- [ ] Existing tests in `DirectorOptionsTest` pass (`make check`)
- [ ] Enable LLM polishing and dictate a sentence with a spoken acronym (e.g. "the A P I is ready") — confirm output is properly formatted
- [ ] Dictate a run-on sentence with an email address — confirm comma insertion and `@`/`.` notation are applied