### PR TITLE
docs: configure speedofsound.io as custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Voice typing for the Linux desktop: press a key, speak your text, and it types i
 
 ## Getting Started
 
-For installation and usage information, see the [documentation site](https://zugaldia.github.io/speedofsound).
+For installation and usage information, see [speedofsound.io](https://speedofsound.io).
 
 ## Built with
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+speedofsound.io

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Speed of Sound
-site_url: https://zugaldia.github.io/speedofsound
+site_url: https://speedofsound.io
 site_author: Antonio Zugaldia
 site_description: Voice typing for the Linux desktop
 repo_url: https://github.com/zugaldia/speedofsound


### PR DESCRIPTION
## Summary

- Add `docs/CNAME` file so GitHub Pages serves the site under `speedofsound.io`
- Update `site_url` in `mkdocs.yml` to `https://speedofsound.io`
- Update README documentation link to point to `https://speedofsound.io`

## Test plan

- [ ] After merging, verify `https://speedofsound.io` serves the docs site
- [ ] Verify HTTPS is enforced in repo Pages settings