### PR TITLE
docs: expand Support section to cover contributions and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,12 @@ on Linux. Stargate, in turn, depends on the fantastic [dbus-java](https://github
 Common questions about privacy, cloud providers, Wayland support, model selection, and more are answered
 in the [FAQ](docs/FAQ.md).
 
-## Support
+## Support and Contributions
 
 If you run into any issues, have questions, or need troubleshooting help, please open a ticket on the
-[GitHub issues page](https://github.com/zugaldia/speedofsound/issues).
+[GitHub issues page](https://github.com/zugaldia/speedofsound/issues). Pull requests are also welcome.
+
+There are several ideas already tracked as tickets to improve the project. Everything planned on the
+roadmap has a corresponding issue. If you'd like to contribute, please use those tickets to guide your
+work. You can also use GitHub emoji reactions on issues to vote for the ones that matter most to you,
+which helps with prioritization.


### PR DESCRIPTION
## Summary

- Renames the "Support" section to "Support and Contributions"
- Invites users to open tickets and pull requests
- Explains that roadmap items are tracked as GitHub issues and encourages contributors to use them as a guide
- Asks users to use GitHub emoji reactions to vote on issues for prioritization

## Test plan

- [ ] Review rendered README on GitHub to confirm formatting and links look correct