### PR TITLE
docs: add "Built with" section crediting open-source dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ The transcribed text will be typed into whatever application is currently focuse
 
 The in-app shortcuts (all except the global one) are active only while the Speed of Sound window is focused.
 
+## Built with
+
+Speed of Sound stands on the shoulders of these excellent open source projects:
+
+- [Java-GI](https://github.com/jwharm/java-gi) — GTK/GNOME bindings for Java, enabling access to native libraries
+  (including LibAdwaita and GStreamer) via the modern Panama framework.
+- [Sherpa ONNX](https://github.com/k2-fsa/sherpa-onnx) — On-device ASR (and more) using the performant ONNX Runtime,
+  including pre-built models for Whisper and many other popular models.
+- [Whisper](https://github.com/openai/whisper) — OpenAI's open-source speech recognition model.
+  Its release transformed the on-device ASR landscape.
+
+Additionally, Speed of Sound uses [Stargate](https://github.com/zugaldia/stargate), a companion project by the same
+author that provides JVM applications with high-level access to [XDG Desktop Portals](https://flatpak.github.io/xdg-desktop-portal/docs/index.html)
+on Linux. Stargate, in turn, depends on the fantastic [dbus-java](https://github.com/hypfvieh/dbus-java) project.
+
 ## FAQ
 
 Common questions about privacy, cloud providers, Wayland support, model selection, and more are answered

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
@@ -15,10 +15,12 @@ fun buildAboutDialog(): AboutDialog {
     dialog.licenseType = License.MIT_X11
     dialog.copyright = "Copyright (c) 2025-2026 Antonio Zugaldia"
     dialog.addAcknowledgementSection(
-        "Special Thanks",
+        "Built on the Shoulders of Giants",
         arrayOf(
-            "David M. (@hypfvieh) and the Java D-Bus team.",
-            "Jan-Willem Harmannij (@jwharm) and the Java GI team."
+            "The Java-GI team (https://github.com/jwharm/java-gi)",
+            "The Sherpa ONNX team (https://github.com/k2-fsa/sherpa-onnx)",
+            "The Whisper team (https://github.com/openai/whisper)",
+            "The dbus-java team (https://github.com/hypfvieh/dbus-java)",
         )
     )
 


### PR DESCRIPTION
## Summary

- Adds a new "Built with" section to the README crediting the key open-source projects Speed of Sound depends on (Java-GI, Sherpa ONNX, Whisper, Stargate, dbus-java).