### PR TITLE
Integrate flatpak-gradle-generator plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 APP_ID = io.speedofsound.App
 export GRADLE_OPTS = --enable-native-access=ALL-UNNAMED
 
-.PHONY: run app-run cli-run build check clean jar-run docs-serve docs-build
+.PHONY: run app-run cli-run build check clean jar-run flatpak-sources docs-serve docs-build
 
 clean:
 	./gradlew clean
@@ -24,6 +24,9 @@ check:
 #
 # Flatpak
 #
+
+flatpak-sources:
+	./gradlew :app:flatpakGradleGenerator :core:flatpakGradleGenerator --no-configuration-cache
 
 flatpak-linter:
 	flatpak run --command=flatpak-builder-lint org.flatpak.Builder appstream $(APP_ID).metainfo.xml

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("buildsrc.convention.kotlin-jvm")
     alias(libs.plugins.buildconfig)
     alias(libs.plugins.detekt)
+    alias(libs.plugins.flatpakGradleGenerator)
     alias(libs.plugins.shadow)
     alias(libs.plugins.versions)
     application
@@ -45,4 +46,10 @@ buildConfig {
 
 tasks.shadowJar {
     archiveFileName.set("speedofsound.jar")
+}
+
+tasks.flatpakGradleGenerator {
+    outputFile = file("flatpak-sources.json")
+    downloadDirectory = "${rootProject.projectDir}/offline-repository"
+    excludeConfigurations = listOf("testCompileClasspath", "testRuntimeClasspath")
 }

--- a/app/flatpak-sources.json
+++ b/app/flatpak-sources.json
@@ -1,0 +1,4881 @@
+[
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/biz/aQute/bnd/biz.aQute.bnd.annotation/7.1.0/biz.aQute.bnd.annotation-7.1.0.jar",
+    "sha512": "b29e68403ff0b0cd0efacf23a466390b922ef464f79b49c25518864839a1cd86329ace0a7214c6f0ce99056019d857301994bbb71dea0c35dd94511edd789ca4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/biz/aQute/bnd/biz.aQute.bnd.annotation/7.1.0",
+    "dest-filename": "biz.aQute.bnd.annotation-7.1.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/biz/aQute/bnd/biz.aQute.bnd.annotation/7.1.0/biz.aQute.bnd.annotation-7.1.0.pom",
+    "sha512": "10ec365640b4974ecbf49e842187601d526c9110e60aaf5067884af603440a3ee261cbfd027f004c201824b1077132ab09e314a2f52af83c3a0fc4012f56ce36",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/biz/aQute/bnd/biz.aQute.bnd.annotation/7.1.0",
+    "dest-filename": "biz.aQute.bnd.annotation-7.1.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java-client-okhttp/2.12.0/anthropic-java-client-okhttp-2.12.0.jar",
+    "sha512": "1d80ac5368c4aecb89e71babc31fe2aa09b4cafc3ab2ff1894962bf94cd7c6a191410212409d32a53cf330a265258cfb6d2de10510333671691c6b89cd90fea2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java-client-okhttp/2.12.0",
+    "dest-filename": "anthropic-java-client-okhttp-2.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java-client-okhttp/2.12.0/anthropic-java-client-okhttp-2.12.0.module",
+    "sha512": "c6dfa9aa46a2ba95c11332c6e54f26329963ad4000592c40e5a7c5a1509b28df5e2fc2043b24ff0e9eb348b9babb5e9c6980d22188391da101db7c292d71f984",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java-client-okhttp/2.12.0",
+    "dest-filename": "anthropic-java-client-okhttp-2.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java-client-okhttp/2.12.0/anthropic-java-client-okhttp-2.12.0.pom",
+    "sha512": "2e4ae5314307d8dca4f49ba0cc4d46b725f34a2925833e92de97614ddd16e9ce1d8553aed325e1f65415c383461be2ae8b975cdf46ade9d56a458099ce7b635d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java-client-okhttp/2.12.0",
+    "dest-filename": "anthropic-java-client-okhttp-2.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java-core/2.12.0/anthropic-java-core-2.12.0.jar",
+    "sha512": "92af9894470d1c361d93b2b63dbc5ee16837f1416dec09905deaaad88b28c21bd9d5bd3f95b37d1ab6358f321b02fa5be8b465c92886ee642ceb90384e6faab1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java-core/2.12.0",
+    "dest-filename": "anthropic-java-core-2.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java-core/2.12.0/anthropic-java-core-2.12.0.module",
+    "sha512": "555a222f08cad026e98415ac1506f88e91fdd821122492b9a4845f8384ef267be00b7b4525c3dac87a220e3214e45ee5aff29449e6a8e8881b28b799126dca01",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java-core/2.12.0",
+    "dest-filename": "anthropic-java-core-2.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java-core/2.12.0/anthropic-java-core-2.12.0.pom",
+    "sha512": "a2044b42b95184df08aa620f89efe0273d16d80ad9e979f53039b22218198d59baf8f4a335269cc8a109fba169a7d253a1ce8b48c00f60bfbd3752b2fec440dc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java-core/2.12.0",
+    "dest-filename": "anthropic-java-core-2.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java/2.12.0/anthropic-java-2.12.0.jar",
+    "sha512": "56d346bf0d987cb3f5c837450d2bef6598f32feb7fb55efff68473eacf771ec077c0ff22a125dee87cdfd11f162ca2b69bc7ad55b10c9f35dd47155eecb110f3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java/2.12.0",
+    "dest-filename": "anthropic-java-2.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java/2.12.0/anthropic-java-2.12.0.module",
+    "sha512": "0435af5cb1b214d7f1fc45ec61c2661aa533c7d6ba886ddfae94bfc89110c40c8fca161a6271cf1e6ceb427f0734036819f70d814f4830a44343f717b57fc12b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java/2.12.0",
+    "dest-filename": "anthropic-java-2.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java/2.12.0/anthropic-java-2.12.0.pom",
+    "sha512": "004ccc1dbfc9608f663182d2a6384a747f4d20d3f16095678836f9466c61f7023d54caf05c56afeacdab49a9cce000461cd12dc459922c7b12012c5725ac9e37",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java/2.12.0",
+    "dest-filename": "anthropic-java-2.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/classmate/1.7.0/classmate-1.7.0.jar",
+    "sha512": "6761a0a8efe5ba89a812e49d8f7d2a9e1a100d4edd63ede79ee9a6d22758b2e2511653ea5964b4b9a2e5567ea062337ab581960acbe710aacac055770fbbcefd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/classmate/1.7.0",
+    "dest-filename": "classmate-1.7.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/classmate/1.7.0/classmate-1.7.0.pom",
+    "sha512": "8e9fa6da466091dc9292eb7deeee71ee43dbc81bb22d1183a5e8dcbf04692350128d6c4008db31080a37d7ac1da04b4b560f94a0a9cb5d4492a08ff3e86a39ce",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/classmate/1.7.0",
+    "dest-filename": "classmate-1.7.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-annotations/2.18.2/jackson-annotations-2.18.2.jar",
+    "sha512": "d375e5761052e202e409400637cdc9ce0f45cf01a90628f36ca3c81757ac30695cc6e60146cbf14685c5c50912ad932564eb794ea76ab8461ce1786a02eab867",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-annotations/2.18.2",
+    "dest-filename": "jackson-annotations-2.18.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-annotations/2.18.2/jackson-annotations-2.18.2.module",
+    "sha512": "0fc74c9f6a2ac3fd2a709fe85b5068bcd2a0185a07cf113bcd75ab7a129ef93e9da2dc6f2626fecd11901695a38e780aff5b90c853c572b3ee186d0bcf11529d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-annotations/2.18.2",
+    "dest-filename": "jackson-annotations-2.18.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-annotations/2.18.2/jackson-annotations-2.18.2.pom",
+    "sha512": "4d7832be241e3d910de7468d00fb12d10f85b6c970b7c4473ea5fc6951e69a843b2b84513bb9842e69807d4a8148a02de647801300a14d4db4019e4c87f5fdd3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-annotations/2.18.2",
+    "dest-filename": "jackson-annotations-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-core/2.18.2/jackson-core-2.18.2.jar",
+    "sha512": "2223f6d8235c6831b488dd2723a4569e4dab6c2371f0e39f867b57a3a443e093d1fce05dc070a350fa306d7e952888cb09c7c816254147b01083d122964fc3a5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-core/2.18.2",
+    "dest-filename": "jackson-core-2.18.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-core/2.18.2/jackson-core-2.18.2.module",
+    "sha512": "8f95c7940be185d209864af410d88b84787a05d38195ae0a9e1afb65443a7133bcfd26e6638a034839593db8638023b1a848ba36365281916acc4af8fe9d3a31",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-core/2.18.2",
+    "dest-filename": "jackson-core-2.18.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-core/2.18.2/jackson-core-2.18.2.pom",
+    "sha512": "4f72d09f9f6adfd344914f6bc535468e4e53d3789f72e728df886691b5626707062de6cdc056d6034cca56e757ddb4b78f6dbfa94c003d7f3476c98907ae9575",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-core/2.18.2",
+    "dest-filename": "jackson-core-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-databind/2.18.2/jackson-databind-2.18.2.jar",
+    "sha512": "bbdfaaffaaab2a032a754cd9dade06552e9f79fd39ae396873315415219b37e0675fde0a02953efe0701e17be4c282b118a96fcb752f53ca37ab89624f0a52ac",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-databind/2.18.2",
+    "dest-filename": "jackson-databind-2.18.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-databind/2.18.2/jackson-databind-2.18.2.module",
+    "sha512": "69ed0c95a48335d66f15935c3290c0bbeea6f09a870063112de5858ab06b943eab965c58ff40f19c951c0415924947a4fc5091c61d59e58c55816cc17aeca8b2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-databind/2.18.2",
+    "dest-filename": "jackson-databind-2.18.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-databind/2.18.2/jackson-databind-2.18.2.pom",
+    "sha512": "026780d41cf9089c6904d5cc803de65a69c089cc9c337d0c0b27cd2a170149ce1c4f2ee43994ec8573207410edb50c1e5a6bd0e2fc53deb0f2c8881d50d6162c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-databind/2.18.2",
+    "dest-filename": "jackson-databind-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-avro/2.18.2/jackson-dataformat-avro-2.18.2.pom",
+    "sha512": "f04275e22fb184679bd0ffb375c1fa9fc221c3c6e760c7ebdf1de33eb8ee8d605512f8b7a2b1b8cecd47e90e8c41af9cb34632783f1bb9dbb90ede20fa4a537b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-avro/2.18.2",
+    "dest-filename": "jackson-dataformat-avro-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.18.2/jackson-datatype-jdk8-2.18.2.jar",
+    "sha512": "50b79ee59b1f98b607978adcfbcd339f7c260b8f9717c91527fcfb51440509750c5da6afdf595d84a28dbe93c2a53115383a84c139a9f0293bbae64d7f0fb166",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.18.2",
+    "dest-filename": "jackson-datatype-jdk8-2.18.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.18.2/jackson-datatype-jdk8-2.18.2.module",
+    "sha512": "4dafd4b958d79892271ecf9fb8bbb369b9060c887b19bf3772584cb52ce661818b1c5257319c04da8a698f24593c430cfe19f67dc1de11e734fea4a31e131a0d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.18.2",
+    "dest-filename": "jackson-datatype-jdk8-2.18.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.18.2/jackson-datatype-jdk8-2.18.2.pom",
+    "sha512": "5f141872be9e847f070d496c32cf0e83632dd6d54347aa450d713e27a7fbfe34b29a1a93f0791fa3ca841b48e4d6b27bbde17a098d0fc6a1b9f7c1a40d12c0b0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.18.2",
+    "dest-filename": "jackson-datatype-jdk8-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.18.2/jackson-datatype-jsr310-2.18.2.jar",
+    "sha512": "bc1cb3e193996ba0b876baefa99122672bbe617f2de582f5208609efb1bb5886832857406de5b0fd7969fce8c07dba0a672b3f077bac2f7efbc3d0cc252c1ee9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.18.2",
+    "dest-filename": "jackson-datatype-jsr310-2.18.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.18.2/jackson-datatype-jsr310-2.18.2.module",
+    "sha512": "25e5fd0ac798db663c689bc5b382730a3a4b280e7a3db287ce6343f31423a2035c69d9b6c3f041a083940b527974df57083d25dae699846b249fdc7841fbf7c8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.18.2",
+    "dest-filename": "jackson-datatype-jsr310-2.18.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.18.2/jackson-datatype-jsr310-2.18.2.pom",
+    "sha512": "457c0e5cde43e3f8f3f3a2fee0e13dd2f5bb3d3aa9187e227f399bd18788c50112cf7c36f5277f95cf9c2aac08369ebfb5da7d378585e8f037e1b302dbb8ebf4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.18.2",
+    "dest-filename": "jackson-datatype-jsr310-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-base/2.18.2/jackson-base-2.18.2.pom",
+    "sha512": "06f50257724de15b301001e01bfba6daf5dffb361b98989deef27940c8e104419e25bf677f4135e8bd095d4019d20c31c797aa04ae5c916d967395c3336e429d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-base/2.18.2",
+    "dest-filename": "jackson-base-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-bom/2.17.2/jackson-bom-2.17.2.pom",
+    "sha512": "f05a8b021a85f86e760ec291eacd3bc1b76dbc0aadeecaa32394c689a21660c26a0fb72eeaca3c982e04306e3b962aec0bcad3e282ab51b12ed7bd33030f3e10",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-bom/2.17.2",
+    "dest-filename": "jackson-bom-2.17.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-bom/2.18.2/jackson-bom-2.18.2.pom",
+    "sha512": "1621725b517af085cbca45fd123905e1d1ccca34c3c6555ed86ed0e1425229db9e650bc4681b05ac4b91bb366726001115bcac88ddd5ce1fb69bfea2f116e87c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-bom/2.18.2",
+    "dest-filename": "jackson-bom-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-bom/2.19.1/jackson-bom-2.19.1.pom",
+    "sha512": "4a2c1a8b9a99049b80dccb672cdff0c7de7223401edfae708d9c5a217bbcef86f424f3099bf83dd47c036137129d52066a1ba332ac022ca4c7bf55e87b694933",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-bom/2.19.1",
+    "dest-filename": "jackson-bom-2.19.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-parent/2.17/jackson-parent-2.17.pom",
+    "sha512": "889bce47f091857fa87083867de570a4fb4e2f20e0a409aee77fa6ae962d15239287edcabed19488459cb5cedd7e3a5d817634085ead9b75e0cc367809d2e9f9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-parent/2.17",
+    "dest-filename": "jackson-parent-2.17.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-parent/2.18.1/jackson-parent-2.18.1.pom",
+    "sha512": "f8e24c8676736bb78c4a46a68e6042b78a86b99470790ccc549e2609063a4b725a37df51901d8c0d9da5c24c5cb4c27af1139a248e38e3bf7f88e428a9bd0d6d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-parent/2.18.1",
+    "dest-filename": "jackson-parent-2.18.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-parent/2.19.2/jackson-parent-2.19.2.pom",
+    "sha512": "8c4a0dca3ed71ca97d44ea6665025a4d3059d9ac64f6065e7cfa4a51ef7dd45c7cee374157148e3a07aa0cf0532dc9b22486bf3805bae5025c139e299b112f0a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-parent/2.19.2",
+    "dest-filename": "jackson-parent-2.19.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-kotlin/2.18.2/jackson-module-kotlin-2.18.2.jar",
+    "sha512": "7e2ef964be79568f13992f9a8108921471809796801b7b0ada6cbf481f6109fade9e7dcdef908b66c95f7dde336bcc8bef1dbe2a6862fae9956b0b1cdd0d807a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/module/jackson-module-kotlin/2.18.2",
+    "dest-filename": "jackson-module-kotlin-2.18.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-kotlin/2.18.2/jackson-module-kotlin-2.18.2.module",
+    "sha512": "d1844414f38814634d60830936b9ecf067f4cab12206797afc1f6886bd7d049152a8d6ca5b70e2b8bbf6c93583b119fe3ec966fa48d720e7d5af1fdbbef61b7b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/module/jackson-module-kotlin/2.18.2",
+    "dest-filename": "jackson-module-kotlin-2.18.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-kotlin/2.18.2/jackson-module-kotlin-2.18.2.pom",
+    "sha512": "d0dc61d6e2646950a4fb4dd5356795d2757d469c3520025c29220d43cb24f0eecc5cc1e62085d8b4bc6efea86d0f65f008bef15c772e9c81101c095e0100fa4f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/module/jackson-module-kotlin/2.18.2",
+    "dest-filename": "jackson-module-kotlin-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-modules-java8/2.18.2/jackson-modules-java8-2.18.2.pom",
+    "sha512": "d82f9a41ca67065610927e3667f2d8eeb05e2702b394b0d035c376947ad71dadb2c1172445179a2f3b0fcf0e901d954e7d3755e615091085ace0f4578ae8c967",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/module/jackson-modules-java8/2.18.2",
+    "dest-filename": "jackson-modules-java8-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/oss-parent/55/oss-parent-55.pom",
+    "sha512": "1e1758084b1a2c1992d6f04eb027afdfe0ab743a0c4c878bff6e241b6cddebe0e73cb91c00ec7561294efe2642123927827393c818ad19c1395c1fbb30df99b6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/oss-parent/55",
+    "dest-filename": "oss-parent-55.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/oss-parent/56/oss-parent-56.pom",
+    "sha512": "15c6a21926b0ee0172ed9544bf2cd8154ce96ea85f42a89e1fa29e3571ceb736879298763efac5e0e6541c81bd1877513a41bff6cb91ecf8e0fd8f957ba490b8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/oss-parent/56",
+    "dest-filename": "oss-parent-56.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/oss-parent/58/oss-parent-58.pom",
+    "sha512": "8b56185b2d67a26d95e913a1a613083cd0499ea03b4036796542ea7a8beabb6f5182f83596856425deb6b16826bb3d1672b4d4204fb9f351c01e3ef8e5e9d39b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/oss-parent/58",
+    "dest-filename": "oss-parent-58.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/oss-parent/61/oss-parent-61.pom",
+    "sha512": "24731b163cd4c1a3758c0dd8d743937fa1b36d37a58ca60d5487fc48d3e46e4c33b8e1374ee2952be972ff1c9a2fc8c551edf207f2d7fb312dafc33901316271",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/oss-parent/61",
+    "dest-filename": "oss-parent-61.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/oss-parent/68/oss-parent-68.pom",
+    "sha512": "7c9d51b7fd00d0ea30d00d048ce2e9ab3ec1bae3073f9f52d034a66572d5e6680992e42695e649d826c1a3f4b8f089460df8d2549afd15afe45488b6f9984528",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/oss-parent/68",
+    "dest-filename": "oss-parent-68.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/woodstox/woodstox-core/7.1.0/woodstox-core-7.1.0.jar",
+    "sha512": "257260a61892f52a94979c512cc86d3cfaf83c8c1ef231f15033f27c1af4c2b7928b7df9ac0005ef617746193273fe2df68ac0164d5f51e47be580506464b857",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/woodstox/woodstox-core/7.1.0",
+    "dest-filename": "woodstox-core-7.1.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/woodstox/woodstox-core/7.1.0/woodstox-core-7.1.0.pom",
+    "sha512": "ea62babf58db841a24f9c4d027d8ba2a2d93e7cd5f1a9a3c726be7c558ca3bd381e66900edf587d968e54506c20f1665b738419b152de942b206225a769f0a4e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/woodstox/woodstox-core/7.1.0",
+    "dest-filename": "woodstox-core-7.1.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/ben-manes/gradle-versions-plugin/0.53.0/gradle-versions-plugin-0.53.0.jar",
+    "sha512": "c28e3bcf6d8e8cd54086d52665474156962d211e9861785ef0b1ecab3272f8baba5ba9900293362f788163381276d9d2f502a69a05cd07eccb51d015ae36419a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/ben-manes/gradle-versions-plugin/0.53.0",
+    "dest-filename": "gradle-versions-plugin-0.53.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/ben-manes/gradle-versions-plugin/0.53.0/gradle-versions-plugin-0.53.0.module",
+    "sha512": "7b84e913fcce7f42f20b8f1ff1396609b11398c0321c2f5997a49b25dfd3574a66f06575c6fbdf7aa0032c6755789fb3788e8d1fa86bfaaa9df3d2d2e15c774f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/ben-manes/gradle-versions-plugin/0.53.0",
+    "dest-filename": "gradle-versions-plugin-0.53.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/ben-manes/gradle-versions-plugin/0.53.0/gradle-versions-plugin-0.53.0.pom",
+    "sha512": "bed41fbcda79db623fad65c97d1ef4c6172a8e3a32b1a960d6e6400c3b194bf3d7e8d39d4652f6c74324442bd83e250f7ed7e1b05f403c8eef28bf66cbe1ce1f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/ben-manes/gradle-versions-plugin/0.53.0",
+    "dest-filename": "gradle-versions-plugin-0.53.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/ben-manes/versions/com.github.ben-manes.versions.gradle.plugin/0.53.0/com.github.ben-manes.versions.gradle.plugin-0.53.0.pom",
+    "sha512": "137e55cf08227f98bd782b00b788e8457c4c532e9db6299f93c1e89a8ae1b2fc515ad8d6f202324f439bfceb48067b5a401a75b96c649201d1e67e710a75b8e9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/ben-manes/versions/com.github.ben-manes.versions.gradle.plugin/0.53.0",
+    "dest-filename": "com.github.ben-manes.versions.gradle.plugin-0.53.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/gmazzo/buildconfig/com.github.gmazzo.buildconfig.gradle.plugin/6.0.7/com.github.gmazzo.buildconfig.gradle.plugin-6.0.7.pom",
+    "sha512": "cc653e67b9d0456d3a81ce8cf8ed0ab7bd89f940eb0dceac01bf5cb49dd131439cc6221f46b4dc7a550338fc9274f2932b16783f50a33f3051bcfe5f142ff57a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/gmazzo/buildconfig/com.github.gmazzo.buildconfig.gradle.plugin/6.0.7",
+    "dest-filename": "com.github.gmazzo.buildconfig.gradle.plugin-6.0.7.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/gmazzo/buildconfig/plugin/6.0.7/plugin-6.0.7.jar",
+    "sha512": "4013777670e13533ac9c1200f51fb7408c2e8576b0f110eea78b7153a380d95f666b7d15ffd04e86d7c4e962390b11f8f41eabf8060c4f16e94f09a89e955158",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/gmazzo/buildconfig/plugin/6.0.7",
+    "dest-filename": "plugin-6.0.7.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/gmazzo/buildconfig/plugin/6.0.7/plugin-6.0.7.module",
+    "sha512": "b8b22c62e309267f9f7a8947505ae9a2b5156091d4dad0ff59681b662e9bf2b5ccfed694dd5c60d1fc163c693ae3b368822e0560cff5dd537977b91aaf77367c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/gmazzo/buildconfig/plugin/6.0.7",
+    "dest-filename": "plugin-6.0.7.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/gmazzo/buildconfig/plugin/6.0.7/plugin-6.0.7.pom",
+    "sha512": "9247a76e93b6a284da02989000b16f0d95c7de85a773e8a7607f8f3cab35ca9e91a230ff0a4a54de18c9370bf0e236af9b08ce4b11bea5650521e3ecfe834e51",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/gmazzo/buildconfig/plugin/6.0.7",
+    "dest-filename": "plugin-6.0.7.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/hypfvieh/dbus-java-core/5.2.0/dbus-java-core-5.2.0.jar",
+    "sha512": "f774fb5c55312ef13f9c31d5115330d318ab93a484e8b52a06b16f60b6e226a67a1732d3bb565397ecd6fe94e8bbe19b16b04df37b68d6aaf466832427445275",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/hypfvieh/dbus-java-core/5.2.0",
+    "dest-filename": "dbus-java-core-5.2.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/hypfvieh/dbus-java-core/5.2.0/dbus-java-core-5.2.0.pom",
+    "sha512": "f36b2cc09392300347d168423e4d6af9a605fb4849814a96338c121f8ad67b7826bde35f753b71144bb0fcf171d061fc64c718c5f0731c42b505e05741f47a4d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/hypfvieh/dbus-java-core/5.2.0",
+    "dest-filename": "dbus-java-core-5.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/hypfvieh/dbus-java-parent/5.2.0/dbus-java-parent-5.2.0.pom",
+    "sha512": "a7c89a9ac5c62bef0a3e96dad4d2fb36380498c5eb2b49806c8bc99866a75af01933d54b4b56caebbc9d6a2d74c7ca9e8d04dcd3b6e5b82f5ed47924f223fa6f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/hypfvieh/dbus-java-parent/5.2.0",
+    "dest-filename": "dbus-java-parent-5.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/hypfvieh/dbus-java-transport-native-unixsocket/5.2.0/dbus-java-transport-native-unixsocket-5.2.0.jar",
+    "sha512": "65f952e1f9789a1765b5c62d1a144019434ae8d9dd86fb894b1231735a383cd3be4226fa9f7b4c3363277676437a96f1f7264b7ad421ce2d5355e8c66f676f2f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/hypfvieh/dbus-java-transport-native-unixsocket/5.2.0",
+    "dest-filename": "dbus-java-transport-native-unixsocket-5.2.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/hypfvieh/dbus-java-transport-native-unixsocket/5.2.0/dbus-java-transport-native-unixsocket-5.2.0.pom",
+    "sha512": "e1a7b87c86b7c23aed5a8f5b4c75d3f3694bd050dd7a06c3604e6dbdae1295c1d651b42fa4be9645382a7f1c5f5007693eb35a16d84dd36416d228a8d2b26464",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/hypfvieh/dbus-java-transport-native-unixsocket/5.2.0",
+    "dest-filename": "dbus-java-transport-native-unixsocket-5.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-generator-bom/4.38.0/jsonschema-generator-bom-4.38.0.pom",
+    "sha512": "21b1eeb12b77a34e362698c9d1a57c7227af3568edbae169db56dc96326135dbdab84ad5daff460ce957dc622c93bba1e661104749ab96bdcff397a760fa136f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-generator-bom/4.38.0",
+    "dest-filename": "jsonschema-generator-bom-4.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-generator-parent/4.38.0/jsonschema-generator-parent-4.38.0.pom",
+    "sha512": "4684a3bcf6d99aa90ee382b960ecc82fabe2d349d7a7d9cf8046ac8dad0686e5b2f79854992d901bc318e325c594e9b5f1a1f316a8d2f3db72370f792724692e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-generator-parent/4.38.0",
+    "dest-filename": "jsonschema-generator-parent-4.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-generator/4.38.0/jsonschema-generator-4.38.0.jar",
+    "sha512": "78da88c528d51314e1e2a69ed197671e8d37c676dfc715513859c4735decddab38c0a75a7f4eefd42659f69b8553b7d928b93358a5bc486db2bd01fa57774b85",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-generator/4.38.0",
+    "dest-filename": "jsonschema-generator-4.38.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-generator/4.38.0/jsonschema-generator-4.38.0.pom",
+    "sha512": "44649d6680cab5eab9795630f72d2019c4eb69fa4c12feddf6155c359a91abd3d586403fea9ed6e12a616f7d702443f5d523261a6a2eee3460d86318515cddd6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-generator/4.38.0",
+    "dest-filename": "jsonschema-generator-4.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-module-jackson/4.38.0/jsonschema-module-jackson-4.38.0.jar",
+    "sha512": "d2d3b08a3367a0f35ae774aab0f90c77954dea5d5664105126e509643c63a5fbc471b88def4f0f3eb7d1a9585050521e914f6c34e92f8fb533ab9de318952903",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-module-jackson/4.38.0",
+    "dest-filename": "jsonschema-module-jackson-4.38.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-module-jackson/4.38.0/jsonschema-module-jackson-4.38.0.pom",
+    "sha512": "3492082adb84ec7953d2f105263fbe8371d94013734a3b9215ef0e1b37606a92dcc56af723e0c4a76736901b74b6015e6a7e95195c0b44eb6930494dbb4d5216",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-module-jackson/4.38.0",
+    "dest-filename": "jsonschema-module-jackson-4.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-module-swagger-2/4.38.0/jsonschema-module-swagger-2-4.38.0.jar",
+    "sha512": "0c5ff0fe4582262bdf16c47ecbf1d8cc384dd66252089345a3a3815a48b51ff3d143953c03d8a6022559da5fff016201550ee6f2d697eb2bf7e500fa10c3dde6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-module-swagger-2/4.38.0",
+    "dest-filename": "jsonschema-module-swagger-2-4.38.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-module-swagger-2/4.38.0/jsonschema-module-swagger-2-4.38.0.pom",
+    "sha512": "59ab50f711ac91e418c4d4e2ab637b8bbc6945463444f0b9dd5a4feb0abe846c8f12999643f6665d6aa8370762445c34cd95ad1bf9a712bcbda8362525c8e8bd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-module-swagger-2/4.38.0",
+    "dest-filename": "jsonschema-module-swagger-2-4.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.1.0/stargate-0.1.0.jar",
+    "sha512": "0a965471e65b0357e44670cd0c111c1716f6751c77566aa65a7a3023458ef27ca1d05d539ccb4e49d2a5ba85c47b70556df08f7aec522b50a5ca6bc7d915dfc2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/zugaldia/stargate/0.1.0",
+    "dest-filename": "stargate-0.1.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.1.0/stargate-0.1.0.module",
+    "sha512": "0626ce5c21f14e123c2c8e0eb24853d83ca42f28dab7c687887e385f1839f64d6392186f8d35c49c0ce5d4d0bd740494711aa70bcf298cf38e0b4384d899747d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/zugaldia/stargate/0.1.0",
+    "dest-filename": "stargate-0.1.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.1.0/stargate-0.1.0.pom",
+    "sha512": "b194bf0af4e00608be82ecbd86253114af7c1e4390ff5eb3824566c2ed43908a109792558212bfc2c867cb9748d10171c1499fcd0c1bee44de1a706baf70c81f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/zugaldia/stargate/0.1.0",
+    "dest-filename": "stargate-0.1.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/api/api-common/2.45.0/api-common-2.45.0.jar",
+    "sha512": "3c61e1b4ebfe6b19b1c3ba7c0d674e59083cc50866fd91131525c57d57b1f4ac1bc01a6330223648a18ac98aca449843b1a412fcc4c7b345e965a2c4b78da82a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/api/api-common/2.45.0",
+    "dest-filename": "api-common-2.45.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/api/api-common/2.45.0/api-common-2.45.0.pom",
+    "sha512": "f01260b0ee1198f0cd9d548aef56a73dd446462cc74505bac670063139c3fad29fd8b7d3dabe3431e979583ca55bc8b9c450b219548b78812a05fd867a6c2b12",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/api/api-common/2.45.0",
+    "dest-filename": "api-common-2.45.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/api/gapic-generator-java-pom-parent/2.54.0/gapic-generator-java-pom-parent-2.54.0.pom",
+    "sha512": "1365d798c2b1ccff6ed3528b3ccba984213cff7a4814eeb05571bc1e6774e411da5ff2a1fe6386d38ed4055cc05e0397262663841eb94db0ce1d4252cc29f90e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/api/gapic-generator-java-pom-parent/2.54.0",
+    "dest-filename": "gapic-generator-java-pom-parent-2.54.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auth/google-auth-library-credentials/1.33.0/google-auth-library-credentials-1.33.0.jar",
+    "sha512": "767012b41b0b7f384c42423aed282c09ee11d0e663ac28100206fc65665990b38b165fd1566a32b835581dc7c380e5db51e2d402eafbf89b18f72f1eb6c86422",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auth/google-auth-library-credentials/1.33.0",
+    "dest-filename": "google-auth-library-credentials-1.33.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auth/google-auth-library-credentials/1.33.0/google-auth-library-credentials-1.33.0.pom",
+    "sha512": "173cb50ca30b394d7b0416bf54aff41b13bab525072658cd2f87c1d1a32da8221f3b8132203c7e98c12c07e39d29709f726cfd6404e207aa5ad906e054d84ffe",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auth/google-auth-library-credentials/1.33.0",
+    "dest-filename": "google-auth-library-credentials-1.33.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auth/google-auth-library-oauth2-http/1.33.0/google-auth-library-oauth2-http-1.33.0.jar",
+    "sha512": "9215321a579668ed7b0e3700010d2d3a06dafe19b965861d3ae5b994740b2c65f84de186106133e0d689c4d45f9b9fff2faecf427a40c61ea7bb6ff80e21996f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auth/google-auth-library-oauth2-http/1.33.0",
+    "dest-filename": "google-auth-library-oauth2-http-1.33.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auth/google-auth-library-oauth2-http/1.33.0/google-auth-library-oauth2-http-1.33.0.pom",
+    "sha512": "00cb1e7dc13e42ca0fc4f4fac6da4a643d8ee2c749a46b914777fd282ec2e9f634f6be5dbe09a3a307f4f17c1ad0c8f7216ac459b085def717d162f1f3228a8b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auth/google-auth-library-oauth2-http/1.33.0",
+    "dest-filename": "google-auth-library-oauth2-http-1.33.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auth/google-auth-library-parent/1.33.0/google-auth-library-parent-1.33.0.pom",
+    "sha512": "f12a18a8f80198aa8722d8744cd0f926655c7892478b875583af1ca47922ada2b187971cc71e9b2afaddbfabafe62c6c0598b6049606e9f4d17f5d195e281002",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auth/google-auth-library-parent/1.33.0",
+    "dest-filename": "google-auth-library-parent-1.33.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auto/value/auto-value-annotations/1.11.0/auto-value-annotations-1.11.0.jar",
+    "sha512": "339742a85491c0fe529e97668cd86d9c3a7a80061d226e1a51eae45fb9c466e10ee2a4d4fc3b502b96aa473ac4e03850aef8a3b744d3972a934b279ceb80816e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auto/value/auto-value-annotations/1.11.0",
+    "dest-filename": "auto-value-annotations-1.11.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auto/value/auto-value-annotations/1.11.0/auto-value-annotations-1.11.0.pom",
+    "sha512": "93e3171b6ee7078400896bd975f245cf4fcbe8375bd12e73f3be07ffdf19f06d0c5e0d49ef2ba1186f5524a6f586cbca8501e177d1504100c910e95722fe0d5a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auto/value/auto-value-annotations/1.11.0",
+    "dest-filename": "auto-value-annotations-1.11.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auto/value/auto-value-parent/1.11.0/auto-value-parent-1.11.0.pom",
+    "sha512": "f8e40aad8ade476e8c779a97948816309ca6cd9620324e138b8db1f189fd25f0f3e0a50b6921a48b6c0693513e38adf08520af0207e0fc3beccaec9f8877045e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auto/value/auto-value-parent/1.11.0",
+    "dest-filename": "auto-value-parent-1.11.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/google-cloud-shared-config/1.14.3/google-cloud-shared-config-1.14.3.pom",
+    "sha512": "72a483cc8da9fe1d982e00e24ad94e7e5e225fdba0692856d8276807e832f90861eb7fd5a04e1c4018ed8b4d9c73bd97511a4ddd75869d949ee505874756267b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/google-cloud-shared-config/1.14.3",
+    "dest-filename": "google-cloud-shared-config-1.14.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/google-cloud-shared-config/1.14.4/google-cloud-shared-config-1.14.4.pom",
+    "sha512": "97652c65ccf8e1c827b7e74e97de6e93659de130b9d8f32f141f9a611b7f02ae8ea921d4378d3104bc66e143db6e7060679ae70a82ace7eab5a9bebcb39a8df3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/google-cloud-shared-config/1.14.4",
+    "dest-filename": "google-cloud-shared-config-1.14.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/google-cloud-shared-config/1.15.0/google-cloud-shared-config-1.15.0.pom",
+    "sha512": "a8fdf3d5375862b6d642502c8fb8fb79ce963db6ae8d8e1f289955bb0cb7c96e195524e6ed7cc081442800a05936a24aa7df6660efefbf71eff6b98b3a944811",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/google-cloud-shared-config/1.15.0",
+    "dest-filename": "google-cloud-shared-config-1.15.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/native-image-shared-config/1.14.0/native-image-shared-config-1.14.0.pom",
+    "sha512": "bb179c7d390d44f347a47df474853343bb758a565afee1924a9f40714ade8812828fe496f9db3094c52e17f0119baa8f6159ba1bb8f7d3fda8e1e7cc51cbe237",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/native-image-shared-config/1.14.0",
+    "dest-filename": "native-image-shared-config-1.14.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/native-image-shared-config/1.14.3/native-image-shared-config-1.14.3.pom",
+    "sha512": "2ab6223b327619f56776c815507c7e1cd19551e63405252c1b2ff25e44468211d12c23f3363288d134e0db9a90a65508029d081f914137a4f96b997e21514f3a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/native-image-shared-config/1.14.3",
+    "dest-filename": "native-image-shared-config-1.14.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/native-image-shared-config/1.14.4/native-image-shared-config-1.14.4.pom",
+    "sha512": "cd2823bb0a8dfc64ebbc9a9c11bb9d3ce564c767f251df9dadcdcc6cbcee518c0896e43337520b73d764154c030601a1a0e0e3bd75373d577edb00e4ea8ed851",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/native-image-shared-config/1.14.4",
+    "dest-filename": "native-image-shared-config-1.14.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/native-image-shared-config/1.15.0/native-image-shared-config-1.15.0.pom",
+    "sha512": "b6cba2b6a2277d27207b936cf6aea934d9dc815783fb49bc3dfa2f7f22b868cc7aa8aad9eea86df1935ccd3f98ad450a9dd73ee7dd4b34141f0c86ae8ccb1cc3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/native-image-shared-config/1.15.0",
+    "dest-filename": "native-image-shared-config-1.15.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/sdk-platform-java-config/3.45.1/sdk-platform-java-config-3.45.1.pom",
+    "sha512": "c7095ae6e78c848d34df976ebfeae3bc5485696b9eba226c33793ca12238aaff647b494474e14d8cb553f95eb4e512dd143e654f2bb52b8d90ce143d4e6a1f58",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/sdk-platform-java-config/3.45.1",
+    "dest-filename": "sdk-platform-java-config-3.45.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+    "sha512": "bb09db62919a50fa5b55906013be6ca4fc7acb2e87455fac5eaf9ede2e41ce8bbafc0e5a385a561264ea4cd71bbbd3ef5a45e02d63277a201d06a0ae1636f804",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/findbugs/jsr305/3.0.2",
+    "dest-filename": "jsr305-3.0.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom",
+    "sha512": "08e1cc341a153f64b670d87831eedfe79a150b8fb7e3a4afbaef54deaa28d2767ae86d12b4f0c5404184360ab8e48a3655e610f3bf2fe6c97a06e9fc3df49b37",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/findbugs/jsr305/3.0.2",
+    "dest-filename": "jsr305-3.0.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/gson/gson-parent/2.12.1/gson-parent-2.12.1.pom",
+    "sha512": "e099a89999f863e95465baceeba2490fec16032a4eedf0955e3ec230ede9d5e2e6658a3f527a34a651ff3f3121713148e4afd4a03a97f8b0e145f152dae199b7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/gson/gson-parent/2.12.1",
+    "dest-filename": "gson-parent-2.12.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/gson/gson-parent/2.13.2/gson-parent-2.13.2.pom",
+    "sha512": "e6524dbb8aa13707fa51df7413a8b247a4de248812e212702e4e5888d0df29c6ebe39a3b1e09aefb12a1a095c42d19d074756a30918bfc4c1fe55c39b9a7c1fa",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/gson/gson-parent/2.13.2",
+    "dest-filename": "gson-parent-2.13.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/gson/gson/2.12.1/gson-2.12.1.jar",
+    "sha512": "fafc369544e2d4a89f32c353dcbd012410a64a315a3cae9165d4ead6f8960aef5f77ced84c374d6a09af117748adca571b0426eb0e2864f584debb59707ebc03",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/gson/gson/2.12.1",
+    "dest-filename": "gson-2.12.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/gson/gson/2.12.1/gson-2.12.1.pom",
+    "sha512": "49aca8b17b4b4377dd358a356aec85d2105b5c8fca2a88fd4f5b5454a7f7e952980e0754e070adfa7136d01b9442c6efacc989c8a25d9928267c9fe3e869c61f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/gson/gson/2.12.1",
+    "dest-filename": "gson-2.12.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/gson/gson/2.13.2/gson-2.13.2.jar",
+    "sha512": "8974a052656d2e5ec968b6bac2edf51413ffc62040fdc65f14f00597e738ab544d22487f8579ba90618b5a7f94ef33773510fac67b408fee6ed274b38f3d9947",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/gson/gson/2.13.2",
+    "dest-filename": "gson-2.13.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/gson/gson/2.13.2/gson-2.13.2.pom",
+    "sha512": "c0d089089bf0d6bcfae008f329dcc2db2538d02654f8bc7690cb8db2ec94fe0d2aa069ac1d70a111a28cced0ffd7742ac8db29a884d64d9413ebf9b2af5dab82",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/gson/gson/2.13.2",
+    "dest-filename": "gson-2.13.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_annotations/2.36.0/error_prone_annotations-2.36.0.jar",
+    "sha512": "bd6f5650902526d3db06aa1cc7bd36723658166acfabb823aca27d0b2c3814e83ae24a8217ce915c3e194c2c696a102580b4c21ef5dba61f7610bcb8d580f566",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_annotations/2.36.0",
+    "dest-filename": "error_prone_annotations-2.36.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_annotations/2.36.0/error_prone_annotations-2.36.0.pom",
+    "sha512": "0c1d663f70a1bec083cdd007b1ee673df144bbfbd4d065c7cad0edba8410bcd1f578902133155a534a1506a82d6a6aa211b4e6c907c4df25b0da4c781caa9008",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_annotations/2.36.0",
+    "dest-filename": "error_prone_annotations-2.36.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_annotations/2.38.0/error_prone_annotations-2.38.0.jar",
+    "sha512": "b13fdb7e06ec1f12ea1d63b0ff942c239e4decb391d736a1f7d46c9aa9e2744e9391be4398a02a78d551a96969622e65b75bbd31e5bf67a5938716765f451f3a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_annotations/2.38.0",
+    "dest-filename": "error_prone_annotations-2.38.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_annotations/2.38.0/error_prone_annotations-2.38.0.pom",
+    "sha512": "acf440b0491fb1f1a48562479254642941f1f98a09f0aa9d204ba55c79cc4a335ca0e7717ad11812518e19f041b76f2bb3a761132cb1d865426157d89d81027d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_annotations/2.38.0",
+    "dest-filename": "error_prone_annotations-2.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_annotations/2.41.0/error_prone_annotations-2.41.0.jar",
+    "sha512": "e2eb4bf9f36f95a4d4c5ea344db5cd90a456e63bef8e52932b8f6f4ecfdd59cb2f6c2ce9e67b0070c82177e42885688b95afef591b16001f789b378f18afdf30",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_annotations/2.41.0",
+    "dest-filename": "error_prone_annotations-2.41.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_annotations/2.41.0/error_prone_annotations-2.41.0.pom",
+    "sha512": "07bb0fc1b8659cd8c9ffb49563d4ec5f86bb30f5515eb6951e272de83e64670b0490f2e40b33ff6673f0d603719430c3378630478686d5849242028285204cdc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_annotations/2.41.0",
+    "dest-filename": "error_prone_annotations-2.41.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_parent/2.36.0/error_prone_parent-2.36.0.pom",
+    "sha512": "8157ba706ab6932cb428ebd295693477491a7439341c95994f492a10cc3b3222b30a3777e61a9f208fcd1623fc613a3a7fd3cc22c95c56c64e3dbb9d3ca5aeed",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_parent/2.36.0",
+    "dest-filename": "error_prone_parent-2.36.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_parent/2.38.0/error_prone_parent-2.38.0.pom",
+    "sha512": "d2fabe3762adddea6b7696d8f18246eb22e6d0a873fa7e5073f631053742e7d8884ceedf2fa7059488cc644e53fac788184d773bd028ad9ccedf1961cb5392ba",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_parent/2.38.0",
+    "dest-filename": "error_prone_parent-2.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_parent/2.41.0/error_prone_parent-2.41.0.pom",
+    "sha512": "ab85819cbab15554b3dbc1fd75eac6a13440178ee8c92a2b0fceeecac970f464d3aafc017842a2f7a692d15e7875389eb31ae9c0e08844990d7104f6c2f23f2a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_parent/2.41.0",
+    "dest-filename": "error_prone_parent-2.41.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/genai/google-genai/1.37.0/google-genai-1.37.0.jar",
+    "sha512": "b9925cfc8a9c0b677d7fa6c0bce5ed5e9badfa26af666faf674be744643ee044c690bdc3ffad41d757b5e4a16b4559487c367975cc61ad51fc3f93541d33bc7a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/genai/google-genai/1.37.0",
+    "dest-filename": "google-genai-1.37.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/genai/google-genai/1.37.0/google-genai-1.37.0.pom",
+    "sha512": "441ae61bf9f9bc9695cbb609c76300c652a44036490a1117d9684bccca17ca1cf46cbbb126414197b0ecdaef58d4f69b394a84f16f9f1c2f574b0b6984b203ea",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/genai/google-genai/1.37.0",
+    "dest-filename": "google-genai-1.37.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/failureaccess/1.0.2/failureaccess-1.0.2.jar",
+    "sha512": "ff4ee76aa661708989d53d45576cff3beea9ebbd86481dbbf2ee8c81bb22f882097b430588312b711025f0e890f22c6799d722ccd422a6a7278de08660fe2f51",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/failureaccess/1.0.2",
+    "dest-filename": "failureaccess-1.0.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/failureaccess/1.0.2/failureaccess-1.0.2.pom",
+    "sha512": "4e5144a31143d0ee374dc323752d57c28d7a0117abcf75a67397ba1a26c93dcf2c248c357d52c4ce75e2fe7c366df909a0a77db5775cc30c92c4e72a433566af",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/failureaccess/1.0.2",
+    "dest-filename": "failureaccess-1.0.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom",
+    "sha512": "1d786f14fbfa5c90eedcc160d1e0a71acb2141f372049b22ce62b0bd1e883c17cc24a59dc8b00e5037e959cccdb54d4d8dc8f252302d4bb7ce82dfdaff764476",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/guava-parent/26.0-android",
+    "dest-filename": "guava-parent-26.0-android.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/guava-parent/33.4.0-jre/guava-parent-33.4.0-jre.pom",
+    "sha512": "0182ac06632a0d7e9329d101b1e2a18b27f34eae0f83f24c195d76d4a9ffc6fcc3ba0a74d1abfae630a399d956135a02777832782d0b7b292565801554927dba",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/guava-parent/33.4.0-jre",
+    "dest-filename": "guava-parent-33.4.0-jre.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.jar",
+    "sha512": "778bd20c3ad83dd17d742368814cf97f28f3ec5723ef952a634290dbe0b4ced8c2a8f878d710fed10223d4393c510df39583c78921c592f605a0bb7003d98f84",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/guava/33.4.0-jre",
+    "dest-filename": "guava-33.4.0-jre.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.module",
+    "sha512": "435bb752f9daa0c25c8e3a8e5c87313c47cd7e2c6a6cb859a6d642f5ca9ec97e3b3a4dd62260fe022011d2b71e1866263e61b830317aaa8fcafd1af81457972f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/guava/33.4.0-jre",
+    "dest-filename": "guava-33.4.0-jre.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.pom",
+    "sha512": "7117b4c5001f3bee46475748299c19f3df4a0645f875770a1468261ee49705d2bb889efad52e8594e7c8bea5377cbc82fd404efe5c7a2911c3f1f06818da630d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/guava/33.4.0-jre",
+    "dest-filename": "guava-33.4.0-jre.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+    "sha512": "c5987a979174cbacae2e78b319f080420cc71bcdbcf7893745731eeb93c23ed13bff8d4599441f373f3a246023d33df03e882de3015ee932a74a774afdd0782f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava",
+    "dest-filename": "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom",
+    "sha512": "140544970539199c860d5e7e2d8096bbccd55980602773f29e8d74ab4f3e24c43aa369b0c7d06b026ba7a9db3353be285d7ffb9cd94b2bedf62820c3fdfd1d5f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava",
+    "dest-filename": "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/http-client/google-http-client-bom/1.46.2/google-http-client-bom-1.46.2.pom",
+    "sha512": "35e013584b8b70f38c89fad7b26abb2f899172f680509d8a239d8fea990e587ea409c51335e1f346a6b0dcf351eb485bd52d6274fa019fd415f1e7563268af7c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/http-client/google-http-client-bom/1.46.2",
+    "dest-filename": "google-http-client-bom-1.46.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/http-client/google-http-client-gson/1.46.2/google-http-client-gson-1.46.2.jar",
+    "sha512": "c964c5c1425309916153ffa889113d61412236632bd7dc3607fe1cb5b5439e0bb57ba8b95caf88090d8aa739874b9ba9a95019e268b6076786a14f93d44548be",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/http-client/google-http-client-gson/1.46.2",
+    "dest-filename": "google-http-client-gson-1.46.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/http-client/google-http-client-gson/1.46.2/google-http-client-gson-1.46.2.pom",
+    "sha512": "80ac890bd8bd1ea33465f9311ee3e97203bd390833090bdbc1131601b5ea3b3179fb191b62f6617ff9cfcc6022354197b6a11f7bb58aab4ff703d6a20fb69b5e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/http-client/google-http-client-gson/1.46.2",
+    "dest-filename": "google-http-client-gson-1.46.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/http-client/google-http-client-parent/1.46.2/google-http-client-parent-1.46.2.pom",
+    "sha512": "5c5dc3500287eb3e8d60b7179a90780808eee47daea0ce4860d11421b9ad513089f28a3c00699b6b4cf131497d8d7f7c350e59ec12e3d993d5bb32d558365512",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/http-client/google-http-client-parent/1.46.2",
+    "dest-filename": "google-http-client-parent-1.46.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/http-client/google-http-client/1.46.2/google-http-client-1.46.2.jar",
+    "sha512": "fbe51026af2291da20e5961ed28a1f84744ea0dfbec970856f1644ae48bce4fea1d2786f2604215e52349cde54c2cd74f681089b86e7dc51d26ed342e2b326f8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/http-client/google-http-client/1.46.2",
+    "dest-filename": "google-http-client-1.46.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/http-client/google-http-client/1.46.2/google-http-client-1.46.2.pom",
+    "sha512": "482a8548c2dcd8911920bca761d72f2c6d3808d9b8c1760bc88a7ae7a029840c6a32c12e7c254708c7df61b37f6ff04243f248cda7b614a2f24e0625e6199c1f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/http-client/google-http-client/1.46.2",
+    "dest-filename": "google-http-client-1.46.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.jar",
+    "sha512": "1406b1aa53b19f8269129d96ce8b64bf36f215eacf7d8f1e0adadee31614e53bb3f7acf4ff97418c5bfc75677a6f3cd637c3d9889d1e85117b6fa12467c91e9f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/j2objc/j2objc-annotations/3.0.0",
+    "dest-filename": "j2objc-annotations-3.0.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.pom",
+    "sha512": "3c0f19b8e1275dbbaf8a0d02f9ef27a7edbb73ffdd75ae2c9fd334b5dbc373e8420f896b962c86f5d3540007c07acd1995eed8d119d7c6e7068305e9c12f0181",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/j2objc/j2objc-annotations/3.0.0",
+    "dest-filename": "j2objc-annotations-3.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/protobuf/protobuf-bom/3.25.5/protobuf-bom-3.25.5.pom",
+    "sha512": "b900a81cfd33a1e85c903ef0eeea375a1e5d85cc6ccb3470b7bbbcceaf928e9e8670405a546aafe2cd0e7e9ed565628eb0990bcb1ae643e0c394f2745cd84007",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/protobuf/protobuf-bom/3.25.5",
+    "dest-filename": "protobuf-bom-3.25.5.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/protobuf/protobuf-java/3.25.5/protobuf-java-3.25.5.jar",
+    "sha512": "432d8a9359e614d38fe416b7a4564aed3e358fd5f3c2c4f22caf97945a0f3e5cbd2220b690d6b822504e7bcbbd67458eb12d232232dd113f804683a172f8eb71",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/protobuf/protobuf-java/3.25.5",
+    "dest-filename": "protobuf-java-3.25.5.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/protobuf/protobuf-java/3.25.5/protobuf-java-3.25.5.pom",
+    "sha512": "2e9ea8539bf92bf9ab89e08614fdccd4a663db1f2cf5b4e35f59ec7276a34d9e83e57da51bcd7ef5959016072768a9ba105f78d6c1334dbc9e61f90b37103810",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/protobuf/protobuf-java/3.25.5",
+    "dest-filename": "protobuf-java-3.25.5.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/protobuf/protobuf-parent/3.25.5/protobuf-parent-3.25.5.pom",
+    "sha512": "7470211ceeff2ee79ac892d9f1ed22e698a0f9e07ac1546943bd5abd20e0133de075ec00a5bb230d16ffe900995ef028ff950c7395887ba3108c59ecf1074456",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/protobuf/protobuf-parent/3.25.5",
+    "dest-filename": "protobuf-parent-3.25.5.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/gradleup/shadow/com.gradleup.shadow.gradle.plugin/9.3.1/com.gradleup.shadow.gradle.plugin-9.3.1.pom",
+    "sha512": "5f2d8551ef63b0dd42535d0c42bb5d811e9cd6583745f4958035828b8ae2c10bdf9da885ef692eaf3115905fe48d65c1f9d5c42826fbfa51223950b65ff97259",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/gradleup/shadow/com.gradleup.shadow.gradle.plugin/9.3.1",
+    "dest-filename": "com.gradleup.shadow.gradle.plugin-9.3.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/gradleup/shadow/shadow-gradle-plugin/9.3.1/shadow-gradle-plugin-9.3.1.jar",
+    "sha512": "856adaae78911ee03b1ae8927eb067fc910b860029461c6128b9894ed33615b92bd229a0954296a634f8a38273036514aae0bda6db3fa02088989eb8fa0f0ca6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/gradleup/shadow/shadow-gradle-plugin/9.3.1",
+    "dest-filename": "shadow-gradle-plugin-9.3.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/gradleup/shadow/shadow-gradle-plugin/9.3.1/shadow-gradle-plugin-9.3.1.module",
+    "sha512": "67a35aaa1f5f493e019cd080417fa37f3c0fbe0ab4a4ba064b8ae9a4dc9033c2fa4fa67099135dfa42b0e7c77538e9fadd6a0f23bb70e1d8646904b16a67245f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/gradleup/shadow/shadow-gradle-plugin/9.3.1",
+    "dest-filename": "shadow-gradle-plugin-9.3.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/gradleup/shadow/shadow-gradle-plugin/9.3.1/shadow-gradle-plugin-9.3.1.pom",
+    "sha512": "1687a63f468650fa6dcf52a923332651f0b06f6a7926cb6c74900d1547c7be8689112afb06a8f4966693baa1104969db7114e3dd712abe97306a5ac98a0fba01",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/gradleup/shadow/shadow-gradle-plugin/9.3.1",
+    "dest-filename": "shadow-gradle-plugin-9.3.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java-client-okhttp/4.17.0/openai-java-client-okhttp-4.17.0.jar",
+    "sha512": "7a7cde2976ccbd7771eb4d59840c7e8ce0328c354dc87525979e2cfd1b8db29d3767d598ca9eb031845e5af626c8582384dd385e3fc273cbf51b7b9c2b27ff47",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java-client-okhttp/4.17.0",
+    "dest-filename": "openai-java-client-okhttp-4.17.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java-client-okhttp/4.17.0/openai-java-client-okhttp-4.17.0.module",
+    "sha512": "f18c1c41a060909ffff7067684704945b1606f17553c3da3f800bd65a3f211c9b59b00f29ca3e3def26ec91823e5d9f6310eac87e504977de115f5983e8f1b71",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java-client-okhttp/4.17.0",
+    "dest-filename": "openai-java-client-okhttp-4.17.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java-client-okhttp/4.17.0/openai-java-client-okhttp-4.17.0.pom",
+    "sha512": "fa501f37c5a531a8303a1af38e26e0aa3d422246c3dc0c9c700bf0f107d15ca26cf525c14670b5c1bbb685cfe70934ab24948c13da4bb9037d83ea7e5b0a0a34",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java-client-okhttp/4.17.0",
+    "dest-filename": "openai-java-client-okhttp-4.17.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java-core/4.17.0/openai-java-core-4.17.0.jar",
+    "sha512": "5c6ac5757be72f7e46cee2e03a98c35fc6bf95c0cbfbd6aca54d66d2848a4db5d0db3c7729919aa635822fe96b2d2f1f945f3dc663f2ca9b7ab38337020f2286",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java-core/4.17.0",
+    "dest-filename": "openai-java-core-4.17.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java-core/4.17.0/openai-java-core-4.17.0.module",
+    "sha512": "a3c9e79dc2d0e118f54b6ab43a9a6c1d8b9949d374098ed41cfa5492625d18d54037190d0d2f1f862e3e9a40d083100a2a6cb76a64b7cea615942f77cd60cce9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java-core/4.17.0",
+    "dest-filename": "openai-java-core-4.17.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java-core/4.17.0/openai-java-core-4.17.0.pom",
+    "sha512": "d02298143edd62a56047270c4c8c3fa2ebb6123011785fc449a593decafe0263180759d3c27c36abf15edd67362d6d2b89c59b21b2267176d65ae7decf5be6bd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java-core/4.17.0",
+    "dest-filename": "openai-java-core-4.17.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java/4.17.0/openai-java-4.17.0.jar",
+    "sha512": "c15ec7473125b89764895a6f25f734135e5ec6f83aaea86308f92c0f5b62298ea0ab29ecc34746da16c07b999aeb12f7b59e35483c31773f9cd632240aa33a1e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java/4.17.0",
+    "dest-filename": "openai-java-4.17.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java/4.17.0/openai-java-4.17.0.module",
+    "sha512": "78e806b23e62408aa89a1f6ef3f641c6ba28b6b5306f3d429e6fb5789f2b2fc5749c8f3fc5e3157977b9efed9028019aa7236f61cc0b8a77965fc24488802935",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java/4.17.0",
+    "dest-filename": "openai-java-4.17.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java/4.17.0/openai-java-4.17.0.pom",
+    "sha512": "e42d3eba7ea7759954a49d8d412c96be669932d49d6ba481995260986a0308ab903814e7111d065af478789dcaf71ba8e51b49a14a28b0411afec0b1c34e9dd7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java/4.17.0",
+    "dest-filename": "openai-java-4.17.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/javapoet/1.13.0/javapoet-1.13.0.jar",
+    "sha512": "7cb92cc78332c37d6d557ea308b8fa9e973c482fa080f521ffdf3342583d3013048ab613cc84185e117ba5fd8c420164f7b81e3ebd753dff8a12e0df98dd5da1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/javapoet/1.13.0",
+    "dest-filename": "javapoet-1.13.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/javapoet/1.13.0/javapoet-1.13.0.pom",
+    "sha512": "82802f280b0000cde84a17739bac236ef3915c24ac192fa40db6b96376b543d61a9e43b84fdd9003ddf844a3e575d01bc2ad9f20f860c9708835e750125dff1e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/javapoet/1.13.0",
+    "dest-filename": "javapoet-1.13.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/kotlinpoet-jvm/2.2.0/kotlinpoet-jvm-2.2.0.jar",
+    "sha512": "e6c9a6eb46b0f290cd412aced209f5d9d0ecd439eed06d48c82e5a537a58af4cf7e25bd6eee1d8079cf65dc2ca4a21954285b53902d721ef967cb73ff8b9f7ab",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/kotlinpoet-jvm/2.2.0",
+    "dest-filename": "kotlinpoet-jvm-2.2.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/kotlinpoet-jvm/2.2.0/kotlinpoet-jvm-2.2.0.module",
+    "sha512": "575f410b67f27922897337a65cce98de157e6f554e4c2b08eb4b22c5a5bf3c8b7896250e07c4c3d5b9345df5a4ed4309a7f4c2a560802755de660a4469b1ac13",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/kotlinpoet-jvm/2.2.0",
+    "dest-filename": "kotlinpoet-jvm-2.2.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/kotlinpoet-jvm/2.2.0/kotlinpoet-jvm-2.2.0.pom",
+    "sha512": "8af1c560ba3c552308b38946c82149a91ee52fd6a125b0f3cd33ecfbfb1b918ee1b60e31fdd4f1c5705ed87a199d1992e3cbd5c6e4d4486ba1f32682b57442f7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/kotlinpoet-jvm/2.2.0",
+    "dest-filename": "kotlinpoet-jvm-2.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/kotlinpoet/2.2.0/../../kotlinpoet-jvm/2.2.0/kotlinpoet-jvm-2.2.0.module",
+    "sha512": "575f410b67f27922897337a65cce98de157e6f554e4c2b08eb4b22c5a5bf3c8b7896250e07c4c3d5b9345df5a4ed4309a7f4c2a560802755de660a4469b1ac13",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/kotlinpoet/2.2.0/../../kotlinpoet-jvm/2.2.0",
+    "dest-filename": "kotlinpoet-jvm-2.2.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/kotlinpoet/2.2.0/kotlinpoet-2.2.0.module",
+    "sha512": "db99d6a283e2b9d795ec6fa1c9ffeb901e18bd9fa486c06b80f87378cd5104ed6bb9e4db8d3e70fa653e1ac15402124ba664bce3f70895e42c5587002f49c487",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/kotlinpoet/2.2.0",
+    "dest-filename": "kotlinpoet-2.2.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/kotlinpoet/2.2.0/kotlinpoet-2.2.0.pom",
+    "sha512": "c73ec6753346271c1b6ee48835a4f864bf2158264e5382ace5f0de840358e01afe840341056dd0cb6037eff580aff8ef8c93155711606523cf7080767db947bd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/kotlinpoet/2.2.0",
+    "dest-filename": "kotlinpoet-2.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/moshi/moshi-kotlin/1.12.0/moshi-kotlin-1.12.0.jar",
+    "sha512": "8274888bb124316940c156b399e12bee2e7cbe5f17c7b1dd0870b4601846d9b8f4eefd98e66be2a14b1ae7a3a356a929e3826d363880509987ed5d8ed71385e6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/moshi/moshi-kotlin/1.12.0",
+    "dest-filename": "moshi-kotlin-1.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/moshi/moshi-kotlin/1.12.0/moshi-kotlin-1.12.0.module",
+    "sha512": "003ea42bb848205cc6f208f4cbc4d41155be918455ccd0d667bd18c1ea25dd759ad6c847ecb05f495543d1fc820c44bf16702a1dcc0ce4a82ca8e2ed5bfd7b7b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/moshi/moshi-kotlin/1.12.0",
+    "dest-filename": "moshi-kotlin-1.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/moshi/moshi-kotlin/1.12.0/moshi-kotlin-1.12.0.pom",
+    "sha512": "b734c7a7d861c709b4781563109756cb9f76b47a709bc730acb8961862ce45da614c39a396dcb205d7357df4a6387f632908fc9536f855adfe2a0462c978a542",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/moshi/moshi-kotlin/1.12.0",
+    "dest-filename": "moshi-kotlin-1.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/moshi/moshi/1.12.0/moshi-1.12.0.jar",
+    "sha512": "b534a18e3e9ab01fb4bf02a750c25759a9fed1b86ef8701c1508c8650b686b2d80be3333cdade09044f516ee12cc19719d250bd7f15eb66d2e3f724aa77804cf",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/moshi/moshi/1.12.0",
+    "dest-filename": "moshi-1.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/moshi/moshi/1.12.0/moshi-1.12.0.module",
+    "sha512": "c5119c9668fa85ed77607188a8fd379895ed87c7ac3d553172c602924723b4a27e99e7905e20b8bdfcde72d3340055d1aa38d57acebefd1bbd08b68783980a50",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/moshi/moshi/1.12.0",
+    "dest-filename": "moshi-1.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/moshi/moshi/1.12.0/moshi-1.12.0.pom",
+    "sha512": "1882458d3b7ddec87bf71ba597b31619f3362325e9db48a5a90c788bcf31a102678dd4dc3e8c435d05eda00480d079b54cd531243b17548020e7ec427dc8ce0e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/moshi/moshi/1.12.0",
+    "dest-filename": "moshi-1.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okhttp3/logging-interceptor/4.12.0/logging-interceptor-4.12.0.jar",
+    "sha512": "a3c77d43197b0277204e5954d3bfb37921a1d9e388bbac66e7a35f8d5f5081805645c09119be2a7037dc41a18695cbd06d7599f111c97f8a1e37196b8f38a03c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okhttp3/logging-interceptor/4.12.0",
+    "dest-filename": "logging-interceptor-4.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okhttp3/logging-interceptor/4.12.0/logging-interceptor-4.12.0.module",
+    "sha512": "3bf588ed8c05dcbd81d55b81b1acb8d45146e925a086f5bcd6b43a6890be007ffe0bcc60a272c5bc1526202459bf6151b00cc0f5c425e441fac756b95e7781ac",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okhttp3/logging-interceptor/4.12.0",
+    "dest-filename": "logging-interceptor-4.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okhttp3/logging-interceptor/4.12.0/logging-interceptor-4.12.0.pom",
+    "sha512": "d5b0fb517ad53814285b9a7f619ed4a9c2f3670855b87457c3742919c9911e6fa250e14e01a3f8179058e9ea854f13f4d4ea549249730f318a026500ab0ec02b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okhttp3/logging-interceptor/4.12.0",
+    "dest-filename": "logging-interceptor-4.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okhttp3/okhttp/4.12.0/okhttp-4.12.0.jar",
+    "sha512": "da63f77c1cae377b40f6fd00cfbbe8177e760e4e622ae2c66860fffd3bbbdf605c8e8e415762e9263445b2289ee834100237c63949f2e01c30b6704315dd8f7b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okhttp3/okhttp/4.12.0",
+    "dest-filename": "okhttp-4.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okhttp3/okhttp/4.12.0/okhttp-4.12.0.module",
+    "sha512": "650297e5804bfbd9878179cfd3e3538bb4e1fc0cc3f9b4690b36853d6c8942b27c429cf67d076c26c4757c22203bd891576d4343760dc0898276ef0b9d3192a0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okhttp3/okhttp/4.12.0",
+    "dest-filename": "okhttp-4.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okhttp3/okhttp/4.12.0/okhttp-4.12.0.pom",
+    "sha512": "bef467d5298848782c944facac82e3f1b043675acfd3b62912a89de3a82778c0d0fe7dc623e4f324a90c5d4b390ed66bb18e2d71739e1dac99acdb9a848449fc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okhttp3/okhttp/4.12.0",
+    "dest-filename": "okhttp-4.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okio/okio-jvm/3.6.0/okio-jvm-3.6.0.jar",
+    "sha512": "a592e93651fb5e335212bb25c1cf474c1b1076eda68d53cbdc82c383cbdd60114a62b698ca92a3b4b5e416d637a70f2ddabbf8a05551c62d59a240c3e3c3d2c6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okio/okio-jvm/3.6.0",
+    "dest-filename": "okio-jvm-3.6.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okio/okio-jvm/3.6.0/okio-jvm-3.6.0.module",
+    "sha512": "3c5a57a33fb90618710b298e233ae81cdcdbeed204328e9dc55fe0aaf63eb3fa24e58f4d489f5dde48e2ff716b16e0c47882d8be61bd3bd579b3e23ee3034ce3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okio/okio-jvm/3.6.0",
+    "dest-filename": "okio-jvm-3.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okio/okio-jvm/3.6.0/okio-jvm-3.6.0.pom",
+    "sha512": "e723f3262137f7a892a6f6fe277272b0e457b48aa035651b52d9f598d9f98ca285217c74356a90dcf8a34800797fe458f6e1c461dbf69f9c8d8fe4e66dbdfdfb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okio/okio-jvm/3.6.0",
+    "dest-filename": "okio-jvm-3.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okio/okio/3.6.0/../../okio-jvm/3.6.0/okio-jvm-3.6.0.module",
+    "sha512": "3c5a57a33fb90618710b298e233ae81cdcdbeed204328e9dc55fe0aaf63eb3fa24e58f4d489f5dde48e2ff716b16e0c47882d8be61bd3bd579b3e23ee3034ce3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okio/okio/3.6.0/../../okio-jvm/3.6.0",
+    "dest-filename": "okio-jvm-3.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okio/okio/3.6.0/okio-3.6.0.module",
+    "sha512": "2942511ac0f204af6261b9b254adeefc432518e8ad123957875f8ff95c9994c2564a019f3edebc3499a8404700e031d8d95eb8c084bee58c535ff9ccc383f19e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okio/okio/3.6.0",
+    "dest-filename": "okio-3.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okio/okio/3.6.0/okio-3.6.0.pom",
+    "sha512": "b28fab6b6ec5b72759815673e6ee9e8dfff3e9940a016588e671f4ef4e2f936117c7cef31c38459a5d702b217e57c47f91bea693a9b9072b3422b84515133fe6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okio/okio/3.6.0",
+    "dest-filename": "okio-3.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-codec/commons-codec/1.19.0/commons-codec-1.19.0.jar",
+    "sha512": "d98a7a1cfcc08aa9cce4f7778e3f37ecb99da7b1da01944e5fa8faf06fbf9f969f2efb0b416832f419d53085250f711c071f1dac9fa0968483c37034198367fb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-codec/commons-codec/1.19.0",
+    "dest-filename": "commons-codec-1.19.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-codec/commons-codec/1.19.0/commons-codec-1.19.0.pom",
+    "sha512": "876e711b79565c3878ea4f0799f5209b53daa08f370e8aac286cced03ef494e2c24c89eb425d68850b5d920c98fe6f813e80c318ee4900dcc9b3271b2860f307",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-codec/commons-codec/1.19.0",
+    "dest-filename": "commons-codec-1.19.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-codec/commons-codec/1.20.0/commons-codec-1.20.0.jar",
+    "sha512": "6a71738f99031685050aadf8579a6ff67ae5fa5b779d7f35e6b9fffcdd524c29ce6d9ba055f2a88b481e80552ae9e61daf09ae8f467c048afb475a763a643097",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-codec/commons-codec/1.20.0",
+    "dest-filename": "commons-codec-1.20.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-codec/commons-codec/1.20.0/commons-codec-1.20.0.pom",
+    "sha512": "22ab6798c1e6f05b6d7d4209eaccf597fa6b53ab772676b6dfb82cc53359c16bb9194c1271eab414fd26c884fbcdb94e0dbc770e030b37a7c2865fcc904bb6d0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-codec/commons-codec/1.20.0",
+    "dest-filename": "commons-codec-1.20.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-io/commons-io/2.20.0/commons-io-2.20.0.jar",
+    "sha512": "fea08e150473673b0608eaee3ae1cb4e73834039db80d3b758710d6baf3a5840a0878a4eb64739ae9bb21ccc7148c8520fe873616a3f6d5cdb4305deabdd015c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-io/commons-io/2.20.0",
+    "dest-filename": "commons-io-2.20.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-io/commons-io/2.20.0/commons-io-2.20.0.pom",
+    "sha512": "db6bfb4d59e6d05d89ec5cca7ceb89c7493398c8b047046066a19db01cd9b4b32873bcce1be531fea85be4be651b836ad2cb698072b5705fd3491c0743884758",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-io/commons-io/2.20.0",
+    "dest-filename": "commons-io-2.20.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-io/commons-io/2.21.0/commons-io-2.21.0.jar",
+    "sha512": "7ac1aa4d834cd7cdecaee223a64c63d481810c73dfdb5109f402234a05cadf754e414cead99072f5140d4f7042ee084161935fb28129a631d908d989c5bbac5d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-io/commons-io/2.21.0",
+    "dest-filename": "commons-io-2.21.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-io/commons-io/2.21.0/commons-io-2.21.0.pom",
+    "sha512": "4728a13da04911617a5a3d981c21015f26551e636076d3a5fbaa12524f04ee46b7ec250a662a670688b5699ce92940e49b7ed70999ab3cfdaf4949ec6894449d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-io/commons-io/2.21.0",
+    "dest-filename": "commons-io-2.21.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+    "sha512": "ed00dbfabd9ae00efa26dd400983601d076fe36408b7d6520084b447e5d1fa527ce65bd6afdcb58506c3a808323d28e88f26cb99c6f5db9ff64f6525ecdfa557",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-logging/commons-logging/1.2",
+    "dest-filename": "commons-logging-1.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-logging/commons-logging/1.2/commons-logging-1.2.pom",
+    "sha512": "75bef548eea62ab04569791f2fdeed3d0a61edae0534aa035a905dc1d011988fc0f06f52bde377f44e94e6afd4380197148120b152b7a4d20628fb6236cc7261",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-logging/commons-logging/1.2",
+    "dest-filename": "commons-logging-1.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-api/2.0.0-alpha.2/detekt-api-2.0.0-alpha.2.jar",
+    "sha512": "f92689ca7394737ea274c33fe7896bf6e43d0f6fc8bffdef6c285d5bbf397dae9cd97da03ff21159de3769353c2f9e35a44142efba0460d169a622c18e29547e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-api/2.0.0-alpha.2",
+    "dest-filename": "detekt-api-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-api/2.0.0-alpha.2/detekt-api-2.0.0-alpha.2.module",
+    "sha512": "606b291c895754ac12c5c69912c2e4ef2ff0e97df6685d9d7cef8d55b9732472477f6eabbe12dbd67fe148fa07f6c446be6dacc9413fe652c6cf7ac22e7e1b6f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-api/2.0.0-alpha.2",
+    "dest-filename": "detekt-api-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-api/2.0.0-alpha.2/detekt-api-2.0.0-alpha.2.pom",
+    "sha512": "e944f352ad343c0891fdfb64fc84617698ceb65b819807f000878b15247ee7b1daeaabca51cfd74cb5c115493ef4f243dc66ec97feff15747b5bdda00ff756ef",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-api/2.0.0-alpha.2",
+    "dest-filename": "detekt-api-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-cli/2.0.0-alpha.2/detekt-cli-2.0.0-alpha.2.jar",
+    "sha512": "57d1f3c7ed2f509e31b3a174bb6411978e62a88663ef495d5481cf92dc68c6242260c098e34845c7d3f83bb48589933361b5b793a1c8ab41609090cf01b02db5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-cli/2.0.0-alpha.2",
+    "dest-filename": "detekt-cli-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-cli/2.0.0-alpha.2/detekt-cli-2.0.0-alpha.2.module",
+    "sha512": "05d42afdc938b1471db70107f615d0183ab0640c1f937337598bb221a076a66298c331d9163cfd8d716cdefc16ee2d8665971bd8c59c36ae8617c02e8d6ab8d3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-cli/2.0.0-alpha.2",
+    "dest-filename": "detekt-cli-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-cli/2.0.0-alpha.2/detekt-cli-2.0.0-alpha.2.pom",
+    "sha512": "eba9fff1065d166099c2812e699be25cfc43844451f12eb37e33aa31b8154c244354e11b64a969a85a2c2184fe3f2b9976c59b9383adca44b3a70f49db20cad7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-cli/2.0.0-alpha.2",
+    "dest-filename": "detekt-cli-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-core/2.0.0-alpha.2/detekt-core-2.0.0-alpha.2.jar",
+    "sha512": "01a70f541d2710e47a0e667ff653679b095a360ca8df4d621a90d5269d1689a1e57ac4dfd94c47fcbbb4272596a377a9f59551a808991173feb3fa19c93c0d8c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-core/2.0.0-alpha.2",
+    "dest-filename": "detekt-core-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-core/2.0.0-alpha.2/detekt-core-2.0.0-alpha.2.module",
+    "sha512": "551ad364524ddbb10e452ee55be023632b3fb104f0feca293857c11fe772c148de1ad083e7523eef46226d70946ed04a1cc4bc02a89d198ec86afba8eb383880",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-core/2.0.0-alpha.2",
+    "dest-filename": "detekt-core-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-core/2.0.0-alpha.2/detekt-core-2.0.0-alpha.2.pom",
+    "sha512": "a9e0d9ff48ff7967d426e476c929b313c26e2b4f8b1f46f5360dcf8a2c058eeeb419a118fa11fb82aa331982c167a4d341bdb4012f19b67224e89344b1a42b03",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-core/2.0.0-alpha.2",
+    "dest-filename": "detekt-core-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-gradle-plugin/2.0.0-alpha.2/detekt-gradle-plugin-2.0.0-alpha.2.jar",
+    "sha512": "2e577b61f89fcbcf159daab4dc67a672e73d416a147907ac79df51943322eaaf83d504137952205fd6b87947d28a03ac172271d58f9a379ba0ce93b9d4eae3ec",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-gradle-plugin/2.0.0-alpha.2",
+    "dest-filename": "detekt-gradle-plugin-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-gradle-plugin/2.0.0-alpha.2/detekt-gradle-plugin-2.0.0-alpha.2.module",
+    "sha512": "f0d9e232e5b440809df15ca1f0a2d2e09a66ef6ad1c6c7d27e7d13ffd4c32a2512805bc30124770ab255f2690f37dd7aaff1b66ae74c821f72ed5ec737f43dc5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-gradle-plugin/2.0.0-alpha.2",
+    "dest-filename": "detekt-gradle-plugin-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-gradle-plugin/2.0.0-alpha.2/detekt-gradle-plugin-2.0.0-alpha.2.pom",
+    "sha512": "9ffc7312775a8edccdcf958983fe76e610b122278ab4592c376326438cb9f95960d26ff88c4a4a62e7c2d4d7eae53c631a4f1467e01df88f4a8302f7f17e55eb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-gradle-plugin/2.0.0-alpha.2",
+    "dest-filename": "detekt-gradle-plugin-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-kotlin-analysis-api-standalone/2.0.0-alpha.2/detekt-kotlin-analysis-api-standalone-2.0.0-alpha.2-all.jar",
+    "sha512": "9b343666fb895f0765207a29fb9eafa2ae1d06d2cadc6dccfe000f6b828278d7ff4b3362a69e754008e2c2cf788f0feee0f14ac6aa51555ae73b4740f412ed5b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-kotlin-analysis-api-standalone/2.0.0-alpha.2",
+    "dest-filename": "detekt-kotlin-analysis-api-standalone-2.0.0-alpha.2-all.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-kotlin-analysis-api-standalone/2.0.0-alpha.2/detekt-kotlin-analysis-api-standalone-2.0.0-alpha.2.module",
+    "sha512": "36ae3bd3032ced0169052bd692ecbc47e084b6cfc9d2cd9533e093ee5f174f7597ce5061d627c737278df1ff81a01720af4a8eeb5279be73fa02351e7853eb2b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-kotlin-analysis-api-standalone/2.0.0-alpha.2",
+    "dest-filename": "detekt-kotlin-analysis-api-standalone-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-kotlin-analysis-api-standalone/2.0.0-alpha.2/detekt-kotlin-analysis-api-standalone-2.0.0-alpha.2.pom",
+    "sha512": "989418630bd8a9a90c8bc1d89416527a5eaec2d66e67a3262c506fb0c02ec973dbbba98bd5ceb6ba92d6f4b0c31fcbf2ad4c7d12e3dbb5801cfaaefe528909ce",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-kotlin-analysis-api-standalone/2.0.0-alpha.2",
+    "dest-filename": "detekt-kotlin-analysis-api-standalone-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-kotlin-analysis-api/2.0.0-alpha.2/detekt-kotlin-analysis-api-2.0.0-alpha.2-all.jar",
+    "sha512": "d7e1291ddc50a0117ed43b9eaec75efee985cc91575de20c62391b6a6e3aef3fbacee9d55ec455b2c436a34a48dbe10a61f500d223ab844588921ba99f89d34e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-kotlin-analysis-api/2.0.0-alpha.2",
+    "dest-filename": "detekt-kotlin-analysis-api-2.0.0-alpha.2-all.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-kotlin-analysis-api/2.0.0-alpha.2/detekt-kotlin-analysis-api-2.0.0-alpha.2.module",
+    "sha512": "a9e2018ff3aca245739313c2472912dd8ccf9bfc3a440ea8686d49d5a632e57b687f8dd344720dc46983894b0d3fe7548ee101d38672f51a9bdbadb8c1d31ff2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-kotlin-analysis-api/2.0.0-alpha.2",
+    "dest-filename": "detekt-kotlin-analysis-api-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-kotlin-analysis-api/2.0.0-alpha.2/detekt-kotlin-analysis-api-2.0.0-alpha.2.pom",
+    "sha512": "9fbf59d2ae763230312b67d4370889af0b958049a675ab3716e0947e7c42e2c5fcd05c6673ca282f6c8e632938f1a8d4ed6b79f6420613e7f093c1b8fd3991ae",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-kotlin-analysis-api/2.0.0-alpha.2",
+    "dest-filename": "detekt-kotlin-analysis-api-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-metrics/2.0.0-alpha.2/detekt-metrics-2.0.0-alpha.2.jar",
+    "sha512": "187878249cb44ea70c9812e9f419f43de4b11276a7cc642fb0c796a0ecae860bd13ef33a7fcfe8f4a1a9cbafb798f3b4865fee69bbebd48ce0b14da2903e3f65",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-metrics/2.0.0-alpha.2",
+    "dest-filename": "detekt-metrics-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-metrics/2.0.0-alpha.2/detekt-metrics-2.0.0-alpha.2.module",
+    "sha512": "265874aa5f736a99534633d6003507fad2ad37c42647ebd2479e5ed8a8fe32c3d2b790fae259f7dd43c0f2f383402913b1047d7d09cad565c5d18269efcd11ac",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-metrics/2.0.0-alpha.2",
+    "dest-filename": "detekt-metrics-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-metrics/2.0.0-alpha.2/detekt-metrics-2.0.0-alpha.2.pom",
+    "sha512": "7888a7fec038af3a697f40cfcc909670e76dcc1936bc7c0d12f5e7422cb35e203ef8053cd3f4102e92f612ec5bf7bb1636eedaa4b00741480f5271817d7a6749",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-metrics/2.0.0-alpha.2",
+    "dest-filename": "detekt-metrics-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-parser/2.0.0-alpha.2/detekt-parser-2.0.0-alpha.2.jar",
+    "sha512": "fd78fe027efae4843d5bedd7b16927fc2cece256688ab5fae69e44947414f32798a1f0b56d1435d36e4726c843426aabf5456cfcfcfeac9b203e574392a3f9d5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-parser/2.0.0-alpha.2",
+    "dest-filename": "detekt-parser-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-parser/2.0.0-alpha.2/detekt-parser-2.0.0-alpha.2.module",
+    "sha512": "6eddf1845b7087a0ad62df9ab7c14b203bd8bd47a36633faaf3c7c505364ac06c1b9a43d6292e13cea53a315a1379c7cade534837f2eba067af0910d6133290d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-parser/2.0.0-alpha.2",
+    "dest-filename": "detekt-parser-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-parser/2.0.0-alpha.2/detekt-parser-2.0.0-alpha.2.pom",
+    "sha512": "ff99d51847d0dd496e3cae512e7d859a0541848903d3b585004334d33a2b2c3a5d597e9725508912fada1b349d150df78184478894a164ffd667ae23f623d2a5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-parser/2.0.0-alpha.2",
+    "dest-filename": "detekt-parser-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-psi-utils/2.0.0-alpha.2/detekt-psi-utils-2.0.0-alpha.2.jar",
+    "sha512": "30d30513acaec8d33d22a62e6f5f8cfeba459e04eaaa783d6373fe0f86fea7f278b96c77daa62f2115b4a04cdd54872ad5a71f6ad2fce7f260ce945f0b925d65",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-psi-utils/2.0.0-alpha.2",
+    "dest-filename": "detekt-psi-utils-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-psi-utils/2.0.0-alpha.2/detekt-psi-utils-2.0.0-alpha.2.module",
+    "sha512": "446d8ea2ad5117063d5a060853c0abd98cea1a8480b109664ef3a4c7d56174fd62754053dbfc37181a918f286c99fc26e9a5637b94d8a118cb032bb439d1e6d5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-psi-utils/2.0.0-alpha.2",
+    "dest-filename": "detekt-psi-utils-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-psi-utils/2.0.0-alpha.2/detekt-psi-utils-2.0.0-alpha.2.pom",
+    "sha512": "9cb2f9deb0af2c66ecaa95dad907d1b3cbd0f94299f0c1399271bcf4f117c8245be0efd01756875f7485f3ebfca5c07c9767ce04f2a8628392073de5550c850e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-psi-utils/2.0.0-alpha.2",
+    "dest-filename": "detekt-psi-utils-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-checkstyle/2.0.0-alpha.2/detekt-report-checkstyle-2.0.0-alpha.2.jar",
+    "sha512": "5141a71fbb8a0e6ec8148009915586fb147b2d974173d744ee3b42310b91125d8412cfccbfd5d08776676f181511f16b8c9509ed3de6e288f470dadd72c5cfd8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-checkstyle/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-checkstyle-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-checkstyle/2.0.0-alpha.2/detekt-report-checkstyle-2.0.0-alpha.2.module",
+    "sha512": "c0457adb87ae47fac3144017aaeae8ecb1c99ea9b3a912d1368d1913080fd32526dbc1951082f896531380531793ab68b14a19ed39ccda349fe3213c36c19e16",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-checkstyle/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-checkstyle-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-checkstyle/2.0.0-alpha.2/detekt-report-checkstyle-2.0.0-alpha.2.pom",
+    "sha512": "8628406e3fa8ac0f6c7c7ee0bffaf78c6f1d86a30c9f5b33fe8b7b84acc5f33017e829f595b491e02c410c1329f567138b88ca03bafb2b71f3ca77e37c486d99",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-checkstyle/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-checkstyle-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-html/2.0.0-alpha.2/detekt-report-html-2.0.0-alpha.2.jar",
+    "sha512": "1d871c4e8cbaf6a1eb80638416785539ecae709324f0f0c697a1f38c7e2b6838f94c3ae3406ad69090d20f62265b912ea9ec7f99848825989d89ba162d8a1b75",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-html/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-html-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-html/2.0.0-alpha.2/detekt-report-html-2.0.0-alpha.2.module",
+    "sha512": "1868b1c8cc6768678945857cea31debeef485fd790f421aa49ddcfbb5188f3282d99df7c421ef19978d69202cce1c2c09618ce8f42d8a8c71fc790b464002ff0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-html/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-html-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-html/2.0.0-alpha.2/detekt-report-html-2.0.0-alpha.2.pom",
+    "sha512": "cc956d94a570b0eb22239bbfc15cb32fd93241a3b7bc51867741a908ab4c1236724eb7396f649498b19bfd1c07ee92a8858eedb4f4cada3a79dcab855d35a482",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-html/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-html-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-markdown/2.0.0-alpha.2/detekt-report-markdown-2.0.0-alpha.2.jar",
+    "sha512": "6fac22bf6401ae24e4a2b48f82732ed9ecce16013701b06651744ed0462931419f00eae761a0a4e60718abda8f6fa860416755235b450c0725b2a4bcaedb58c9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-markdown/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-markdown-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-markdown/2.0.0-alpha.2/detekt-report-markdown-2.0.0-alpha.2.module",
+    "sha512": "7fec75d8fca549133c94282f4b99c6a9424e2a82afc09d6c42f0b81d67514b9cc7677c9ce01f63d99541d59d65a00106d24c7aa610c942f6f28e0333ae5ce5f9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-markdown/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-markdown-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-markdown/2.0.0-alpha.2/detekt-report-markdown-2.0.0-alpha.2.pom",
+    "sha512": "1606e1929a8a74f2997ff7e1b25b811fbdda17e378cfe972fc37c7cb56d67a54149cbe2c215dc2b4912cd667e187ee857c268939aceb5922fe15939449bddacb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-markdown/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-markdown-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-sarif/2.0.0-alpha.2/detekt-report-sarif-2.0.0-alpha.2.jar",
+    "sha512": "6b66db75561f0550fb7303f0cb4e105c4b8cb46226694e8431447345620c0510182427d1405018059bffeac25bbf3e51ce9645aa5d722bfa5f274ecff0a870c4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-sarif/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-sarif-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-sarif/2.0.0-alpha.2/detekt-report-sarif-2.0.0-alpha.2.module",
+    "sha512": "2b3b4d4153832f37b1372bde5dcae5b46db7a7c61a88d2b208070fc3488dbf69451de59c5f5eb95c891354a7e83fb6f4af5f0915d8b4cdff0e6051d743bc161b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-sarif/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-sarif-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-sarif/2.0.0-alpha.2/detekt-report-sarif-2.0.0-alpha.2.pom",
+    "sha512": "353cf21bd023e792e43268d6cc77d2dd67ec1b5246ea6cc9ead306d1dcf413582a7aee711eedf13584fe28319ee041614a37f7d2ee111c3cd13c70dafe63a102",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-sarif/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-sarif-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-comments/2.0.0-alpha.2/detekt-rules-comments-2.0.0-alpha.2.jar",
+    "sha512": "d7c82c6eadf7762b4fd0f0b5ba40df846a3940168e6fac5ae18f7903fdc65379239ce2eb2a611670ebb7c96e8de67b8d6c9f4625e78be3246faeecfce05831b8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-comments/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-comments-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-comments/2.0.0-alpha.2/detekt-rules-comments-2.0.0-alpha.2.module",
+    "sha512": "8efdc4662ec1797ee536b9038cf526ff6f09f5515d5fb9f971d569f0b04f21dac6b8a278b59570b0e4be430b10666a86cc10469b0d41510b011e484fb78e6172",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-comments/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-comments-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-comments/2.0.0-alpha.2/detekt-rules-comments-2.0.0-alpha.2.pom",
+    "sha512": "cdce5f5fb2387f74c246c8d2721e4ef835c36b670ac14796be0636de1424fca772393de5f3b468d0140a8d4a7bc09ad2504e0f901b8e7b409f924b4c3b206bd3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-comments/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-comments-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-complexity/2.0.0-alpha.2/detekt-rules-complexity-2.0.0-alpha.2.jar",
+    "sha512": "b135ed082cd968b0ac073585cfc99e6176fcf5268ba4f580bd53440556a1f77771b1d428b7e5a3162be485107f57a868b17733718851eb2ab3d20b013a933c89",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-complexity/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-complexity-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-complexity/2.0.0-alpha.2/detekt-rules-complexity-2.0.0-alpha.2.module",
+    "sha512": "2bca45c343f778bd221f60da08e1b4d8e9caa330c55dd27d00f4a8dad3409ed0bbf5d0fc3adf28e2807f9fbfb1e1884a0f88cb4cba2a4d9c6cd20925284b1b0c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-complexity/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-complexity-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-complexity/2.0.0-alpha.2/detekt-rules-complexity-2.0.0-alpha.2.pom",
+    "sha512": "fe0b1a68f3629612944a7e2182b8777b9db30828da6832f5fb3ca14017b5516c9c905009beba5e8e8c959f07ade2d143edd2527d1c20a1a94b11deafb64efd44",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-complexity/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-complexity-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-coroutines/2.0.0-alpha.2/detekt-rules-coroutines-2.0.0-alpha.2.jar",
+    "sha512": "d3b94f9c3a9f10cb913f23c4777786719bce3a59c3271e4c7e509852de73aa8a952377d7041142459dbd4a58bbcb1671a138ad2912183c3ca176f2724b1e0631",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-coroutines/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-coroutines-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-coroutines/2.0.0-alpha.2/detekt-rules-coroutines-2.0.0-alpha.2.module",
+    "sha512": "1994f4cba047b44f47fed1e7da35f53c392bfe0a5635e125a07dc1e2e22c5139f3fa590e01a32f8d3f10aab9090039ff86b65b394c0a3c5e072716964ae24b2f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-coroutines/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-coroutines-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-coroutines/2.0.0-alpha.2/detekt-rules-coroutines-2.0.0-alpha.2.pom",
+    "sha512": "39b203f66a52ba19dfd256776876947beaf49b259dc22150077dcc72a2a2d8b9bbbb9800d8ae607b8212ebd2332e7ebc06c71c0e91302a619c5ef0eee6e4c93d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-coroutines/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-coroutines-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-empty-blocks/2.0.0-alpha.2/detekt-rules-empty-blocks-2.0.0-alpha.2.jar",
+    "sha512": "91d159ccf1416a1b697920621ceba878ea63a7d5caa656807f1aa090adcc736fdfb39dd0b668a521f9308bfb81fdadfb2aa7c5722b53148dfb30c002f82b6c16",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-empty-blocks/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-empty-blocks-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-empty-blocks/2.0.0-alpha.2/detekt-rules-empty-blocks-2.0.0-alpha.2.module",
+    "sha512": "fe10cba7e53ae99f9cfb634aea9bcc1c61620d61d8e1f20b6e7cbdd66bcab9d61473fb9ffdfaeab793e0b0228be8b70662ae99be1703936af33eb09b9aed9ae4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-empty-blocks/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-empty-blocks-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-empty-blocks/2.0.0-alpha.2/detekt-rules-empty-blocks-2.0.0-alpha.2.pom",
+    "sha512": "ee50ffeb3d1ddce52d0687b96cabd710f46664d9602b74cc75d0e524d9d8b12acaf019005a70be7234d06c58f36a28aeb4012818a7acce23c27efbb208f748bf",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-empty-blocks/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-empty-blocks-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-exceptions/2.0.0-alpha.2/detekt-rules-exceptions-2.0.0-alpha.2.jar",
+    "sha512": "cd3d1060e92e8eb416c2baad815787b798eeb2b342c41368d43b448952f876eaf83d33dc3fb104acbaa78db72b2930427ed6f86db0059b46bdb2c862de26d557",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-exceptions/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-exceptions-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-exceptions/2.0.0-alpha.2/detekt-rules-exceptions-2.0.0-alpha.2.module",
+    "sha512": "d4883c8b503f0664db886397d9ef16605ee7d2ffa2822f7bb327e5e34ee65d19b4b7a942ee42acb5bd418f1ec94b799052c09f21d7864a6376867cf490d1c4c0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-exceptions/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-exceptions-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-exceptions/2.0.0-alpha.2/detekt-rules-exceptions-2.0.0-alpha.2.pom",
+    "sha512": "b9fdc6764d5799643148d8041d1f071bf217283e70b25de079521ca2e1d8760f808ea9640c7507c3d2f32cd760bf7ffb34d24d3271ecd08187ece8139e528a27",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-exceptions/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-exceptions-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-naming/2.0.0-alpha.2/detekt-rules-naming-2.0.0-alpha.2.jar",
+    "sha512": "a4aaee7220180f7fdb2e0a9358aacc73356ff8e5022cbd7083610503beaaff2b5370ae68a08a263ee3bdfa1a5d5ce1956467df0b3d80bec092c9eade6a9696d5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-naming/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-naming-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-naming/2.0.0-alpha.2/detekt-rules-naming-2.0.0-alpha.2.module",
+    "sha512": "eb4bd51f615e7b8ecc7b91afc804eba794f68bdcbc62ae7b2228b14c72ed8be6128e1f8d9488c0241e755ce3dd34ed8e986fbf477adc07c34a15ca5c97b61917",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-naming/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-naming-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-naming/2.0.0-alpha.2/detekt-rules-naming-2.0.0-alpha.2.pom",
+    "sha512": "681d8370aa01d330449e321a93f35f4dc654e092860bdd7f7d6cfd8d77e9206cf9c1feb4d54a5678b43fa71eae3fd3c9d18cb2d530a0fc04b0a245be34781c7c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-naming/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-naming-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-performance/2.0.0-alpha.2/detekt-rules-performance-2.0.0-alpha.2.jar",
+    "sha512": "364df0aebca79a978878e0ac1a20f91096876c9d867db6756a363e885ae86c558232c4f11f80b35cce8fe579c06f817a0247d0171ef30e6adb945f365bb27654",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-performance/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-performance-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-performance/2.0.0-alpha.2/detekt-rules-performance-2.0.0-alpha.2.module",
+    "sha512": "777d78f44f3510e959866d75489b0840e87ae5cef701fbe2538b7b03829f1acb05996500a5fefe9137ae524b8cfd693fadfd9294171f4647443a3fcd75f58b52",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-performance/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-performance-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-performance/2.0.0-alpha.2/detekt-rules-performance-2.0.0-alpha.2.pom",
+    "sha512": "9173cc5c4fc88de2337b273667182e6bffc8ebbfb533e41eb9e43453b0a2131c54cb3b5098c8e149fd2865572466bb37fd50b3e08e56157d5f54da606f043a89",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-performance/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-performance-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-potential-bugs/2.0.0-alpha.2/detekt-rules-potential-bugs-2.0.0-alpha.2.jar",
+    "sha512": "4b883a0acaeafec44d59629f56992101c0a134ceebdc4003a1fdb9508b8aabb15ae8af0e5369be6e3bc4ac4d992fe4cd46cde6ca5b9330dca65236fede19801c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-potential-bugs/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-potential-bugs-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-potential-bugs/2.0.0-alpha.2/detekt-rules-potential-bugs-2.0.0-alpha.2.module",
+    "sha512": "7968bb82385a53fcfb3080b14c67b919cddca053ac6787b4aac8585ea2b4714b6af39afda3729ed455263e7be0339b654b92a2e98c176471efc0feb46e6d6811",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-potential-bugs/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-potential-bugs-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-potential-bugs/2.0.0-alpha.2/detekt-rules-potential-bugs-2.0.0-alpha.2.pom",
+    "sha512": "77744a2a0dcdd4ad0444372f6eda83a56e307b7b640a737933fa706c187b73e2b789cf7c0af457c0263ee6746488bf3567a795f8c37209f8dd8e4646a0c56c7f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-potential-bugs/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-potential-bugs-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-style/2.0.0-alpha.2/detekt-rules-style-2.0.0-alpha.2.jar",
+    "sha512": "43a92593951e67037aa8e168d0fc5c523145e73e405894ccd37d0c12e1272e39dc1cfb78d8ebf708fc46c56e6cd6a18a2ac043f054291a3b564afd0ab0a1c608",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-style/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-style-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-style/2.0.0-alpha.2/detekt-rules-style-2.0.0-alpha.2.module",
+    "sha512": "bfd53e31296ace3411c3c3fe5af2cd041b24dc75936eab0e992ec0da82080690d4d9b9142b3d6a13423b352d1e3766fc3ca9603a4eea7ac7713439c971f95f7d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-style/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-style-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-style/2.0.0-alpha.2/detekt-rules-style-2.0.0-alpha.2.pom",
+    "sha512": "7dd159c3aa3ffcba95e4da075750763f2f27285a56e0e91230dad86759b5d5b5c39f846d5b84cf1e743571d6adcf91c8cb0da5f173b2b28fbb4e5f6a2ad4bd31",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-style/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-style-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules/2.0.0-alpha.2/detekt-rules-2.0.0-alpha.2.jar",
+    "sha512": "1487e5a20c9e4d74f298e07c42e96a61be11b7a768c3fbc199ee138cd68e1fc2267d1cfe3f11f288acc05df755315344d052cc5f6f751f126ab4fe1caa5125ea",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules/2.0.0-alpha.2/detekt-rules-2.0.0-alpha.2.module",
+    "sha512": "c31b2b2485651ae28a1e240212d7c4869fef450a0f80c7c364323d43359551c39903736c6c5496a4b86159f23cc2e8aad4858030bae13208510cef8a7346d915",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules/2.0.0-alpha.2/detekt-rules-2.0.0-alpha.2.pom",
+    "sha512": "261d913632c5e996bfd534e55f66417e63aeb32a0042935f1a99fc0cfb7c17adeed32c9d3650b109ded2ffb0891fee3dfa9c5be030f78faf65a1e9512923647f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-tooling/2.0.0-alpha.2/detekt-tooling-2.0.0-alpha.2.jar",
+    "sha512": "77af5970cac6f432c7f3a0b39485c8df8e943d1b529edda9518afe94d539ce4ae8b2ec560419838771172381eef03ee827a16ba6acd9ecfd876005a338ecf741",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-tooling/2.0.0-alpha.2",
+    "dest-filename": "detekt-tooling-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-tooling/2.0.0-alpha.2/detekt-tooling-2.0.0-alpha.2.module",
+    "sha512": "69d4a955547522b26875a8339bad82d06e2bcbb2c9591a0f92115a48da184e716c88b277c00e8d18deb42d0d2805299448c1b577fb423578eb9ceca5bcf4e00e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-tooling/2.0.0-alpha.2",
+    "dest-filename": "detekt-tooling-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-tooling/2.0.0-alpha.2/detekt-tooling-2.0.0-alpha.2.pom",
+    "sha512": "7a827a5625fcb6677c38901588d2d18c0975b723e0a2c68a3d99b139016fb9a0d608b75f20a2056bc8064830a698a741ef6eb8d2f8c021fd2766a564b37bc9d5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-tooling/2.0.0-alpha.2",
+    "dest-filename": "detekt-tooling-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-utils/2.0.0-alpha.2/detekt-utils-2.0.0-alpha.2.jar",
+    "sha512": "0840be78882bb10690cfd623e75a56c7373e12eb1306c100bdec01c492bb2b2802778bb6d5dee665da140ecae8a41a351281f7aae7317d1d67628b35b1b03543",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-utils/2.0.0-alpha.2",
+    "dest-filename": "detekt-utils-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-utils/2.0.0-alpha.2/detekt-utils-2.0.0-alpha.2.module",
+    "sha512": "fa8135b77d32c87a75b50b7159775f30599933a386027fcbf9cc9ecdaec31b44b29f19ed812061399a9043dcc0dcccb09268a889f92388ae39190a2f1a7ac269",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-utils/2.0.0-alpha.2",
+    "dest-filename": "detekt-utils-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-utils/2.0.0-alpha.2/detekt-utils-2.0.0-alpha.2.pom",
+    "sha512": "031f11821a02bc8deee5a30ea6e28682e7521be7f5ca9dc6bda14b2afe9a3d8d5dacd135866f485cd8f9cb39be2900c2dcd55f1ec8151e15adf66a196211c79c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-utils/2.0.0-alpha.2",
+    "dest-filename": "detekt-utils-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/dev.detekt.gradle.plugin/2.0.0-alpha.2/dev.detekt.gradle.plugin-2.0.0-alpha.2.pom",
+    "sha512": "9142bda2e3b8075031d7f70850b9ab00e73c2fcfd31b6b79a65f8d544e3e0d801912a29e885a13ebe9cc8bf1054c50fcc3e027722fbf23a5ae1329290811a125",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/dev.detekt.gradle.plugin/2.0.0-alpha.2",
+    "dest-filename": "dev.detekt.gradle.plugin-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/drewhamilton/poko/poko-annotations-jvm/0.21.1/poko-annotations-jvm-0.21.1.jar",
+    "sha512": "fce3f02184999f5843c63b43482e411815fdaf103d4a7fd0102afcf959eba00dc364a2adae3918debd0ce7fc52fd4b22da809a82562aaccfa473bb1ecf8441e0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/drewhamilton/poko/poko-annotations-jvm/0.21.1",
+    "dest-filename": "poko-annotations-jvm-0.21.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/drewhamilton/poko/poko-annotations-jvm/0.21.1/poko-annotations-jvm-0.21.1.module",
+    "sha512": "3afcf82f3e8b2e4cc4c771a0f5d66ac89ae9b5bbb629444228e7a043d35c9b114ab88a5606f547f0b08decea76f146b1a6c491a5dd1435af8088ca57a7ca2a92",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/drewhamilton/poko/poko-annotations-jvm/0.21.1",
+    "dest-filename": "poko-annotations-jvm-0.21.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/drewhamilton/poko/poko-annotations-jvm/0.21.1/poko-annotations-jvm-0.21.1.pom",
+    "sha512": "df5ab6c62a87bcdc953cd0d37b9c3510c8ef298b9c75b65369a5f09d02f7456004dd8bd3a7b53b0889c9ba5e95aca1a56781e2f05f36799e7b704f7298a4c12a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/drewhamilton/poko/poko-annotations-jvm/0.21.1",
+    "dest-filename": "poko-annotations-jvm-0.21.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/drewhamilton/poko/poko-annotations/0.21.1/../../poko-annotations-jvm/0.21.1/poko-annotations-jvm-0.21.1.module",
+    "sha512": "3afcf82f3e8b2e4cc4c771a0f5d66ac89ae9b5bbb629444228e7a043d35c9b114ab88a5606f547f0b08decea76f146b1a6c491a5dd1435af8088ca57a7ca2a92",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/drewhamilton/poko/poko-annotations/0.21.1/../../poko-annotations-jvm/0.21.1",
+    "dest-filename": "poko-annotations-jvm-0.21.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/drewhamilton/poko/poko-annotations/0.21.1/poko-annotations-0.21.1.module",
+    "sha512": "891fdb48c5b3afe9bf63dac10763342a313ffbc562211386f04b33fbe65cf6e0df2182145cb2040f59767d9e537e8b7508849058e5f899cb13f5372e29805bfd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/drewhamilton/poko/poko-annotations/0.21.1",
+    "dest-filename": "poko-annotations-0.21.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/drewhamilton/poko/poko-annotations/0.21.1/poko-annotations-0.21.1.pom",
+    "sha512": "c30eef3f9c06efa1f7c78b70e5d30916daaa69115c8bc49442e432c42aef026362bc3943afa7de34cbb43465d95d723eb74f6f06da65259270df3083a8028559",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/drewhamilton/poko/poko-annotations/0.21.1",
+    "dest-filename": "poko-annotations-0.21.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.jar",
+    "sha512": "96499a151e1250bf976db95def8caf8949ab1464b59dc8a233f12ced64e815635a806e77f81fec846a44d51832628703f64ce5c83313843f90093dc49b9b6353",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0",
+    "dest-filename": "sarif4k-jvm-0.6.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.module",
+    "sha512": "0dce653298ad8dab783148e2259d2029eb66bad6a54b9685b5a25e6e36ee7290b035833cf07be8051018333afd477bd207b44cbe2c5da2c6a6b511bbd2d4ba99",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0",
+    "dest-filename": "sarif4k-jvm-0.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.pom",
+    "sha512": "dd77f3d7d236ab57741fa7540a5ff6d2f3fe69444e619a2fef0dd105f271f4bbfb320649edb2114dc31a0d019e6c3411d0e247956400daa1b340bf03fd1d887f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0",
+    "dest-filename": "sarif4k-jvm-0.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/detekt/sarif4k/sarif4k/0.6.0/../../sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.module",
+    "sha512": "0dce653298ad8dab783148e2259d2029eb66bad6a54b9685b5a25e6e36ee7290b035833cf07be8051018333afd477bd207b44cbe2c5da2c6a6b511bbd2d4ba99",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/detekt/sarif4k/sarif4k/0.6.0/../../sarif4k-jvm/0.6.0",
+    "dest-filename": "sarif4k-jvm-0.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/detekt/sarif4k/sarif4k/0.6.0/sarif4k-0.6.0.module",
+    "sha512": "f5c3ca971084e0fe4f011764f86c91e2bd3b6c0e5667c67d40e0a82e90622c77d9ac49d4079899a1f309e45ce0de6948df12f126b895b75c31b8021dba77755e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/detekt/sarif4k/sarif4k/0.6.0",
+    "dest-filename": "sarif4k-0.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/detekt/sarif4k/sarif4k/0.6.0/sarif4k-0.6.0.pom",
+    "sha512": "f0cb71efc54db1266cc8851b31a446cc0b5909c5dd7b536eef11d5bef920f9b357f615bb6c43350510bb6555dc969215caded2d3f885bfc2bcda3de566b5de0e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/detekt/sarif4k/sarif4k/0.6.0",
+    "dest-filename": "sarif4k-0.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/java-diff-utils/java-diff-utils-parent/4.12/java-diff-utils-parent-4.12.pom",
+    "sha512": "67476b78236fac9cf37c521a4ec52365ac0cdff510083af8b272a13b669900c4800dfd5ce263ee0769297357edc41769647c272f9283ac50aff69dcf1971eeed",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/java-diff-utils/java-diff-utils-parent/4.12",
+    "dest-filename": "java-diff-utils-parent-4.12.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar",
+    "sha512": "df950eaccfc24641ba7957e42e0bd54024bafe07450cfed8404b8e9efb00931bb96b2518c582310f98508ac550c34d38cde49a220fc9d743bbc52d0fd25feb53",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/java-diff-utils/java-diff-utils/4.12",
+    "dest-filename": "java-diff-utils-4.12.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.pom",
+    "sha512": "4e3f08b0636b7a6c499f91408561dd30403ba94e2fc6c1e11678b2d138991414e6ccdcfc5e110a95700a8e2e5eaa9a656a6af692ba4187e604274edd9964e4e3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/java-diff-utils/java-diff-utils/4.12",
+    "dest-filename": "java-diff-utils-4.12.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/jwharm/cairobindings/cairo/1.18.4.2/cairo-1.18.4.2.jar",
+    "sha512": "b9ede971f04608ee34c2e9fb8cbab71a79e2fc46feaab2d48c71fc36ed14e2f83d2ffaabf05f5ae9e9cedb616cde4437fc15898708fdb384dab374f98049cd14",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/jwharm/cairobindings/cairo/1.18.4.2",
+    "dest-filename": "cairo-1.18.4.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/jwharm/cairobindings/cairo/1.18.4.2/cairo-1.18.4.2.module",
+    "sha512": "ea15a91e2267067c75779237380313e3e3a470715b740c76560e0dedc27744983500358063b4a6e4220fa8dabdff3fa29ea82ccf812e1e5e288177ad1593ad0c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/jwharm/cairobindings/cairo/1.18.4.2",
+    "dest-filename": "cairo-1.18.4.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/jwharm/cairobindings/cairo/1.18.4.2/cairo-1.18.4.2.pom",
+    "sha512": "eaaa9a9bd7a390611217f93a1e99e222e6ed1e6b869a2e561261d733c7e355882dfbd60917eafb5ec3f4ee080f953a64b8ec0a2f222ef995bb65b32fd18574d3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/jwharm/cairobindings/cairo/1.18.4.2",
+    "dest-filename": "cairo-1.18.4.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/jwharm/flatpak-gradle-generator/io.github.jwharm.flatpak-gradle-generator.gradle.plugin/1.6.0/io.github.jwharm.flatpak-gradle-generator.gradle.plugin-1.6.0.pom",
+    "sha512": "fbe6480fc584f081469ca53936edaae0597f91e973c761b3a51332c3f89486c27c7c37b7c6493846b072ce5b38d78daa7a64c0b2da1da02ef3b43678cd2c74cc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/jwharm/flatpak-gradle-generator/io.github.jwharm.flatpak-gradle-generator.gradle.plugin/1.6.0",
+    "dest-filename": "io.github.jwharm.flatpak-gradle-generator.gradle.plugin-1.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/jwharm/flatpak-gradle-generator/plugin/1.6.0/plugin-1.6.0.jar",
+    "sha512": "a3ea69f67a305030a02f5818a5349753522a382fe36bc22140ac7b63998c14bdb211810b43859e91be0203723490a5de2c1f5e968f696019ec5a31e92d42843e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/jwharm/flatpak-gradle-generator/plugin/1.6.0",
+    "dest-filename": "plugin-1.6.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/jwharm/flatpak-gradle-generator/plugin/1.6.0/plugin-1.6.0.module",
+    "sha512": "aa1756741388b43d5d07bd65934b1cbbb746085bc4df8f98c506f2d5bc367276fd4b0c01e51540d981a5be37715f5ae3d64dcc29b9157b602f59bd929560d1ec",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/jwharm/flatpak-gradle-generator/plugin/1.6.0",
+    "dest-filename": "plugin-1.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/jwharm/flatpak-gradle-generator/plugin/1.6.0/plugin-1.6.0.pom",
+    "sha512": "3149ff19058093c6665f5d0d5f36ca174250a5cad22a38710502071cfaa7520645dc00546e3b5190437c496ddb630d13815477934221ac7672e65a5b60ad8f6b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/jwharm/flatpak-gradle-generator/plugin/1.6.0",
+    "dest-filename": "plugin-1.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/grpc/grpc-api/1.70.0/grpc-api-1.70.0.jar",
+    "sha512": "011e0ce3870ade374954e5818f3a03ab22bd19fbbf171d2873bdf1ecdbdefae183a512043f9155aa120dce3e1c902680372b18c3dcf1bb64ae508ecfa7631677",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/grpc/grpc-api/1.70.0",
+    "dest-filename": "grpc-api-1.70.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/grpc/grpc-api/1.70.0/grpc-api-1.70.0.pom",
+    "sha512": "7fc13aacac59fe2fa298807055f796fa52e659f4db41334ec7b2dd1091d2ad3f57a8234155bdb785daa997093994fa0de348bc796de8b8ae41c2bef7872eb6e3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/grpc/grpc-api/1.70.0",
+    "dest-filename": "grpc-api-1.70.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/grpc/grpc-context/1.70.0/grpc-context-1.70.0.jar",
+    "sha512": "430cd53a07173fcfe8ac65d0b6f682a30eb7a50df9c33850a39dd2d48a159e63afec1e430471aeeb00c9c88e2354d4d5c456e451309ef5640c91a73def197fb7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/grpc/grpc-context/1.70.0",
+    "dest-filename": "grpc-context-1.70.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/grpc/grpc-context/1.70.0/grpc-context-1.70.0.pom",
+    "sha512": "27e9abc7de5cfb5fc6d70bc038e4adf281ad8a35c2625d5ed4f1f47f448cf389cbfb1248f8db053b57da1305c091c833fba48c26fd531665bf1905ec2560313f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/grpc/grpc-context/1.70.0",
+    "dest-filename": "grpc-context-1.70.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-cio-jvm/3.4.0/ktor-client-cio-jvm-3.4.0.jar",
+    "sha512": "bcc2537a2d7a9be7cf39fe84e0a47a45b49d1e22dc8b0810039b97c8a6cea77585c5b9d723901beaff64bc59ee214f9f65fa5310d35deed3aa0f68db2930e093",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-cio-jvm/3.4.0",
+    "dest-filename": "ktor-client-cio-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-cio-jvm/3.4.0/ktor-client-cio-jvm-3.4.0.module",
+    "sha512": "ca998f3d21c11b0e3af8bac46ff8c3e32d88d75d2d1fcd2590ee79fc86c4c017dbc94e99eb3c746cab9754c5560641ec33ae3febe09ff51c13f271968fa21cbc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-cio-jvm/3.4.0",
+    "dest-filename": "ktor-client-cio-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-cio-jvm/3.4.0/ktor-client-cio-jvm-3.4.0.pom",
+    "sha512": "1807de9887750e59e5a1287713191c65ea1710739fc14f77fd801b9c6522618e267eabaeae4bbe701193cb8a4a46c9d94901a6978f981b8ef9cd74de05b5894c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-cio-jvm/3.4.0",
+    "dest-filename": "ktor-client-cio-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-cio/3.4.0/../../ktor-client-cio-jvm/3.4.0/ktor-client-cio-jvm-3.4.0.module",
+    "sha512": "ca998f3d21c11b0e3af8bac46ff8c3e32d88d75d2d1fcd2590ee79fc86c4c017dbc94e99eb3c746cab9754c5560641ec33ae3febe09ff51c13f271968fa21cbc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-cio/3.4.0/../../ktor-client-cio-jvm/3.4.0",
+    "dest-filename": "ktor-client-cio-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-cio/3.4.0/ktor-client-cio-3.4.0.module",
+    "sha512": "8636ed10df53caf2f69d2f807bf6a4decefe384769a765ff16f9d2e6d4977ea0cb36e8e3dd1d33afd4ceabf413fd88b31858b477246156aa6524df89ecfcbbac",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-cio/3.4.0",
+    "dest-filename": "ktor-client-cio-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-cio/3.4.0/ktor-client-cio-3.4.0.pom",
+    "sha512": "3986a365f255093fd3e9738cb2fdc2ee4358f2f49d9e57c64e2e6f8f61133130a0bc629d94f67b68d149a516d9bee4a390f69077479589f4a0f9a338a100b8f0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-cio/3.4.0",
+    "dest-filename": "ktor-client-cio-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-core-jvm/3.4.0/ktor-client-core-jvm-3.4.0.jar",
+    "sha512": "93127c846b605117238ab3cfa1786c69a0d4233e817c76270e3001db4a6c4a28c4561186af21bf2b181e56d4cf4f7d7c0334cf9eddcd3d6371a657b5d645d0c2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-core-jvm/3.4.0",
+    "dest-filename": "ktor-client-core-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-core-jvm/3.4.0/ktor-client-core-jvm-3.4.0.module",
+    "sha512": "454fc0c777d851164dc055cf8a0ea91dd56adf87015e9702484ede7dbc7b260df2ad7d2a050e529551b2cb4f835bac9e8185ddb8572a290833a283ce732952e2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-core-jvm/3.4.0",
+    "dest-filename": "ktor-client-core-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-core-jvm/3.4.0/ktor-client-core-jvm-3.4.0.pom",
+    "sha512": "d4d505410728910c8a19b0d915d266fde7848e8f5beb6b951971ba0a184178c3d12d441f110cfadf3e86f766adaf4bc6f8b84d2518aaced0a0c11ae4ebb0974d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-core-jvm/3.4.0",
+    "dest-filename": "ktor-client-core-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-core/3.4.0/../../ktor-client-core-jvm/3.4.0/ktor-client-core-jvm-3.4.0.module",
+    "sha512": "454fc0c777d851164dc055cf8a0ea91dd56adf87015e9702484ede7dbc7b260df2ad7d2a050e529551b2cb4f835bac9e8185ddb8572a290833a283ce732952e2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-core/3.4.0/../../ktor-client-core-jvm/3.4.0",
+    "dest-filename": "ktor-client-core-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-core/3.4.0/ktor-client-core-3.4.0.module",
+    "sha512": "4ca0ac613a363bda093e082a69443e677ba655503d0f81302ef254659ae286ace0d8169ae1b620f32b2b50b0dd2c71f2409137ee2b3cce41847342e803fa161e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-core/3.4.0",
+    "dest-filename": "ktor-client-core-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-core/3.4.0/ktor-client-core-3.4.0.pom",
+    "sha512": "514ca419c3901a77fdd265525fd8739a5be97af626cb4a3a721a07a2456be3d23c9b0e30f03602ce0cd951d1764143895d294274942616ad9006ae4001889fff",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-core/3.4.0",
+    "dest-filename": "ktor-client-core-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-events-jvm/3.4.0/ktor-events-jvm-3.4.0.jar",
+    "sha512": "33864efe33f3c6f91d8d2f0c1dd48c5c5bf491505ae38a3f59a7e891c1dd48c28b30fe6e0d11f5fc2702ca0833eebbbcd467d6fecff1f6cda2cb32c1e33fd3d4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-events-jvm/3.4.0",
+    "dest-filename": "ktor-events-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-events-jvm/3.4.0/ktor-events-jvm-3.4.0.module",
+    "sha512": "6511e76da8c31517298cf665f49785e29a03d70ba00a5d4ee62fc914beb7576fe092cd95b4b6ef8f3970e4c1e342bdf6cd80110af618afd698e7e2193668c29a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-events-jvm/3.4.0",
+    "dest-filename": "ktor-events-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-events-jvm/3.4.0/ktor-events-jvm-3.4.0.pom",
+    "sha512": "2eb12963f0473c9dde6b06c07494ef50557c559a563c45c88e2c22ed65447655a98f06e94da0ee39328810e90dd267d13e1994ac13587f7498fe5de1e71b2c20",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-events-jvm/3.4.0",
+    "dest-filename": "ktor-events-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-events/3.4.0/../../ktor-events-jvm/3.4.0/ktor-events-jvm-3.4.0.module",
+    "sha512": "6511e76da8c31517298cf665f49785e29a03d70ba00a5d4ee62fc914beb7576fe092cd95b4b6ef8f3970e4c1e342bdf6cd80110af618afd698e7e2193668c29a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-events/3.4.0/../../ktor-events-jvm/3.4.0",
+    "dest-filename": "ktor-events-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-events/3.4.0/ktor-events-3.4.0.module",
+    "sha512": "233c614a4124355b4aeb49eb5d931a3739e76bc5cd52a4381bda6080fcff96221f3629a5e31cc58d4bdb69a2f24cb67fb1373f30d48abf70ec56a049c640e461",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-events/3.4.0",
+    "dest-filename": "ktor-events-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-events/3.4.0/ktor-events-3.4.0.pom",
+    "sha512": "51cd3d52e98e430bbb5f9a7ade3e0d9c21e68ef262c14debc67c3c90c31216058d7462f58d5d5bc40ede4102ea107117359650a565e14c9525f7bb9c4ee99f0f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-events/3.4.0",
+    "dest-filename": "ktor-events-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-cio-jvm/3.4.0/ktor-http-cio-jvm-3.4.0.jar",
+    "sha512": "e0f008ac63ae08ad2b1f11b4a6f5ef11fc6e2f47cd0bf01669c2ba299ff45894bcecd5fe8203b68aec3fe0d94d799d939afbeb11cf172096ecdc8229b32d4f46",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-cio-jvm/3.4.0",
+    "dest-filename": "ktor-http-cio-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-cio-jvm/3.4.0/ktor-http-cio-jvm-3.4.0.module",
+    "sha512": "907c05600c54c5a2a9ecc982466dcbf39d1d153f9681e4fa0102a7fd5723e1598086015fd2f91fcb81aa9332771664b2ca535666381a741e53f8e8cd686fe9f0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-cio-jvm/3.4.0",
+    "dest-filename": "ktor-http-cio-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-cio-jvm/3.4.0/ktor-http-cio-jvm-3.4.0.pom",
+    "sha512": "6569892c75edda0dff2f3b97116c9daaa172230f46b6e43aa0ab914e93de2e1055cb1955fa38b695303fca15655eeb94f4c56ee36d1558509fc34f0117a03d2e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-cio-jvm/3.4.0",
+    "dest-filename": "ktor-http-cio-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-cio/3.4.0/../../ktor-http-cio-jvm/3.4.0/ktor-http-cio-jvm-3.4.0.module",
+    "sha512": "907c05600c54c5a2a9ecc982466dcbf39d1d153f9681e4fa0102a7fd5723e1598086015fd2f91fcb81aa9332771664b2ca535666381a741e53f8e8cd686fe9f0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-cio/3.4.0/../../ktor-http-cio-jvm/3.4.0",
+    "dest-filename": "ktor-http-cio-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-cio/3.4.0/ktor-http-cio-3.4.0.module",
+    "sha512": "c6c26925584c49f2f40c4d884afa6f280eb8e2c3155a06b20f4f7ff5b00fbaee7615550a21ca9ef887b0cfefcccd5c12451b73658736a35497615a77135dcb25",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-cio/3.4.0",
+    "dest-filename": "ktor-http-cio-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-cio/3.4.0/ktor-http-cio-3.4.0.pom",
+    "sha512": "5406516493e1f9012df5a58de1ec67b10ca5044a35a21360a3ef447f14bae628bda6cb3eac8592d69ef95d082cdcc57916a60d0e176afa93df16e1493e371d90",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-cio/3.4.0",
+    "dest-filename": "ktor-http-cio-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-jvm/3.4.0/ktor-http-jvm-3.4.0.jar",
+    "sha512": "86002ecc21b98677f3926a0b6361216cbe5a77f605531280985805d95f3964766be5ffd2c2b8c7db53ffe2acd50f1136cb271f4416ad0dcda5e487c2b7b551d8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-jvm/3.4.0",
+    "dest-filename": "ktor-http-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-jvm/3.4.0/ktor-http-jvm-3.4.0.module",
+    "sha512": "c0d5ee8e6e90e44d492487605b998c22f03f9c4cf12c7b8e10808001852de7141ba482a511f4a0827a5fb5b780d0bf2f6e4301dfbf26d2887de0c348700e2293",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-jvm/3.4.0",
+    "dest-filename": "ktor-http-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-jvm/3.4.0/ktor-http-jvm-3.4.0.pom",
+    "sha512": "57ddb41e0961edaa57800163d6245fd40df429a91c7e0ca1b8ec1bb9b94b3da53cdfeae2016a75cf3062fa396a1c7af9aa02bb103aa4181515d276c96f1ac9af",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-jvm/3.4.0",
+    "dest-filename": "ktor-http-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http/3.4.0/../../ktor-http-jvm/3.4.0/ktor-http-jvm-3.4.0.module",
+    "sha512": "c0d5ee8e6e90e44d492487605b998c22f03f9c4cf12c7b8e10808001852de7141ba482a511f4a0827a5fb5b780d0bf2f6e4301dfbf26d2887de0c348700e2293",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http/3.4.0/../../ktor-http-jvm/3.4.0",
+    "dest-filename": "ktor-http-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http/3.4.0/ktor-http-3.4.0.module",
+    "sha512": "9828795873d6581ca747d50166eb328d0bbae339a8cf70d18650f919a83eda78a8597a3b834b2e1b65a082637ccd881dbcada0eaed6fef81c2832c0fa30e6948",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http/3.4.0",
+    "dest-filename": "ktor-http-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http/3.4.0/ktor-http-3.4.0.pom",
+    "sha512": "67dee2380feaada6a07aa6432745c0005367776fb1ab0b0cb425dbe9519b7667caeb3c142184ea01598e03fdde9ae66518631f17a16db6ba1667b5448d6b03c6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http/3.4.0",
+    "dest-filename": "ktor-http-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-io-jvm/3.4.0/ktor-io-jvm-3.4.0.jar",
+    "sha512": "493b6339009e27d63be548b834e5f8adbcad59876feb1b5551600c333d2fbe834cc512da2ea34643dcff756d331b0bacf7dc00e673630eefe436a444d84f2007",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-io-jvm/3.4.0",
+    "dest-filename": "ktor-io-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-io-jvm/3.4.0/ktor-io-jvm-3.4.0.module",
+    "sha512": "7ad34833659bab526659ec0cb10f3b7a3e6cb957ce3e74d8c4935c133df7cd5de5ef2ff906c606cf345908d20f5dae2b1cf24165eadaeaf3e9eaa6cb10dd381a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-io-jvm/3.4.0",
+    "dest-filename": "ktor-io-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-io-jvm/3.4.0/ktor-io-jvm-3.4.0.pom",
+    "sha512": "bf66bf42736a0d1bf50087fdd02eb0ed2e77eb462a3590cb50d6206ccc86a5476f8e556df71f4d19796f558512fc88caff8a025705b5811b3fbf083ea2b31219",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-io-jvm/3.4.0",
+    "dest-filename": "ktor-io-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-io/3.4.0/../../ktor-io-jvm/3.4.0/ktor-io-jvm-3.4.0.module",
+    "sha512": "7ad34833659bab526659ec0cb10f3b7a3e6cb957ce3e74d8c4935c133df7cd5de5ef2ff906c606cf345908d20f5dae2b1cf24165eadaeaf3e9eaa6cb10dd381a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-io/3.4.0/../../ktor-io-jvm/3.4.0",
+    "dest-filename": "ktor-io-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-io/3.4.0/ktor-io-3.4.0.module",
+    "sha512": "72aad672cf73ad92324de5b6e2d923fe143ddd160ee8fe3de7a515eca1f93d2f0202896b10412835c9cc976a81e59f278765e6d3b4f0aa1d6115358bc9eedc19",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-io/3.4.0",
+    "dest-filename": "ktor-io-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-io/3.4.0/ktor-io-3.4.0.pom",
+    "sha512": "69361b1b2f6e74e9d0a87f552a6a605b117f88a4735d5b18266c88e96d10951111ea8afcc385612ba51156f8d1b89ebdae20a193f84660219244c16e065fde04",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-io/3.4.0",
+    "dest-filename": "ktor-io-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-jvm/3.4.0/ktor-network-jvm-3.4.0.jar",
+    "sha512": "4bddc6d36b5bed26f6182a21634bed70a64c5ddfec6d46c8f9ee921baafa6ea3dc3590e31c05a50813b3d1588b1e826ead91c6bc1fcad9415d1322c30a5ef7f7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-jvm/3.4.0",
+    "dest-filename": "ktor-network-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-jvm/3.4.0/ktor-network-jvm-3.4.0.module",
+    "sha512": "7a0d5a8e0413e5bda278741cfe69e0af910ff2fdc58dfafbda567734b47a39f03d6de0e59112d7113a8cea1edd1fdce33109aa0e5d99b3820ba7f3a1d5bb13e7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-jvm/3.4.0",
+    "dest-filename": "ktor-network-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-jvm/3.4.0/ktor-network-jvm-3.4.0.pom",
+    "sha512": "fa5908c584671f65303e14cd4b9718515d8672f9d37973bc94befe4840bb9e20b04a61ee9e0b4a3aca5e99d59600e900d4c398796da2fdd35310d32c8cb08cd7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-jvm/3.4.0",
+    "dest-filename": "ktor-network-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-tls-jvm/3.4.0/ktor-network-tls-jvm-3.4.0.jar",
+    "sha512": "3ffd2dcc1400f4147209b3526d5a1da75cd8c14a3e81236615973ff4beecd5ca8e581186ba1384d950c937315cf9601ee7b8e5b6be84adcf3620544a559950d1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-tls-jvm/3.4.0",
+    "dest-filename": "ktor-network-tls-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-tls-jvm/3.4.0/ktor-network-tls-jvm-3.4.0.module",
+    "sha512": "5db670ac72a543694a2e759ecc962a1d1520d203c6884092af9c7e27dd84201a0115f8e4de77e22768a509822c136655e6f5941291db307651d66e0eb7522cef",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-tls-jvm/3.4.0",
+    "dest-filename": "ktor-network-tls-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-tls-jvm/3.4.0/ktor-network-tls-jvm-3.4.0.pom",
+    "sha512": "de1ef605fda675576d93113cc0c36c87f95f0736b83c0c576ef349c2ade07973ca68b12ad825dabf5b9b26d3e99461495342d54fb795340c6d30a01f53833c38",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-tls-jvm/3.4.0",
+    "dest-filename": "ktor-network-tls-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-tls/3.4.0/../../ktor-network-tls-jvm/3.4.0/ktor-network-tls-jvm-3.4.0.module",
+    "sha512": "5db670ac72a543694a2e759ecc962a1d1520d203c6884092af9c7e27dd84201a0115f8e4de77e22768a509822c136655e6f5941291db307651d66e0eb7522cef",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-tls/3.4.0/../../ktor-network-tls-jvm/3.4.0",
+    "dest-filename": "ktor-network-tls-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-tls/3.4.0/ktor-network-tls-3.4.0.module",
+    "sha512": "e1af93ba29162c476b712e768edc5fc73315228c210bc25c95120070e0e558883c7547c72a0d480fbda81b63d66f41c1c05341448bf8aab4d716da7dab8360d9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-tls/3.4.0",
+    "dest-filename": "ktor-network-tls-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-tls/3.4.0/ktor-network-tls-3.4.0.pom",
+    "sha512": "c0a529b0a5e42570ae6b03ee8662e3c2d222206587592ef91fda296a508f0977afa86467b6f2214398ca9290b47071ee8015a754e5d0338a486adc25d756d606",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-tls/3.4.0",
+    "dest-filename": "ktor-network-tls-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network/3.4.0/../../ktor-network-jvm/3.4.0/ktor-network-jvm-3.4.0.module",
+    "sha512": "7a0d5a8e0413e5bda278741cfe69e0af910ff2fdc58dfafbda567734b47a39f03d6de0e59112d7113a8cea1edd1fdce33109aa0e5d99b3820ba7f3a1d5bb13e7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network/3.4.0/../../ktor-network-jvm/3.4.0",
+    "dest-filename": "ktor-network-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network/3.4.0/ktor-network-3.4.0.module",
+    "sha512": "d8818ab270760a5fff352e269f21265d9bca90f59c1d9620fc828c4332dcade0458b93f8e73612de211acd4f24f49e9f1d514d6890cb3dc0d8b6a64c72b4e7c0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network/3.4.0",
+    "dest-filename": "ktor-network-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network/3.4.0/ktor-network-3.4.0.pom",
+    "sha512": "15c8a0b53c21ae39c8c53eb1c6c3a4322014db80f7eb88f6534d67e7babb8ac1ae61297178f319963259ddb157d57d2561d8f57358fd2e996e0ab0479d5b4c21",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network/3.4.0",
+    "dest-filename": "ktor-network-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-serialization-jvm/3.4.0/ktor-serialization-jvm-3.4.0.jar",
+    "sha512": "2835cf8f605f89cfdac308dc775998a6c82a1291bdb5aaa74ca4da91b08b4bf5ac43f11e4c586a2cc74a7e4202760be842e50ebc24acca485ed1cb11a495a077",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-serialization-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-serialization-jvm/3.4.0/ktor-serialization-jvm-3.4.0.module",
+    "sha512": "d690d301b2db9e32a16490661d27c08d6c7dbc563ee0f49398f481fdf889e3adf0d1114f845722dca79dfc2e5baff0dbff808c2159a1e718e161a090cd2cb5b4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-serialization-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-serialization-jvm/3.4.0/ktor-serialization-jvm-3.4.0.pom",
+    "sha512": "587d2eada3cc8f0fddbfcb476d53e78392607e525c9d325d55a21aff632ff5c7d31bd760a6d8d9b2cb3e7c08ca661171a208bc1fd994b61d7dc5d58f48fe51d5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-serialization-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-serialization/3.4.0/../../ktor-serialization-jvm/3.4.0/ktor-serialization-jvm-3.4.0.module",
+    "sha512": "d690d301b2db9e32a16490661d27c08d6c7dbc563ee0f49398f481fdf889e3adf0d1114f845722dca79dfc2e5baff0dbff808c2159a1e718e161a090cd2cb5b4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-serialization/3.4.0/../../ktor-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-serialization-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-serialization/3.4.0/ktor-serialization-3.4.0.module",
+    "sha512": "d97157b0b0d0d28908b8273f93fa62cbbbec09c115a2fdfec1c9d98437b07190c8b6c1bf70b95378b14947a1463334d47af33369691abe277f9ca5dc98990784",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-serialization/3.4.0",
+    "dest-filename": "ktor-serialization-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-serialization/3.4.0/ktor-serialization-3.4.0.pom",
+    "sha512": "0a69b4110c4248f49a8f10e2eda97051b66d044bc8289ee8531e85b6015bc62aa301de6480a2c44bddc769b80ccca886568b8f4f12bedd8e6e2ee377f48a545c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-serialization/3.4.0",
+    "dest-filename": "ktor-serialization-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-sse-jvm/3.4.0/ktor-sse-jvm-3.4.0.jar",
+    "sha512": "70c8873934e6567d26d38b0dcea32bd39ec7d0f2088df168f1bb5b159956ec1d8e43f775c4987e8042062b1826324bf9da86f458debc62cc49897e878c1675d6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-sse-jvm/3.4.0",
+    "dest-filename": "ktor-sse-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-sse-jvm/3.4.0/ktor-sse-jvm-3.4.0.module",
+    "sha512": "c6f4e5a313b521d71edbc7c61abe823370d4df606e7fa07b92aa5409e5ada2ae5ae9737a0df85919f4e1d6a7c25e9855c2818474b79818fe200796a5a28e553b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-sse-jvm/3.4.0",
+    "dest-filename": "ktor-sse-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-sse-jvm/3.4.0/ktor-sse-jvm-3.4.0.pom",
+    "sha512": "1e336075c24c6093e629d7e5ddf8ab30647f2fe596c84885a3d205487809049de00d4069575e84a4f0fb5241e1a4bf337c788e11589388caa287c22b08da9719",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-sse-jvm/3.4.0",
+    "dest-filename": "ktor-sse-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-sse/3.4.0/../../ktor-sse-jvm/3.4.0/ktor-sse-jvm-3.4.0.module",
+    "sha512": "c6f4e5a313b521d71edbc7c61abe823370d4df606e7fa07b92aa5409e5ada2ae5ae9737a0df85919f4e1d6a7c25e9855c2818474b79818fe200796a5a28e553b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-sse/3.4.0/../../ktor-sse-jvm/3.4.0",
+    "dest-filename": "ktor-sse-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-sse/3.4.0/ktor-sse-3.4.0.module",
+    "sha512": "03be1cc20473ae761d68d9bede830792d4bfc7c64a72572b494eb9aa251dd891ce4dd982702be71e89538a57f6b551dec2ec82303fd8519337c9378205bc21fa",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-sse/3.4.0",
+    "dest-filename": "ktor-sse-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-sse/3.4.0/ktor-sse-3.4.0.pom",
+    "sha512": "f3414006401f12c9209d69457406d074bf557f28750dbeed3e2fc499fe12b1527a0fe61a37b70677887b9e837391acba2b361b56e389761ea50e07eba3c5cd7c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-sse/3.4.0",
+    "dest-filename": "ktor-sse-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-utils-jvm/3.4.0/ktor-utils-jvm-3.4.0.jar",
+    "sha512": "167a52204a8008cfad13b0483b42660bff1802e8990e63f63c22d1f6372b63b8955c6c947b7222d7e12eb6fb371221f2bf2fa17c34249bee5535d7290cc487c7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-utils-jvm/3.4.0",
+    "dest-filename": "ktor-utils-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-utils-jvm/3.4.0/ktor-utils-jvm-3.4.0.module",
+    "sha512": "6e73198e9e9329ae35f711196d8c0606e1819a011f6b83a2f505e407411e9c2c434e4d1a524e410b47ff33d41627086323b99ce7628bba0b2020e3c2549d8d41",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-utils-jvm/3.4.0",
+    "dest-filename": "ktor-utils-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-utils-jvm/3.4.0/ktor-utils-jvm-3.4.0.pom",
+    "sha512": "aee39cafff63c4252648e39d0694a38892fae1b31b84db1756bf39ddb8de4a84b428b54f8d77813851fdc1761b7f2441fafe678f1c80b713e40f3aa763842dee",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-utils-jvm/3.4.0",
+    "dest-filename": "ktor-utils-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-utils/3.4.0/../../ktor-utils-jvm/3.4.0/ktor-utils-jvm-3.4.0.module",
+    "sha512": "6e73198e9e9329ae35f711196d8c0606e1819a011f6b83a2f505e407411e9c2c434e4d1a524e410b47ff33d41627086323b99ce7628bba0b2020e3c2549d8d41",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-utils/3.4.0/../../ktor-utils-jvm/3.4.0",
+    "dest-filename": "ktor-utils-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-utils/3.4.0/ktor-utils-3.4.0.module",
+    "sha512": "e923bf27ebe2fc08eaefc6d93f11d4c62b9e9407f396fb919573ff2b70cda5d67510eeb25157bb36179b9b45a0cf4d1142c7780120f31b16b429a611f06e7ed2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-utils/3.4.0",
+    "dest-filename": "ktor-utils-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-utils/3.4.0/ktor-utils-3.4.0.pom",
+    "sha512": "55468d197489538c3844a4b6032aaa81bb8d299289efdefaabf128e9d1ff26e72d04a333a6d7312e4447fc231d1c5212f90035d345858ebf688a32963e1475ee",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-utils/3.4.0",
+    "dest-filename": "ktor-utils-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websocket-serialization-jvm/3.4.0/ktor-websocket-serialization-jvm-3.4.0.jar",
+    "sha512": "3e895604a08d959d70a4019b4d96f767be3c8ef6569952039ad5eb5bd90d7f86d288a477e355dc2556ba65cab793ed3946a6db8b71d9f315cc67bcf95330f728",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websocket-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-websocket-serialization-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websocket-serialization-jvm/3.4.0/ktor-websocket-serialization-jvm-3.4.0.module",
+    "sha512": "e94fbe3344b7aa861f843354af88e5235c1fb2ed094eb5280c1d749b66a25ad6e78fb7d0ab84fa05a7eb42bcfc0652d798a8997962ef0a19e5338b4ae0595b3e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websocket-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-websocket-serialization-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websocket-serialization-jvm/3.4.0/ktor-websocket-serialization-jvm-3.4.0.pom",
+    "sha512": "27d1f240459e977fb9c0eb8fcb3882713233753fe4d1c2ae55b69794b8546dd016ca51e78c5fd8a0998e7ae358a0c923369d5c2dbd943c9cbf59ef6dddb2695e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websocket-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-websocket-serialization-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websocket-serialization/3.4.0/../../ktor-websocket-serialization-jvm/3.4.0/ktor-websocket-serialization-jvm-3.4.0.module",
+    "sha512": "e94fbe3344b7aa861f843354af88e5235c1fb2ed094eb5280c1d749b66a25ad6e78fb7d0ab84fa05a7eb42bcfc0652d798a8997962ef0a19e5338b4ae0595b3e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websocket-serialization/3.4.0/../../ktor-websocket-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-websocket-serialization-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websocket-serialization/3.4.0/ktor-websocket-serialization-3.4.0.module",
+    "sha512": "d4c78750c040a2014c8ef5b4b43d710b937febd84861ac584bc3b28955553be07fd86061afb1323576da52382154cadccf5edb96fa5b7810a113d750a17c6f5e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websocket-serialization/3.4.0",
+    "dest-filename": "ktor-websocket-serialization-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websocket-serialization/3.4.0/ktor-websocket-serialization-3.4.0.pom",
+    "sha512": "ca47291ae49f4af6b15afd228caf2c88b7b835a9124f1ee3a8aa67fcf22f28abd2b0e744143f00a4ffd16a67d3645c73edfa51ac476239cdbccf041ee509cb12",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websocket-serialization/3.4.0",
+    "dest-filename": "ktor-websocket-serialization-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websockets-jvm/3.4.0/ktor-websockets-jvm-3.4.0.jar",
+    "sha512": "c5e632d9ed52ac978789dc3add02f05e05676ac9475947ebf917a5115286f1e7fc66b0e3d36f224357209e1cf722f2162f99347f72cfe3cc4a083782656d64a1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websockets-jvm/3.4.0",
+    "dest-filename": "ktor-websockets-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websockets-jvm/3.4.0/ktor-websockets-jvm-3.4.0.module",
+    "sha512": "6eb9c0117c004790629e7e559b4b001a62a6980da182d537c14a652b45a2a1a971e840d09c04b4b1a6eb218e0f8ec99e5fc68b1d2d14437b7b958fbe02e85f09",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websockets-jvm/3.4.0",
+    "dest-filename": "ktor-websockets-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websockets-jvm/3.4.0/ktor-websockets-jvm-3.4.0.pom",
+    "sha512": "8fce88d2f1e8cd471280dad402bb41026ec350923fc3ded7c7afc2a78fd29a73f695f930b8f7c6783867311df28220eb8406cfd064e9ef4368a757f8f605b538",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websockets-jvm/3.4.0",
+    "dest-filename": "ktor-websockets-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websockets/3.4.0/../../ktor-websockets-jvm/3.4.0/ktor-websockets-jvm-3.4.0.module",
+    "sha512": "6eb9c0117c004790629e7e559b4b001a62a6980da182d537c14a652b45a2a1a971e840d09c04b4b1a6eb218e0f8ec99e5fc68b1d2d14437b7b958fbe02e85f09",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websockets/3.4.0/../../ktor-websockets-jvm/3.4.0",
+    "dest-filename": "ktor-websockets-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websockets/3.4.0/ktor-websockets-3.4.0.module",
+    "sha512": "c3fbc677a5920245d6a1d4760d7d6c6f749ca9e2081127543260d230d260c15a341d302d0518170a1fa0804ace90b102f98ff12106868e3944bb74d6d37c8998",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websockets/3.4.0",
+    "dest-filename": "ktor-websockets-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websockets/3.4.0/ktor-websockets-3.4.0.pom",
+    "sha512": "abf96a01db520b9db71b7223ce4d0e9f1acc9ea0c5506c7abbb5481e129b6d901de46941e9672de7f14d8dfa64840ce9b0046fafad90f8669204f52bb91e268b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websockets/3.4.0",
+    "dest-filename": "ktor-websockets-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/opencensus/opencensus-api/0.31.1/opencensus-api-0.31.1.jar",
+    "sha512": "aac98ed2de298609bac9cb5a69ac16df0ca9c9fc82f429720ddcfdd769fdae96b707ed81c8d8c37380de846b302aacaac80156ef75567061aed3f77cc3c3b725",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/opencensus/opencensus-api/0.31.1",
+    "dest-filename": "opencensus-api-0.31.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/opencensus/opencensus-api/0.31.1/opencensus-api-0.31.1.pom",
+    "sha512": "d1a4b97808f714e15aa21dd64292797b8bb02227dd3699d47a3738436c682808658445a602235c0aa964acb4b9461c85b4634171552d0efea683beea61173099",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/opencensus/opencensus-api/0.31.1",
+    "dest-filename": "opencensus-api-0.31.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/opencensus/opencensus-contrib-http-util/0.31.1/opencensus-contrib-http-util-0.31.1.jar",
+    "sha512": "3192532e4989a26d9a69f4246ef994b35058d155e199b500196d14427d1b46b1515f872a36500cb84768524870297388c90272ffa61dc8448f6f7571c4f86b27",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/opencensus/opencensus-contrib-http-util/0.31.1",
+    "dest-filename": "opencensus-contrib-http-util-0.31.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/opencensus/opencensus-contrib-http-util/0.31.1/opencensus-contrib-http-util-0.31.1.pom",
+    "sha512": "1c844455a2555327c106dc16f9bcf0c467473764e20408eae9c1d0493a9cc735d6116d28c90df63f3028b750607d0254e650fbcc4fa359157b7fec56ce79a456",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/opencensus/opencensus-contrib-http-util/0.31.1",
+    "dest-filename": "opencensus-contrib-http-util-0.31.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/swagger/core/v3/swagger-annotations/2.2.31/swagger-annotations-2.2.31.jar",
+    "sha512": "950abb3943cc5207824e167bf6e71205115773b84522d35c5da9e349d6ba107b20fc98e4ae13894567bdbee36e887c5877cc74619399fbcbb127a1e65ed6ec7f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/swagger/core/v3/swagger-annotations/2.2.31",
+    "dest-filename": "swagger-annotations-2.2.31.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/swagger/core/v3/swagger-annotations/2.2.31/swagger-annotations-2.2.31.pom",
+    "sha512": "3170e9c848dd983b03085c0f4563f97a56e95557ad8c1275961267dd481784f077a55f03efc4e1b2c708fe1d95b642680f76098b3cccaec9698da60f4c8b83b1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/swagger/core/v3/swagger-annotations/2.2.31",
+    "dest-filename": "swagger-annotations-2.2.31.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/swagger/core/v3/swagger-project/2.2.31/swagger-project-2.2.31.pom",
+    "sha512": "9d900076540bd9bb18758ee4169ad41d43c8311a7511ace95200384f1170db4cf7791c8b3d3d9a40920c23ab6a97883a78e6382aa1b8a66580221010f64a89d0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/swagger/core/v3/swagger-project/2.2.31",
+    "dest-filename": "swagger-project-2.2.31.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/jakarta/platform/jakarta.jakartaee-bom/9.1.0/jakarta.jakartaee-bom-9.1.0.pom",
+    "sha512": "7938ebe765028f8f231df08fa1e52550034d0b9278760c3b374b5ca21740fe90e2c8ff889c08a091575fe088d8f516d7510484359ea94c3e9ed23f5586567f5b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/jakarta/platform/jakarta.jakartaee-bom/9.1.0",
+    "dest-filename": "jakarta.jakartaee-bom-9.1.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/jakarta/platform/jakartaee-api-parent/9.1.0/jakartaee-api-parent-9.1.0.pom",
+    "sha512": "358a9b92ae14c9c8b2480a1d90675efacc7a9abb3ebde5fa15f2a114d860b7be9842dd70798721383158d6633e75e3b5c37f9555a58be5b6e4ecdf57838cbd43",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/jakarta/platform/jakartaee-api-parent/9.1.0",
+    "dest-filename": "jakartaee-api-parent-9.1.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar",
+    "sha512": "679cf44c3b9d635b43ed122a555d570292c3f0937c33871c40438a1a53e2058c80578694ec9466eac9e280e19bfb7a95b261594cc4c1161c85dc97df6235e553",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/javax/annotation/javax.annotation-api/1.3.2",
+    "dest-filename": "javax.annotation-api-1.3.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.pom",
+    "sha512": "b97c6fb3b5c6f9ba5c6ec2aa35713816fca94927c1393d2eaa04cac6a6c44c464baeb34d62d9af33268a7eaa817318df1b2116641ff7e8ade84c70b358e60bac",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/javax/annotation/javax.annotation-api/1.3.2",
+    "dest-filename": "javax.annotation-api-1.3.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/net/bytebuddy/byte-buddy/1.14.13/byte-buddy-1.14.13.pom",
+    "sha512": "4010b96f40fe4b8caec63b9011caeb90bb9853e28f3dbe10591cbe2deb003de43fb003802180e2646bb0f1c25ff8db8f3cfba8936cc3a3afd4bc7163c1b830fd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/net/bytebuddy/byte-buddy/1.14.13",
+    "dest-filename": "byte-buddy-1.14.13.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/net/java/jvnet-parent/3/jvnet-parent-3.pom",
+    "sha512": "93b78fac40ca4de12d5a2fb4e339ba9e3c40a25ddcfe58272dc2a8e4b36d2c7cc51075aa2a25f0b3c1d4bd3142551e77847d1bd5599c60f5d50d548b72b74bfa",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/net/java/jvnet-parent/3",
+    "dest-filename": "jvnet-parent-3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/ant/ant-launcher/1.10.15/ant-launcher-1.10.15.jar",
+    "sha512": "6fc2b33cde07493704c201b759e6813ba5f60ffd3925a52bb097a7fffedbc950bcc4fbc93fe0a86ec2a41872b16b92868b6be87632d3e8e0dc89a5b4143ccb9e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/ant/ant-launcher/1.10.15",
+    "dest-filename": "ant-launcher-1.10.15.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/ant/ant-launcher/1.10.15/ant-launcher-1.10.15.pom",
+    "sha512": "1339d7d49178a5f78cc4dddcb6cdb4a49743a140a9bc12d7fc97f35767c2448d0cfd133288c54bec660491360660c7412a681d5adf800958757975709b735190",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/ant/ant-launcher/1.10.15",
+    "dest-filename": "ant-launcher-1.10.15.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/ant/ant-parent/1.10.15/ant-parent-1.10.15.pom",
+    "sha512": "a3deb6753ae42920c3cde18dda5a96b8fec3263c1a8e8e65a2f5f53410120fcae39db9b9962fbe7bc39f16658b6c57435d13dde4f50b36357e5a95f19be4ef26",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/ant/ant-parent/1.10.15",
+    "dest-filename": "ant-parent-1.10.15.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/ant/ant/1.10.15/ant-1.10.15.jar",
+    "sha512": "d5109838090a4463098c4a82c171d07b92d42633010e045388fb8a68744fdcdd2b07a75a9fb56783e83ecbcc80664119ccc44537993125d6724956e114508316",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/ant/ant/1.10.15",
+    "dest-filename": "ant-1.10.15.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/ant/ant/1.10.15/ant-1.10.15.pom",
+    "sha512": "a37e3ae2d032563d810a8f609c1d5d8ec0ae4793cdcf72dd275f89725ea399438b5834342828af77252651ffda0bd2e4f92c90ef2d49013c8ed50eac63c8acd3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/ant/ant/1.10.15",
+    "dest-filename": "ant-1.10.15.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/apache/13/apache-13.pom",
+    "sha512": "3b25f9f51a7ee9647fe2e1287e75a67ccdf3f08055bec20c6a60b290876afc691f16b23ab3df7b733695b828411b716a0b3509c22ec6fb0c5dce4f21811ae434",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/apache/13",
+    "dest-filename": "apache-13.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/apache/21/apache-21.pom",
+    "sha512": "c82bd27c06d76b3f467118b1a8e0976c60fd0e7d7a01dac685c9a91e1822c0e6f5829bf48ad532a9fc000089cdb894a97c5686365fd3c8c8bfa787136a4fa9d2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/apache/21",
+    "dest-filename": "apache-21.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/apache/27/apache-27.pom",
+    "sha512": "35e0254ae70a1b2756e63fde157355a138b0924a7298136135c14092a00e36a7207c46f96c12824f7ce41bf80315594c0c65b832fe9df0a1a4f8b7fd97b59da6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/apache/27",
+    "dest-filename": "apache-27.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/apache/35/apache-35.pom",
+    "sha512": "d599ebf085e96ab2c0fa925fec99fc046f1763743a0445e5a4bf255d8259d44aec7bd175881accf1c6562e13efc26b13a54de01c49b46032464366d41869d7e8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/apache/35",
+    "dest-filename": "apache-35.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-compress/1.28.0/commons-compress-1.28.0.jar",
+    "sha512": "f1f140f4f40ab3cf3265919db9dbb95a631a29aa784e305f291de4e68876bb711d9217d62d7937cddddd393982decdf71a608b4b3ab7f4e6375cf28af2893d7f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-compress/1.28.0",
+    "dest-filename": "commons-compress-1.28.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-compress/1.28.0/commons-compress-1.28.0.pom",
+    "sha512": "8e146052d06e3018b7336a52fbbe979b73e2cd1d318fe9fdb37e22f5ee39e65992351ce5278dc4da34a59256f797882d16b6dee34684742a8a5bfb4f0998d82f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-compress/1.28.0",
+    "dest-filename": "commons-compress-1.28.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar",
+    "sha512": "c2c9d497fc1be411050f4011b2407764b78aa098eb42925af8a197eabdbc25b507f09fb898805e9bed4815f35236a508ee5b096e36f363df4d407232d50fc832",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-lang3/3.18.0",
+    "dest-filename": "commons-lang3-3.18.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.pom",
+    "sha512": "8ea9b9e8605b841f95e856918cd21913e9955e42f5c4c487ba9580252a15163ed910a0aed39720394f2a80813015af99849aa2768254531c1cf75fab22036b00",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-lang3/3.18.0",
+    "dest-filename": "commons-lang3-3.18.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-parent/34/commons-parent-34.pom",
+    "sha512": "364ede203a23157ec601d28ff141c0c69759fc5c483e44e346fa1592403f343f0722f7763243b2ee7a190c7a744b1cce1f40247f5a6c7b3dbfbf487c505a40bf",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-parent/34",
+    "dest-filename": "commons-parent-34.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-parent/85/commons-parent-85.pom",
+    "sha512": "f32482d030a5dbad958d91f7137f9a4cd416a1f60b4701000574222f71e3403363f7863b6c32e19e1d1fc4f752128a6b745888172c188471bc096dc81cd7a337",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-parent/85",
+    "dest-filename": "commons-parent-85.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-parent/91/commons-parent-91.pom",
+    "sha512": "c8bcacfe275a5c628179e44142f5af2c3b00febb2c58c488391a8101f636db8e5af16345bed427f673f99080e15c1a2a8f99a80720ba5e59c386958c1905e0af",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-parent/91",
+    "dest-filename": "commons-parent-91.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/groovy/groovy-bom/4.0.27/groovy-bom-4.0.27.pom",
+    "sha512": "50c3d4108e48058c9a0761c6bde742defedc393df49d110f51208f32b156085309420386d83a4474c31460620d2a44f3cfdcb4387311b9d50af62ac75f61f04f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/groovy/groovy-bom/4.0.27",
+    "dest-filename": "groovy-bom-4.0.27.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/client5/httpclient5-parent/5.3.1/httpclient5-parent-5.3.1.pom",
+    "sha512": "4834f80e0a0520ff783411836f2d768d786d1bc7ea51cc236a63cf6d1a1c14cbae51c8d8dd40e65ab9ef73566932a0c5983b22e5a88448763253d65a5128b900",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/client5/httpclient5-parent/5.3.1",
+    "dest-filename": "httpclient5-parent-5.3.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/client5/httpclient5/5.3.1/httpclient5-5.3.1.jar",
+    "sha512": "4c2d75106af8470789f0e08305e64ad86528f2f737da230e561892d33dbca0b6e2dbced2a075f0744cee7801c06ef174481540661b3c9a1bec6d6f93938b05bc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/client5/httpclient5/5.3.1",
+    "dest-filename": "httpclient5-5.3.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/client5/httpclient5/5.3.1/httpclient5-5.3.1.pom",
+    "sha512": "a94286b39d9d4b86572f139642c11af26681af613124839080073e0370677a3a6561725b468fe1e58c2b80070b8935a8ac9b8291b61fd7e2c1348a994ed508ec",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/client5/httpclient5/5.3.1",
+    "dest-filename": "httpclient5-5.3.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/core5/httpcore5-h2/5.2.4/httpcore5-h2-5.2.4.jar",
+    "sha512": "72fbee55f173c43d9ffc0cc5a83d59e60be1002c06ab81de39ba700cc30b04e84fdfed73d3a8985d561a1aa8ac3ca905f9259d01b431e1ff14da6fae622f787d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/core5/httpcore5-h2/5.2.4",
+    "dest-filename": "httpcore5-h2-5.2.4.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/core5/httpcore5-h2/5.2.4/httpcore5-h2-5.2.4.pom",
+    "sha512": "327396bbdc4ca1594a3283c720b9a8596218750fa46d2b320a9e31420c6d62cbe0b81807526b982dd9216b619ba131c7c0e2bd966c93202089574f5ba9471c57",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/core5/httpcore5-h2/5.2.4",
+    "dest-filename": "httpcore5-h2-5.2.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/core5/httpcore5-parent/5.2.4/httpcore5-parent-5.2.4.pom",
+    "sha512": "36ac113db005ef4c3a9b93cfbf290181f05b8bd2b0df45a05306e66cc7f77f0ab4e7af2bda7f9658fffb207163b94739d686fce47ba5b4c3c1b34df54cbc769f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/core5/httpcore5-parent/5.2.4",
+    "dest-filename": "httpcore5-parent-5.2.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/core5/httpcore5/5.2.4/httpcore5-5.2.4.jar",
+    "sha512": "9fb4134d85e665e15410af005b21cd2f9b5e60d75112945d37b879f96f769a70be034557526ea7d05f8b83dda91c56d00f946763c44a183d7aea2857549b4481",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/core5/httpcore5/5.2.4",
+    "dest-filename": "httpcore5-5.2.4.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/core5/httpcore5/5.2.4/httpcore5-5.2.4.pom",
+    "sha512": "81cd2ba8549b791f9d56f3a5c2ba964bcd4423525774106e2a39420a54d77d3da2087f41f94d51b232b0bb1c1fa52268a483b052252a6b1e43921793c83825f6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/core5/httpcore5/5.2.4",
+    "dest-filename": "httpcore5-5.2.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar",
+    "sha512": "a084ef30fb0a2a25397d8fab439fe68f67e294bf53153e2e1355b8df92886d40fe6abe35dc84f014245f7158e92641bcbd98019b4fbbd9e5a0db495b160b4ced",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpclient/4.5.14",
+    "dest-filename": "httpclient-4.5.14.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.pom",
+    "sha512": "46500859b1206c1ec6a69c66d6b6d224ac835c9316a88403a2060c658b4c4e2a7f69ce0b3b5f1900abf479ebda10757c25ab595de9527b53f9e80abdf48383e8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpclient/4.5.14",
+    "dest-filename": "httpclient-4.5.14.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpcomponents-client/4.5.14/httpcomponents-client-4.5.14.pom",
+    "sha512": "7ae6fe0a7865aa7aeb1e4f3f3694856e0b0c5f7d5e452682e3734b45e433d2001352bea46fc32c1694bd10577b16030f77161a0fdca7c369afc2cc5edf4c55e2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpcomponents-client/4.5.14",
+    "dest-filename": "httpcomponents-client-4.5.14.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpcomponents-core/4.4.16/httpcomponents-core-4.4.16.pom",
+    "sha512": "7bc3e413442010aeaaa9fa6fd11e4c32aea9cd50ad19f485869d469a13886ca70f645169c1130ccac864d73570b8dde21562313ef3f8c031ffaf8500b60e14d3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpcomponents-core/4.4.16",
+    "dest-filename": "httpcomponents-core-4.4.16.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpcomponents-parent/11/httpcomponents-parent-11.pom",
+    "sha512": "bc676698caec72d525b9bf408432e9cd9c7b5d2227e0778fd79c303041cb5b07b88f98433d59c0149d6c11c27c3834722ceb283048919e467785efd7f4c399a2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpcomponents-parent/11",
+    "dest-filename": "httpcomponents-parent-11.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpcomponents-parent/13/httpcomponents-parent-13.pom",
+    "sha512": "bd585d7785341389dca9fbf6ef5e054277bdea2a8bb53ed0c2e224e4aded418414959de13e65f8cdc4697d4bc1adfb9930d86a01e329c9f1ff8f0c7ed81e19f0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpcomponents-parent/13",
+    "dest-filename": "httpcomponents-parent-13.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar",
+    "sha512": "168026436a6bcf5e96c0c59606638abbdc30de4b405ae55afde70fdf2895e267a3d48bba6bdadc5a89f38e31da3d9a9dc91e1cab7ea76f5e04322cf1ec63b838",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpcore/4.4.16",
+    "dest-filename": "httpcore-4.4.16.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.pom",
+    "sha512": "8d8809246d6a665e0870dc396da4292c13bee7db7d82fdfffd90049b33141d45d5c1b022d095d0f270fa758472dcd3c6ec742efa045e03eedbe66ceeeca426d4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpcore/4.4.16",
+    "dest-filename": "httpcore-4.4.16.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-api/2.25.3/log4j-api-2.25.3.jar",
+    "sha512": "ce9aaf5beec0fb8cbed8c4ae8a91a58d3f6935c731220b294d70f1569128b5ff367e1bf94d69572dd7ab05bff2a63bde5ff7489eb9743e8c307b644eaeadbc50",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-api/2.25.3",
+    "dest-filename": "log4j-api-2.25.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-api/2.25.3/log4j-api-2.25.3.module",
+    "sha512": "99c9fca00147b10e9dfe429ec71e23d61d48af6f4f6c4bc9f4f742fa4ad98222b88603288588c790e170f5ca6418b9f16cc143bc269504da033b994f4d169b2c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-api/2.25.3",
+    "dest-filename": "log4j-api-2.25.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-api/2.25.3/log4j-api-2.25.3.pom",
+    "sha512": "f5d562192bd39b61888b1294ce30e4a9566a741a21ff3005e2aa71d97ab8947c586df194ee3df48cf9650bdfe16fd9e8c58aa20f70c6abca089528ee730bcfe3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-api/2.25.3",
+    "dest-filename": "log4j-api-2.25.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-bom/2.25.3/log4j-bom-2.25.3.pom",
+    "sha512": "c74685af635596d18404b30c23971b7c300e50d574542f260920495474f36423e752070a3623e58ede6e18e5dac6cf16b69c0d5bfd7da673bea785c55a1e4d19",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-bom/2.25.3",
+    "dest-filename": "log4j-bom-2.25.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-core/2.25.3/log4j-core-2.25.3.jar",
+    "sha512": "64a0776adfd0b082f80e49f4afb8998c15d30c515a3441a074364d37479a2fc059bdd74694c3f609b1fae1d2eca0cb88347e1afd88774ac698a42b8744bf259f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-core/2.25.3",
+    "dest-filename": "log4j-core-2.25.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-core/2.25.3/log4j-core-2.25.3.module",
+    "sha512": "8c27ad55e87bc8484e74f2c03fbddf1015ed7011e26e4c2e2a36c5f5241df1d099d48a7a9253f8185d5d55c990b8773eb25427d642e3d50edbc737cde4585299",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-core/2.25.3",
+    "dest-filename": "log4j-core-2.25.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-core/2.25.3/log4j-core-2.25.3.pom",
+    "sha512": "70d08161e20bf2bd080a9dce25613bbf00a0558c39d25944c27577c800bb1df37e7bc26220bccb5f13a6e8f731b74976a03d988a46963c59735fcb225f6efe9b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-core/2.25.3",
+    "dest-filename": "log4j-core-2.25.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.3/log4j-slf4j2-impl-2.25.3.jar",
+    "sha512": "b10e5a0485e273c93ce54df6e37368e3486c10903b4ee948a116eb48a3bf201521e0abb795130e34911d9e115ddfb5490ed5f761b6e2149bac87ea9932162447",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.3",
+    "dest-filename": "log4j-slf4j2-impl-2.25.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.3/log4j-slf4j2-impl-2.25.3.module",
+    "sha512": "19b422d96455ce7631bd182b162e91937067bb546376c696c02c7751900d3feab36a006181c6294997a483d06959e46a4943efbd019d7d80a6294c2a20d1bbf9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.3",
+    "dest-filename": "log4j-slf4j2-impl-2.25.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.3/log4j-slf4j2-impl-2.25.3.pom",
+    "sha512": "233f84ae615f63c88c997485c19c55bc2d0d15726ac833f461c118d66ac0657e94abfac4811a49aacf88383b91126a2e5508d6e486474fe8c4a9190f06781938",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.3",
+    "dest-filename": "log4j-slf4j2-impl-2.25.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j/2.25.3/log4j-2.25.3.pom",
+    "sha512": "463edf83a6ed927a5612fc92c5e5f312a7c92f55c834a3a090514baef49e5dbcfdaca2ce43111f9900f12febaec5f6fd7c2c1589d3680ce5db1f4e0ce86cf203",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j/2.25.3",
+    "dest-filename": "log4j-2.25.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/maven/maven-api-annotations/4.0.0-rc-3/maven-api-annotations-4.0.0-rc-3.jar",
+    "sha512": "981839b8d7a94e88c56e89e312292f606762cbc8b3c3957745c6545c760a2d7ebbc4e8a7378003295837037a980a7ab3c40ff50bb505c142e9a3259df45a3459",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/maven/maven-api-annotations/4.0.0-rc-3",
+    "dest-filename": "maven-api-annotations-4.0.0-rc-3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/maven/maven-api-annotations/4.0.0-rc-3/maven-api-annotations-4.0.0-rc-3.pom",
+    "sha512": "fcef762b7605b3054caaa64e62639aaa1a2b09750942d74d864816c7648f6702c008c09ee612cc91ee49b443cecb3bb030bcdff217ad521ad11eb3d64b7d058e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/maven/maven-api-annotations/4.0.0-rc-3",
+    "dest-filename": "maven-api-annotations-4.0.0-rc-3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/maven/maven-api-xml/4.0.0-rc-3/maven-api-xml-4.0.0-rc-3.jar",
+    "sha512": "9b5a45e3e7ec7dd262a197f7ecbdefc6e60a1ae3b1c38d4247570baff08db1b8567117d79949cc548fecbdedc20200fefe3da4df69748fd44e7f014cb84bf2c3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/maven/maven-api-xml/4.0.0-rc-3",
+    "dest-filename": "maven-api-xml-4.0.0-rc-3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/maven/maven-api-xml/4.0.0-rc-3/maven-api-xml-4.0.0-rc-3.pom",
+    "sha512": "0d1897062779486ac31e5fd1dda56614f96f3478d016fd6b4fa9eb8a00785a841202006435576cee406b9007d266a361b29d85a6670d71c845aaa5fa4399f3a5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/maven/maven-api-xml/4.0.0-rc-3",
+    "dest-filename": "maven-api-xml-4.0.0-rc-3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/maven/maven-xml/4.0.0-rc-3/maven-xml-4.0.0-rc-3.jar",
+    "sha512": "80622c6cd1705a717a2b68b17c84fff913ad317b2df51017e7f88b260262279575eaf319812a78fd6892fbb94c7371659e14a385c0d4b40c1f5b15b7b6ca39f8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/maven/maven-xml/4.0.0-rc-3",
+    "dest-filename": "maven-xml-4.0.0-rc-3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/maven/maven-xml/4.0.0-rc-3/maven-xml-4.0.0-rc-3.pom",
+    "sha512": "cb9bd6d03addd845a11af7a34670a3b1c5fd6f1e6f12bb2da2a2d32923ccf48aea86eeb8c44d9060df434e3b7224dc880e5da42505139f370ff30f70f3ccac15",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/maven/maven-xml/4.0.0-rc-3",
+    "dest-filename": "maven-xml-4.0.0-rc-3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/maven/plugin-tools/maven-plugin-annotations/3.13.0/maven-plugin-annotations-3.13.0.pom",
+    "sha512": "061ad0e0f20a8d9f42f11df39d77ae8ecfbe1b06282d047e318a22a32c15ab80f33a69a15b9319286c35e2f3416aded318831d82d61209f41f8ed7014ce4992c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/maven/plugin-tools/maven-plugin-annotations/3.13.0",
+    "dest-filename": "maven-plugin-annotations-3.13.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.jar",
+    "sha512": "823ea28e3c822ff48e4e985a421fa0b53ca3419e2c0635c3d4d0a9822399b6491780e26a9161d4733857c97987bff2d725ff4453b2c22ed412eef46ea27f5d84",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/checkerframework/checker-qual/3.43.0",
+    "dest-filename": "checker-qual-3.43.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.module",
+    "sha512": "b5f80edd3661a81288365222b95a85e19096e4bd5485f59b7d72b807553ba8c0dbb1cee300a987f6a0ced3d4114b494cbabe82f52e48f596ae17fab1f1898eba",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/checkerframework/checker-qual/3.43.0",
+    "dest-filename": "checker-qual-3.43.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.pom",
+    "sha512": "b7bdf783e5ea98ee0e11d264f4a0022fd5ae4c228a00e2e8ba2f36c1a3991903ac334ea030bcbf1837e4097599f7cd0a599e0b4c03b35d5dc7550b4d93efda0f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/checkerframework/checker-qual/3.43.0",
+    "dest-filename": "checker-qual-3.43.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/codehaus/plexus/plexus-utils/4.0.2/plexus-utils-4.0.2.jar",
+    "sha512": "a99751d7990df50fd1adc10634c4e14f5deddff8fc1b7c6d26a5c7fc517d3f0e3a8d39435c512c507a0737fc9c3ee67a8f121f9e2aa8b9bfe14d9f01a99a3aa6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/codehaus/plexus/plexus-utils/4.0.2",
+    "dest-filename": "plexus-utils-4.0.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/codehaus/plexus/plexus-utils/4.0.2/plexus-utils-4.0.2.pom",
+    "sha512": "e2c922d4371df0926435624ed586e3290f15d66cedb9281900d4116fb4266f9d0f211e1446f3eb882d6d50dc622c920d7ac872fb1712c2c0966f39cd863d7c3b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/codehaus/plexus/plexus-utils/4.0.2",
+    "dest-filename": "plexus-utils-4.0.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/codehaus/plexus/plexus-xml/4.1.0/plexus-xml-4.1.0.jar",
+    "sha512": "c183471d1b9bbb1b0685b1d205a3ab02a2199b725e72257213551d709857d1630319d3cc58b2bf586c7b55f55eb7112e4d54a03ac34a00e3a7d0636eed780292",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/codehaus/plexus/plexus-xml/4.1.0",
+    "dest-filename": "plexus-xml-4.1.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/codehaus/plexus/plexus-xml/4.1.0/plexus-xml-4.1.0.pom",
+    "sha512": "02ebaa43c73508c9e773078b4396a7c20148e1e467d58b90717af5a6655480259068a2782a056104e5c492b3ac0eaa85371e69c3d57eb44c5cc8e77be1220a97",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/codehaus/plexus/plexus-xml/4.1.0",
+    "dest-filename": "plexus-xml-4.1.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/codehaus/plexus/plexus/20/plexus-20.pom",
+    "sha512": "8add248b20d0b702da654e5cc4a9fa830ff832d45289e5eb3d87941c87e65f02830858028ad4e95d281f505f21afa9f5e80601023b21956d1157196e0f397aa4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/codehaus/plexus/plexus/20",
+    "dest-filename": "plexus-20.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar",
+    "sha512": "1c0587ecb4c5a659ce2ae1fe36ffc12636a8ecba549a29f2cf91cb4d1d36a335c05f35776f480488d40d894230389f76aeeb363887026c6ef5c565995c17b7c6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/codehaus/woodstox/stax2-api/4.2.2",
+    "dest-filename": "stax2-api-4.2.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.pom",
+    "sha512": "64b95aefd534bcc90612e6432516b6a8aa1112869c0f329d60cbab202728bba64b5e90756a718d849a7d71b3df00d09e9fd0dada5651841245d4b603bb8d1b5f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/codehaus/woodstox/stax2-api/4.2.2",
+    "dest-filename": "stax2-api-4.2.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/eclipse/ee4j/project/1.0.7/project-1.0.7.pom",
+    "sha512": "b33f5cf3404c4f9f5cbb69a43dcde2d6f06d6cb3d00444dbce879a1bf14f0be4e3093f21be1aa85104cf45ae86ba69374949e35ed567f82f6ede5812140628de",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/eclipse/ee4j/project/1.0.7",
+    "dest-filename": "project-1.0.7.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/adw/0.14.0/adw-0.14.0.jar",
+    "sha512": "af7083c0690ddb6db9ee3b04b8e3f2b3b6900f8abc778baa278f77e91eb78709260132c7de2dfc28e5addb895bc1dcd0e8cba325855e2d9f8420eef83e583b70",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/adw/0.14.0",
+    "dest-filename": "adw-0.14.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/adw/0.14.0/adw-0.14.0.module",
+    "sha512": "87ae4897295d57c4ae22ce8167d564e70daf8ca99f95f4bcb6ca5971733368af556dbd47bda0aead26659a68a048d2f78202de1931e66232453f39979262ac51",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/adw/0.14.0",
+    "dest-filename": "adw-0.14.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/adw/0.14.0/adw-0.14.0.pom",
+    "sha512": "5c52e141b8f8acec2a16e510824e76438cf93b553fdb1f5066a70c3cfe2bd906ef663a367d4357e0aeda0eded0ac8d565815a4e3f5aa263a7c3a2b69e872601c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/adw/0.14.0",
+    "dest-filename": "adw-0.14.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/gdkpixbuf/0.14.0/gdkpixbuf-0.14.0.jar",
+    "sha512": "a99c1a14c61027b1eb40bab9682639e4f9c1a508f54b9ab89a333019370ecbdc8b6b76d1cf36c4d405821e14c49c7eb2c6d158b8128def293fdf94f84fe9aa0a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/gdkpixbuf/0.14.0",
+    "dest-filename": "gdkpixbuf-0.14.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/gdkpixbuf/0.14.0/gdkpixbuf-0.14.0.module",
+    "sha512": "cd153e96e793c17cb499564ecfac4fc3d8f79c00d22c2f24b62bea949fdb7c1dc615a2fd3397eb9885c56bfb3be11aed92e86eaa056125b0567363f1fe0bf693",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/gdkpixbuf/0.14.0",
+    "dest-filename": "gdkpixbuf-0.14.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/gdkpixbuf/0.14.0/gdkpixbuf-0.14.0.pom",
+    "sha512": "50a5820316b854b4a7ceebd977a74f1b219b2e21673a736a6bffe0e2a415026828b6f61053b1f5e12d6ee84d5675ee4e50a0e49038355e7fcd4f57c810f91610",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/gdkpixbuf/0.14.0",
+    "dest-filename": "gdkpixbuf-0.14.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/glib/0.14.0/glib-0.14.0.jar",
+    "sha512": "87596686f4c04e60a80fe662a6b95c81d04060779445dd2041a8326fc824ec1db34c6db1c40c231db031c2eacd8fcb22c0bdd2cdc871ceb476dbfac2e187864f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/glib/0.14.0",
+    "dest-filename": "glib-0.14.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/glib/0.14.0/glib-0.14.0.module",
+    "sha512": "79cde01e8a119f2fba3c2a6a0a4005a3582b7b8550c87b757582d7706312e707892e86331a64da3ac9f2af4531de1e50512c306397df53c52861810527424050",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/glib/0.14.0",
+    "dest-filename": "glib-0.14.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/glib/0.14.0/glib-0.14.0.pom",
+    "sha512": "e9b947b5763f2c950765fa75dca1a4bb9d4116a71fef1af2450342ba36d58ac149a8b781e969d431b4b80b72bcf3bbe6a354dc4077f385786b4e0f49f2c8cb76",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/glib/0.14.0",
+    "dest-filename": "glib-0.14.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/gstreamer/0.14.0/gstreamer-0.14.0.jar",
+    "sha512": "16335ba19fa111a0694d6cf9b86dd4b400e771028a7a512fb46762ffddcd8059cea3cda7262ca5b743ee3a602240a97a1d9141bdaca6e8bd757929ff43751ef7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/gstreamer/0.14.0",
+    "dest-filename": "gstreamer-0.14.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/gstreamer/0.14.0/gstreamer-0.14.0.module",
+    "sha512": "99ed4a95c63ef92814d409951fc9d9a13ed5b8150f7b982401a1caa188a2577ea20df5d922bff6c9353b16b660047349361a0e2b3f0e5d71e7514b0e6a560e0e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/gstreamer/0.14.0",
+    "dest-filename": "gstreamer-0.14.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/gstreamer/0.14.0/gstreamer-0.14.0.pom",
+    "sha512": "957f0f79b983d92ded2e7fffbecb98d5d60a81fda082ad5c421e20d358d4cfcaa62b27f6c3d9b82b6cd92712fe43ae53262ba0bc2d12ec2ab788dab0fa77e9cf",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/gstreamer/0.14.0",
+    "dest-filename": "gstreamer-0.14.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/gtk/0.14.0/gtk-0.14.0.jar",
+    "sha512": "3c2ce227023456201fd10502b26f1886f0699e04aa4e4a4b26f9e977718799e0c2cb6c88e5cb9c56fad719849cb83021b5a1684c371838e0d9f3c281a6f41ff6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/gtk/0.14.0",
+    "dest-filename": "gtk-0.14.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/gtk/0.14.0/gtk-0.14.0.module",
+    "sha512": "7bd3c555f014af3a468fdc617b04c9f4da02bbdfa407b6f212059ab6912255a47e3fce23d9a5cb19034f759efedcde0a030474adfe051622f512ca7362e1e650",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/gtk/0.14.0",
+    "dest-filename": "gtk-0.14.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/gtk/0.14.0/gtk-0.14.0.pom",
+    "sha512": "978ee93f0af159aae9438e5556e7430541199c14fcca030a042e4651d22e13ee0ec8b7eda1571e3050f5a5312a4ec8e34b9f56eca0b5324b02908a1bf4329733",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/gtk/0.14.0",
+    "dest-filename": "gtk-0.14.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/harfbuzz/0.14.0/harfbuzz-0.14.0.jar",
+    "sha512": "320d5ce2e0fb81e049950f903dcaca0ea89b710473d58051041042a64455782c534ac7d7e6f2eacf5320d62778625ad4f9f24b5570f9e91ca5dcd8eb7019ed96",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/harfbuzz/0.14.0",
+    "dest-filename": "harfbuzz-0.14.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/harfbuzz/0.14.0/harfbuzz-0.14.0.module",
+    "sha512": "52c8bc65c21bfd8adef18d408218943623ad857d4ddb4e33f30fbc0319374e748c7789007f3867dfeb0fc49299c24854b93a9a05bf77fdd86bfea7aa7618e222",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/harfbuzz/0.14.0",
+    "dest-filename": "harfbuzz-0.14.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/harfbuzz/0.14.0/harfbuzz-0.14.0.pom",
+    "sha512": "acde6c10429dbf3a4c6ccede6e022086360824a85e922d37ae09f010b9214d02ad414309c301d726c7eb9406677dcc6cd2e2eaa31663e2a3008ea46bf1b847d7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/harfbuzz/0.14.0",
+    "dest-filename": "harfbuzz-0.14.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/pango/0.14.0/pango-0.14.0.jar",
+    "sha512": "096e68178f96c8cc05b56674fed0f0ae955a9f1ae2340e28e84edde479a64a5d629081512422afc63dca1d262914c79edcb3c15afaaa80376ddfb64e3932e1cb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/pango/0.14.0",
+    "dest-filename": "pango-0.14.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/pango/0.14.0/pango-0.14.0.module",
+    "sha512": "ed29a0c4d2f2e7093b694ccf5a2420d83b5c54d40d4a6a489742d5124d19d515f4cbd76367a480e69ab7bda9efbab758fcd04ec622642ca1a5ebe8b1314a1250",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/pango/0.14.0",
+    "dest-filename": "pango-0.14.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-gi/pango/0.14.0/pango-0.14.0.pom",
+    "sha512": "75619bf7a4222873e0fb736e237c752983f2b2681330bee35af4fb71d82a64c93c9ebd10c3194a51c5778436c2e77fc1a7cbd1c2a87d97ce13f3bbe040971b76",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-gi/pango/0.14.0",
+    "dest-filename": "pango-0.14.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.jar",
+    "sha512": "03a21b3e1f63e7f4d35db7eb5de6f5f25d03fa82b4d3bf4ddf78ddc4a665b83c772f3f4519c38aa92bb81551feb3fe04287ee0a7590dffec1f125b06520a0fc4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-websocket/Java-WebSocket/1.6.0",
+    "dest-filename": "Java-WebSocket-1.6.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.pom",
+    "sha512": "3b85107096331d843208010a02c16a512941ee5439023d551031f40e794642efe1eea2152a248d073263687da8cf0e60e7cd3236d676141ff24312fde46b4346",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-websocket/Java-WebSocket/1.6.0",
+    "dest-filename": "Java-WebSocket-1.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jcommander/jcommander/1.85/jcommander-1.85.jar",
+    "sha512": "aa1d19723c83de1f54f6f645121ab283403ece5ba78319c9daa4418c421e26c7fbd8bc36d35f6ed4cd9b8ae25d6daa2bc36818a1659cec8c5550441d6fb609d0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jcommander/jcommander/1.85",
+    "dest-filename": "jcommander-1.85.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jcommander/jcommander/1.85/jcommander-1.85.module",
+    "sha512": "eabf09e72953ca83854a08222b637325129aca6e34226a5f8f3de878885b7fd8aa5662f9517ef388c75e74bc21fe72c52d6aceff3858b06684db66d8a1115940",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jcommander/jcommander/1.85",
+    "dest-filename": "jcommander-1.85.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jcommander/jcommander/1.85/jcommander-1.85.pom",
+    "sha512": "ccc4052db8f88869b3582941d2bc42a69b6506c5992fcaddb788833bbc8668a2dac3d25917a7f50160d076b87c2b939d5df242107ccaf41d73c9d34b0764a21d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jcommander/jcommander/1.85",
+    "dest-filename": "jcommander-1.85.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar",
+    "sha512": "81642db76358fbf131dfe9c2f1d9c280fc23b6bfde6a16a2d36dacc490a1a2af4e0fb4abb5cd78005718bb1d158a42fd6834cd2bfe616ec59625df01951f2478",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jdom/jdom2/2.0.6.1",
+    "dest-filename": "jdom2-2.0.6.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.pom",
+    "sha512": "b20863c99ff181eb407352bcfd2adfd9b23ca01e7898bd0fdfe6dd345a2a96f0a20ee0bdb61b06f1b8dd298c3e59d78e501abe2828eb8db5ddea38e314238c5f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jdom/jdom2/2.0.6.1",
+    "dest-filename": "jdom2-2.0.6.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/annotations/13.0/annotations-13.0.jar",
+    "sha512": "5622d0ffe410e7272e2bb9fae1006caedeb86d0c62d2d9f3929a3b3cdcdef1963218fcf0cede82e95ef9f4da3ed4a173fa055ee6e4038886376181e0423e02ff",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/annotations/13.0",
+    "dest-filename": "annotations-13.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/annotations/13.0/annotations-13.0.pom",
+    "sha512": "63ef480f698215d4cd4501b06e86df1a741ac2b86216fd3ff6eee146da746caa390df27351e25598971edb368aeae41055ff1ed77e4bf5d7edb6abc832d150ce",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/annotations/13.0",
+    "dest-filename": "annotations-13.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/annotations/23.0.0/annotations-23.0.0.jar",
+    "sha512": "cb82eb0aaae88e3283b299929173296e30c7b078105e0fc5ecfbcd4eb230026f9a7cc46680832d036e6c1ff036ad99d4c50dc296d4919d223879081ac1616944",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/annotations/23.0.0",
+    "dest-filename": "annotations-23.0.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/annotations/23.0.0/annotations-23.0.0.pom",
+    "sha512": "ae58d75b40e44cb0d8e3bb701c7afefa8cbf96066ae52fc3d57c69b7a7e819fd9b3b01971376da6ea94ee010b9ee59ba05a331b93a65e94c047b095131efd6c0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/annotations/23.0.0",
+    "dest-filename": "annotations-23.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/abi-tools-api/2.3.10/abi-tools-api-2.3.10.jar",
+    "sha512": "201ca364021448c2918df71d30089df589a4e3ebe56c3ad8d09014ed672ab7a16dfe1c5ed3362d8ef885dee1a0cf06e188621d1ae9c932ced974a129f30aa18d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/abi-tools-api/2.3.10",
+    "dest-filename": "abi-tools-api-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/abi-tools-api/2.3.10/abi-tools-api-2.3.10.pom",
+    "sha512": "d5f411fa775ec484f75484cf7baae80f0de0e4d3a03328b468474c908305ba25dd035aadbe24dd7bff024d7283fb041b15689d8ba69bd30dedd70829c500570d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/abi-tools-api/2.3.10",
+    "dest-filename": "abi-tools-api-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/abi-tools/2.3.10/abi-tools-2.3.10.jar",
+    "sha512": "ffd8f0cd4874b6a7933c1f9391461c194dc7105267f8425ee3710fe6b69ca78adf4292aa8228b717d2d02c57c99de19eca8c5a846711dbc192dc1730a915bff0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/abi-tools/2.3.10",
+    "dest-filename": "abi-tools-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/abi-tools/2.3.10/abi-tools-2.3.10.pom",
+    "sha512": "fd69ecc8396fa3f5a6db96804886955a4a197ecea84ef69506bea65cf7a53e3a036690ef5ae5daf04c150b27820293dcb3d7175fa96d71a63f85e9f57b80543c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/abi-tools/2.3.10",
+    "dest-filename": "abi-tools-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-bom/2.0.21/kotlin-bom-2.0.21.pom",
+    "sha512": "88c8dea4b08e04982b2882f84609a7c4339205ff449a6c6272b103a84ff3ba5e048eebc9ab36df0e69bb061f27619e2128532b9fb09c5b99178588fb8ac4461b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-bom/2.0.21",
+    "dest-filename": "kotlin-bom-2.0.21.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-build-tools-api/2.3.10/kotlin-build-tools-api-2.3.10.jar",
+    "sha512": "6b8619c015fc3fc0e1668649358adead2916909f713e2be988a9799183e94a9ccbc5dc46610aef96da66e74eccfe77233719641e068d2f4f90d66d1ed6aae9d1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-build-tools-api/2.3.10",
+    "dest-filename": "kotlin-build-tools-api-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-build-tools-api/2.3.10/kotlin-build-tools-api-2.3.10.pom",
+    "sha512": "b8b09e88d3ac6ec5b79cf8ca65a997b633ceb7065ac80b1a64e19d5016bb00baa674f2879384597cbf758211d4f5aa483136d5ccb6dba5bc2bcf2ddbbbdb79d3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-build-tools-api/2.3.10",
+    "dest-filename": "kotlin-build-tools-api-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-build-tools-compat/2.3.10/kotlin-build-tools-compat-2.3.10.jar",
+    "sha512": "e73f230c29d091ee122a2a78917a639a12e34b79ac368279c195321b5c19b5dbfa3c9ad4c36c4e414f790cc61d16c4aed37e9a7d6e88f86a0e8cf0db1453ebca",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-build-tools-compat/2.3.10",
+    "dest-filename": "kotlin-build-tools-compat-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-build-tools-compat/2.3.10/kotlin-build-tools-compat-2.3.10.pom",
+    "sha512": "0dc4f38e5b8e0522a502a5fc7b4c4232a8231959eb10003e9b8dd3da549399af33da9cca16394d3799f37e403d87acaaaf0511692732fb44dc8afaea27fd9ffa",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-build-tools-compat/2.3.10",
+    "dest-filename": "kotlin-build-tools-compat-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-build-tools-impl/2.3.10/kotlin-build-tools-impl-2.3.10.jar",
+    "sha512": "18a3dafb863e9ba01ee521b28ebd8f425b66d58d0f6e26679725010f0321b7d4eb4345511df8244536ec8c9cc34ae6525bb28f56e896375ce7098f3dd431c2fa",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-build-tools-impl/2.3.10",
+    "dest-filename": "kotlin-build-tools-impl-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-build-tools-impl/2.3.10/kotlin-build-tools-impl-2.3.10.pom",
+    "sha512": "db0afec380882da0520e11a10d39ab4e844d653a5a421b24b653e24292fb74c951a12073d23d76e0198f9fd307f28ffcd2529fd0b38654c060e471f8a6ba184b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-build-tools-impl/2.3.10",
+    "dest-filename": "kotlin-build-tools-impl-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.3.10/kotlin-compiler-embeddable-2.3.10.jar",
+    "sha512": "c1621a6ecdcb45286601378ee0724f462741e8dfc44236d6e52e1f0b2bc6696ad9276dd3835cbdcdc016b38be4b1bb72e83d11495f0f8cc8159e97db8f8181f0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.3.10",
+    "dest-filename": "kotlin-compiler-embeddable-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.3.10/kotlin-compiler-embeddable-2.3.10.pom",
+    "sha512": "baa0252d6f6b59c1712662a5eddf26b82f4746db437a6d8b6f57b46f4a62ff21f897be64f697d7f18ccd351594a0f0d576b0af7e3c84dc34f5b7e2200916457f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.3.10",
+    "dest-filename": "kotlin-compiler-embeddable-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-compiler-runner/2.3.10/kotlin-compiler-runner-2.3.10.jar",
+    "sha512": "55add2f091f67c651cbdd7c912f58466f3e402893c64164aae51094a4f2eb063e020660ef7f9b0770b9bb61ced0829a1906226f4c82d4a54d376b9d56c49e3b3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-compiler-runner/2.3.10",
+    "dest-filename": "kotlin-compiler-runner-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-compiler-runner/2.3.10/kotlin-compiler-runner-2.3.10.pom",
+    "sha512": "8c15301805ef93f0f637be11122fcec101e9927a40805b0534de303bb65f0403136fe458b285a972d042a9b99ad1fe48f8a5d1ae0d21cb4fa19df6829b0e3909",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-compiler-runner/2.3.10",
+    "dest-filename": "kotlin-compiler-runner-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-compiler/2.3.0/kotlin-compiler-2.3.0.jar",
+    "sha512": "5b2555207c0a921c79870a8c6b146e7e80d783133b16945e08a31640d5aff3faca7f6b18e460e67ad499883a74750bbe35e69ab3e4d35adf3f454bef7078b3d5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-compiler/2.3.0",
+    "dest-filename": "kotlin-compiler-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-compiler/2.3.0/kotlin-compiler-2.3.0.pom",
+    "sha512": "db14f475c144f8c2a96de259e6b877314587a5b441968e4128a8ca275ed01ed3b9de52ec5e552ba67468e67150c4eeb7537f5128161aa67a47a7a8e58a73fec4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-compiler/2.3.0",
+    "dest-filename": "kotlin-compiler-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-daemon-client/2.3.10/kotlin-daemon-client-2.3.10.jar",
+    "sha512": "74c66b696eaf9f5fabc6f18914154dbdd21c890294344e95638738a37845afaff2157e9ff72c024a02530a25c9f17ab5c3c8755124ff6ab02ce64eb76cc187fb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-daemon-client/2.3.10",
+    "dest-filename": "kotlin-daemon-client-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-daemon-client/2.3.10/kotlin-daemon-client-2.3.10.pom",
+    "sha512": "b607b22a940465aa9448fbb19fdc2fe25e2033165b433cbdd83277aca4f14bd6089ac8cdeeb4c64993ca1f83957558f71f00d513bfdfdba39943b6b53dd4889c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-daemon-client/2.3.10",
+    "dest-filename": "kotlin-daemon-client-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.3.10/kotlin-daemon-embeddable-2.3.10.jar",
+    "sha512": "3a0c370c48c6ddad990b5c9188776c2c9fde554d6b4e29fa84aba03731e84c79327079d1b12785d4eb8e47b551ce40aed1b27e4280210a3e31434a92adbc4b95",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.3.10",
+    "dest-filename": "kotlin-daemon-embeddable-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.3.10/kotlin-daemon-embeddable-2.3.10.pom",
+    "sha512": "559179b27c0a9717be34b4372db9c033c054e9039b0d2d08e45ba9b7348e09844d8b00b1d689be0872402765991cc69f1bebfe10f888ea04809d4120a73b0270",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.3.10",
+    "dest-filename": "kotlin-daemon-embeddable-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-klib-abi-reader/2.3.10/kotlin-klib-abi-reader-2.3.10.jar",
+    "sha512": "380e719aa1ee4330b5826393a6ff9f25f260b97561b89d4e58b5bdece6db8ac2f37498ec1bfbd77777e35efa40c6ccd27cfb7948eea12aeeb327f8619a61fec0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-klib-abi-reader/2.3.10",
+    "dest-filename": "kotlin-klib-abi-reader-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-klib-abi-reader/2.3.10/kotlin-klib-abi-reader-2.3.10.pom",
+    "sha512": "d9cfa10b016a18a07add758dca91e0ec4aefe38d4408a929d3d8e6c1ac8869113d12199e19f57e2716c548c835f719c5d47a83291b46c7ee87a1532c913b99a9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-klib-abi-reader/2.3.10",
+    "dest-filename": "kotlin-klib-abi-reader-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-klib-commonizer-embeddable/2.3.10/kotlin-klib-commonizer-embeddable-2.3.10.jar",
+    "sha512": "f2b2ce4f12266d2b922fd6bfebbee63ff1f44a081e71fb3d328f66a59afca32a255108cb0a2b48d41173d86cbc67c43ba0c0d5772b6c501ea58604124993c565",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-klib-commonizer-embeddable/2.3.10",
+    "dest-filename": "kotlin-klib-commonizer-embeddable-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-klib-commonizer-embeddable/2.3.10/kotlin-klib-commonizer-embeddable-2.3.10.pom",
+    "sha512": "cf87f33795dad94dfd1a3031930518add99a057e654fb1ebd3342b2da6430879f907536745013b3dd166e4e77f22b103470a5b51555dd7e541f758cf831d8f48",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-klib-commonizer-embeddable/2.3.10",
+    "dest-filename": "kotlin-klib-commonizer-embeddable-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-metadata-jvm/2.3.0/kotlin-metadata-jvm-2.3.0.jar",
+    "sha512": "9e31444f2f83383f2eee22699c1bda4f680dda6694516ecbba5fece86c672b21ed2c0e8f745a70d7b5f50d7988acdbde7e569a602c9378f693c5dab21a23d9d6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-metadata-jvm/2.3.0",
+    "dest-filename": "kotlin-metadata-jvm-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-metadata-jvm/2.3.0/kotlin-metadata-jvm-2.3.0.pom",
+    "sha512": "15ca7092b902374f555a1c1e3b228c190b1c91d4b6ed6a3bbe9d5d1b5aec7a66ce3148c14dbd0aeb6ce4e6df08216280e260c4780d0d2b9ae975eeeee2f81b37",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-metadata-jvm/2.3.0",
+    "dest-filename": "kotlin-metadata-jvm-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-metadata-jvm/2.3.10/kotlin-metadata-jvm-2.3.10.jar",
+    "sha512": "3788e4cac83a3c3b1ffb3deb3029bebee8552c9c9c9081cbd34073785688502da43f05a65de63d9d2a7d0ee4d3dfd6481930e519d2582194307fba954c3dbaf1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-metadata-jvm/2.3.10",
+    "dest-filename": "kotlin-metadata-jvm-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-metadata-jvm/2.3.10/kotlin-metadata-jvm-2.3.10.pom",
+    "sha512": "4a9df53992b46995c3157f15b5723e383024aabc9820f7692cfdcabac8960f4daf8d1f9cda0131155dd0614f8a4e06921079b0dd654120c568ff45f0cc4d72e6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-metadata-jvm/2.3.10",
+    "dest-filename": "kotlin-metadata-jvm-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.jar",
+    "sha512": "b28392f114dc049bc4582c5bdbb5b60d74358668efb25579c2ed5ac749debda89dc7426aed1f7f548b5f121f7df227c9d37b4aa49b315a0779afd5847d17872d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/1.6.10",
+    "dest-filename": "kotlin-reflect-1.6.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.pom",
+    "sha512": "3765a8094a88ebdfac50ac898a6cb3e446bc7493fb6f9fad95a4805170f987b9ca0c5c76ed2a22fb53b5171d4564b353a138e4aaad11d42a50ebfe1a11978fe9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/1.6.10",
+    "dest-filename": "kotlin-reflect-1.6.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/1.8.10/kotlin-reflect-1.8.10.jar",
+    "sha512": "43efd3dca21f2de51b3a358c4b297571ac7aa709e9d9036f68e35c1d204afe9e185716b45df412424029ad82de40f87fe3c51895791b469f4be82110cece5a14",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/1.8.10",
+    "dest-filename": "kotlin-reflect-1.8.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/1.8.10/kotlin-reflect-1.8.10.pom",
+    "sha512": "6d82e00c693ccb59a81d03b7ffeb330583eaaf4cf60f4196f7e9a1ff7b0cfcbc43d5fd21211f38e058c09e62e9eaa3d2f3ca287ff9308e461912f06b070736f6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/1.8.10",
+    "dest-filename": "kotlin-reflect-1.8.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/2.2.20/kotlin-reflect-2.2.20.jar",
+    "sha512": "38bf033e964b17c1c7d2a908f6215fed41dfc53dd9dbb592f448e3b78091ef7585807d929e6d5567fd2476e19cad9cc8f0bfe5c7795302b531c97e58fcff2823",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/2.2.20",
+    "dest-filename": "kotlin-reflect-2.2.20.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/2.2.20/kotlin-reflect-2.2.20.pom",
+    "sha512": "6ae6b0853df37b109602f52295d1bb1109eae5ccfb3ab3de12527cb23cbcd1723dab23cbed3c760d10de35f7885ded9abd96a9d6e8285612137233434f5470f5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/2.2.20",
+    "dest-filename": "kotlin-reflect-2.2.20.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/2.3.0/kotlin-reflect-2.3.0.jar",
+    "sha512": "4c015040675028f553d4ebe5edf487a2288d8d20a2b95269a241e141d4087a23a98878d123b31da5a8637bd5f2daf9548a1df9f93a834ffd054e2befd8213de9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/2.3.0",
+    "dest-filename": "kotlin-reflect-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/2.3.0/kotlin-reflect-2.3.0.pom",
+    "sha512": "12e53c164c83b0f51d0f033107449502b7eb20f32ea6d0efd604e0de0af45d7bc48a73cf104be2791909c7975c127027bede64838ab3df9b1a954bebd7161862",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/2.3.0",
+    "dest-filename": "kotlin-reflect-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-script-runtime/2.3.0/kotlin-script-runtime-2.3.0.jar",
+    "sha512": "7755ceb376e7e8df7d96899dd0c38dde88b2ae225f238c203c63ef3b65a2a8cb14297d551448b08a4ab4e5dc08377741344692f41d6617d2ccfdb335a129f3f7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-script-runtime/2.3.0",
+    "dest-filename": "kotlin-script-runtime-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-script-runtime/2.3.0/kotlin-script-runtime-2.3.0.pom",
+    "sha512": "8a5a574b65df5ca7b976ca43e10f7ff5cc610e922138547e9979d10d6a87f3b583d0da3fb439b8d343da1604ddbc6ca9958854a773099bd3c3459acad1c78798",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-script-runtime/2.3.0",
+    "dest-filename": "kotlin-script-runtime-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-script-runtime/2.3.10/kotlin-script-runtime-2.3.10.jar",
+    "sha512": "6485aedee862b55b3c7ffe5b6bc9c186fe173c0fbf3db4b2d09d5d72d9d35080df36738c38f11a59c00d69422133a40df8d0af891d20f0af419af37f4c9017f3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-script-runtime/2.3.10",
+    "dest-filename": "kotlin-script-runtime-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-script-runtime/2.3.10/kotlin-script-runtime-2.3.10.pom",
+    "sha512": "f1f030f118eea20ef31cb91c8e5f6e7029dbdd0fa289778a84d596a02a3d2f9336d356f592a6a81906599f7061162f37e8d68902f84a55c0a1818704b61a5aa5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-script-runtime/2.3.10",
+    "dest-filename": "kotlin-script-runtime-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-common/2.3.10/kotlin-scripting-common-2.3.10.jar",
+    "sha512": "705cbc888414615856c96e8631acb7f4e1bde7590287935fda897553a4ff0d7e3e417983c4d4e922fc33ec264e2cb1984db1c7d9f14173a8d2ef4c4af27c5d64",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-common/2.3.10",
+    "dest-filename": "kotlin-scripting-common-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-common/2.3.10/kotlin-scripting-common-2.3.10.pom",
+    "sha512": "93672a364125052f728b34c946252f589e2885a20c324b63509755765cf1943d33f3ef4ca895f636a93169f9625b8dcc9bfa512a68255b98a3538ad49c6db0c4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-common/2.3.10",
+    "dest-filename": "kotlin-scripting-common-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.3.10/kotlin-scripting-compiler-embeddable-2.3.10.jar",
+    "sha512": "5b0a881bb166b887b755267d4bc99311a6adc7bcabfcc04a580de9cd258194523dbd9f9444b1af15dda6b7bd264d0884229d58a9505c72a7799b7c07e52c32ef",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.3.10",
+    "dest-filename": "kotlin-scripting-compiler-embeddable-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.3.10/kotlin-scripting-compiler-embeddable-2.3.10.pom",
+    "sha512": "4d6ddbd83982997963511bff285b310ee8cbcaa92fe8f55dc6bb2361e8e0b5c16ad5182f37eee077be8abba14c4b8e42d21bef32542eb3767c917933f6caf141",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.3.10",
+    "dest-filename": "kotlin-scripting-compiler-embeddable-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.3.10/kotlin-scripting-compiler-impl-embeddable-2.3.10.jar",
+    "sha512": "0386d858abbc401fdcff38a67da542566dc5baa5ce260808aadeb74ea2eee10c40e58dab7a407c9fd14db2b41f772452601964c13de74b72d10795dc2befac8b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.3.10",
+    "dest-filename": "kotlin-scripting-compiler-impl-embeddable-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.3.10/kotlin-scripting-compiler-impl-embeddable-2.3.10.pom",
+    "sha512": "1e7fb077689afd4abeb174bd1c3aef382e0ff0ac291bb7a226a142464556a36682392bdb5e850b3ff75087ddfd0638fe397460891cf8a4d40f131c3c28a4aa48",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.3.10",
+    "dest-filename": "kotlin-scripting-compiler-impl-embeddable-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.10/kotlin-scripting-jvm-2.3.10.jar",
+    "sha512": "0c48fe52c0dc2892b181a405576a1c40fcb6e72587a39b2d127b9e33ebeb89e4c43265f6a21c1a7ffa03d2736207546f2c603564824430cd75df7f98069c5950",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.10",
+    "dest-filename": "kotlin-scripting-jvm-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.10/kotlin-scripting-jvm-2.3.10.pom",
+    "sha512": "49dd102c42f3dfa46dff8e723e548e10a4be454953414c6f93e8e4a116ff47d16a1ef5a37cf94a2f8ca63d7b3b13999ec27657af74a8ccb1903c519325867735",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.10",
+    "dest-filename": "kotlin-scripting-jvm-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.2.20/kotlin-stdlib-common-2.2.20.module",
+    "sha512": "0ea5884efbdd01b65ff900a38ce23708343102fcfc76de8e7645c0c119b4431970893bea9de466fb43e391937f35c9891f74c63f8c9ca161b5d64a8f11937a0b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.2.20",
+    "dest-filename": "kotlin-stdlib-common-2.2.20.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.2.20/kotlin-stdlib-common-2.2.20.pom",
+    "sha512": "b8637dfe5425a3cbac46c9e94c47e74772b114f1ffb254667e820ed3ffc6379c553be4b0828a2d26c8d9570e1bc8356a798ef1840ce033059bcb195166ec42e1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.2.20",
+    "dest-filename": "kotlin-stdlib-common-2.2.20.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.0/kotlin-stdlib-common-2.3.0.module",
+    "sha512": "0995682bc3816e4e80ec85d511e6bb982efb88c1113181a5f96137a389ac6408ff9f320c88b81fbcc3ee24026e9162d0003ddb7a4b6083f9a138ad9e2dc04e10",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.0",
+    "dest-filename": "kotlin-stdlib-common-2.3.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.0/kotlin-stdlib-common-2.3.0.pom",
+    "sha512": "706f036e03a2084c9bd790f3d2b462629f23b2fb79039a84f5f548b59b4fdfe3a98206a7c05fb2927e847dade6f43a112ee926f411c1261fee5aa7cadd73a623",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.0",
+    "dest-filename": "kotlin-stdlib-common-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.10/kotlin-stdlib-common-2.3.10.module",
+    "sha512": "72c630752805c438cc2ba7ddc3a1a144903094128cb7116fc57ae94749a228e0b89ef1112849c7054d23e98ac33f3edb141d1db2c77bb2fa037548fabc3b67ed",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.10",
+    "dest-filename": "kotlin-stdlib-common-2.3.10.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.10/kotlin-stdlib-common-2.3.10.pom",
+    "sha512": "c56478096092e3ce3b59d2c0dc91f39c04edcb84199605484618dd0571dc6e04fbddcde52a979852a1194d5a06327f8e603f04acb6cc2b11658ef61061331590",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.10",
+    "dest-filename": "kotlin-stdlib-common-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.8.0/kotlin-stdlib-jdk7-1.8.0.pom",
+    "sha512": "f18fd89c03d5abccf2eb2a8306044dc505e29a2bb97e2d8afdd102d7d8c42908494182daa6133e8dceb221c8bcb9a52f62c7a7232c6657abb9c91c77b2a65af7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.8.0",
+    "dest-filename": "kotlin-stdlib-jdk7-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.9.10/kotlin-stdlib-jdk7-1.9.10.jar",
+    "sha512": "f839178f07b9d6bd9a3910d13b181399e975211fa556c3a9ead08eca30ababa74f75c79aee95224ffb7b610b9e56768eeeba18e8fae84826903adb12e122bb67",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.9.10",
+    "dest-filename": "kotlin-stdlib-jdk7-1.9.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.9.10/kotlin-stdlib-jdk7-1.9.10.pom",
+    "sha512": "fdb3c9ce1109cb6f067f0645ffca942982dc7ac66ca92eb5ae22edf9011bc8b5e02ce0e96a5def49945aec45f59f565789dd9c076913f8c8045660dcbcf33a9e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.9.10",
+    "dest-filename": "kotlin-stdlib-jdk7-1.9.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.0.21/kotlin-stdlib-jdk7-2.0.21.jar",
+    "sha512": "6d79df42475c37e332c06da5ffa870589a04e676cd99c292500d10ebc4556d36659440157eb6d88dc813df12126826db7722fd3667f23463011dd284b89fe2d8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.0.21",
+    "dest-filename": "kotlin-stdlib-jdk7-2.0.21.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.0.21/kotlin-stdlib-jdk7-2.0.21.pom",
+    "sha512": "881b72f53a04a0b26787c77a58303988f992844168e49c315ea78b8ee97cb5cc24305d65aaddb0b54694b3e4a3936de22e1d146bbb97c67d7a233b1533a9e7e2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.0.21",
+    "dest-filename": "kotlin-stdlib-jdk7-2.0.21.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.3.0/kotlin-stdlib-jdk7-2.3.0.jar",
+    "sha512": "133a76883131006185eab1bbc258557037cca3d6ed06739a32b1f709c6c6bfc5ddb32f898a8d50ffbb7cebdbb76bc504f3dbbd9bd811707ed33c9cb258af785b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.3.0",
+    "dest-filename": "kotlin-stdlib-jdk7-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.3.0/kotlin-stdlib-jdk7-2.3.0.pom",
+    "sha512": "3e97f4dd1fc3f6e44451876809f78dd182a1f5c1bb1841ab196d6b16b973df949ab00eb8c1b229acb375e8ca9f18a255093b70e93dc6659d5d11da114bb1bd87",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.3.0",
+    "dest-filename": "kotlin-stdlib-jdk7-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.8.0/kotlin-stdlib-jdk8-1.8.0.pom",
+    "sha512": "2c5b573c0e5fcd9137b614586f7e4b5becaff8edcd15431e785bce5014bd23e3c70f22be5fd95ab15ab99326fddc2b27fcdc9726312a59c4d47d34e88940d3f9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.8.0",
+    "dest-filename": "kotlin-stdlib-jdk8-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.9.10/kotlin-stdlib-jdk8-1.9.10.jar",
+    "sha512": "b027fc4a0be8e69f41a86ae775ce350ef0084eb4652e50a0640dbcc600db76c3fc2983e17c96b6071b5698cea636e1b2cb015e84a6c0efe95e6db668036ba3cc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.9.10",
+    "dest-filename": "kotlin-stdlib-jdk8-1.9.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.9.10/kotlin-stdlib-jdk8-1.9.10.pom",
+    "sha512": "8cf0741fc581be275cccb34ab1f37ea6f6adfbeb086ec685258d2ddee1d7fdb03695a4da20c6a97e3043886dbf95f36b29db11699069d71c0c7aff9f4f6c740c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.9.10",
+    "dest-filename": "kotlin-stdlib-jdk8-1.9.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.0.21/kotlin-stdlib-jdk8-2.0.21.jar",
+    "sha512": "8ca85069e6f90da6fe2942e0162676c16c9b45cfa4da7a26b9811e4f1f89c7b859416dc8353c58819c6726ba463546ad7720a859a325a106f4bc606c57f67ee9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.0.21",
+    "dest-filename": "kotlin-stdlib-jdk8-2.0.21.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.0.21/kotlin-stdlib-jdk8-2.0.21.pom",
+    "sha512": "334cb373424c369215261f639a57fef1b9780ed705af93c1c3e9ec074f6a9dfb3269d480bec841ca89dc990df11cd72ff09174cb43e54fdadf962f1a9f40afdc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.0.21",
+    "dest-filename": "kotlin-stdlib-jdk8-2.0.21.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.3.0/kotlin-stdlib-jdk8-2.3.0.jar",
+    "sha512": "522ba4ee4c82627b1b0ab33082d75db0a32a6881622b3712b43da02816ceed31ef5f531536242cce8f97bf7917066a52c1588f7ffd869a431d91821b6dc93cf7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.3.0",
+    "dest-filename": "kotlin-stdlib-jdk8-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.3.0/kotlin-stdlib-jdk8-2.3.0.pom",
+    "sha512": "cd9df8cdd23c2fa0b4cf9044c64cf5bbf8c004bd3cc3e7ca78ca9c63a9b66431870eb5c839d134395088503f0f999e48051cbded83bbda8d4298e212c08bfd89",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.3.0",
+    "dest-filename": "kotlin-stdlib-jdk8-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21.pom",
+    "sha512": "8b1f1ffcd1fdc8f71183f80fad469036a6bdfce169c5691484070259fc37d3eab7879e0658ef605e5609469a18c9c16f77f3123de1f0605153feff616985beb0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.0.21",
+    "dest-filename": "kotlin-stdlib-2.0.21.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.jar",
+    "sha512": "22075ba5931e86fcf471249b88593f0651a356a71a2f3152e25effca9a7420a1562579877aca40c98f625bf5a35fa983393a939cb54bbb4c58de13676254d62d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.2.20",
+    "dest-filename": "kotlin-stdlib-2.2.20.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.module",
+    "sha512": "559e5cb85a6b54840acd2b8941abc3653252f8df44e276e3339d6a3a7e9185128eb68900cbad6d65cf5d33acfdfe83a8df83ca2400c6f64e39628ddf97d0735f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.2.20",
+    "dest-filename": "kotlin-stdlib-2.2.20.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.pom",
+    "sha512": "24e048e39ba8ac1fd249c8276a7024e4ec03fabc10b95c5cc5f8c996ea6e7a29e48457091cae0c1e59985d1f439878b7f12fe77314de14b02824dd986dbdb8ca",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.2.20",
+    "dest-filename": "kotlin-stdlib-2.2.20.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.3.0/kotlin-stdlib-2.3.0.jar",
+    "sha512": "2d19829e49ce79b8587ffc1620f95c4773ec85780f45c609017fa411064c0edbd76fc7c1333775814693258cd9c932d82bc94d18d2c545fc90198fdd3087d6a8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.0",
+    "dest-filename": "kotlin-stdlib-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.3.0/kotlin-stdlib-2.3.0.module",
+    "sha512": "04bc39c3d5650bc8b212f995fb81e872fe563ce3ecb2ff5355ca33bd1b73b6c44e02fbe9492f2222bfe000a8646bb7e02761d543bd7f4cdb4e49266e01a350d3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.0",
+    "dest-filename": "kotlin-stdlib-2.3.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.3.0/kotlin-stdlib-2.3.0.pom",
+    "sha512": "a19afd768945fd94d9a3167b390a6088cd33fdeba5bbd3817e8bf3946f88b9ba3fb370bbe9441347b4d78e60acd3e0fa3e1a4f0f9ec89dd87e3acd60ef2d0305",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.0",
+    "dest-filename": "kotlin-stdlib-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.3.10/kotlin-stdlib-2.3.10.jar",
+    "sha512": "8532b9ef9c0ff224aecb521f7fb6251e9ef37537e48a84f8fd09e1466689b96eb5c7b20d0b3f6f3bee36e0e01911fd0d80577725f6f323fa32c856142d4fbebd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.10",
+    "dest-filename": "kotlin-stdlib-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.3.10/kotlin-stdlib-2.3.10.module",
+    "sha512": "5257ab9b466ff2ed1c9708a80c6fddf140bef07deaf115b03244b78ca4827df25de76d56c0c9df97ac8ba713e45e386e3103e18ecd9b0d1e30dbe8ba3ec49fdb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.10",
+    "dest-filename": "kotlin-stdlib-2.3.10.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.3.10/kotlin-stdlib-2.3.10.pom",
+    "sha512": "e0ad7ce36f588d24ee21868d61f6b15f90678485558cf283b88855f0154a6d69a7bc8db02781d62be7099343a41ac311921d944159ccfa7e378a48f9fcd902b5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.10",
+    "dest-filename": "kotlin-stdlib-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-tooling-core/2.3.10/kotlin-tooling-core-2.3.10.jar",
+    "sha512": "831ec9092a896fefa8c4b2bd0c2304307dfe812ad83738e83870ae4de75d3d829cd89c576e9daadcda5c8d54777371bb5611482cfd9d6bab5fe1645dda7132a3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-tooling-core/2.3.10",
+    "dest-filename": "kotlin-tooling-core-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-tooling-core/2.3.10/kotlin-tooling-core-2.3.10.pom",
+    "sha512": "deddb4bb53eea087d5037914a3e41284503617fe6c96d4d953c9d8722ae912901aa5c0cd3371157265221c7822b4980eb899709d7fc1d942ac9572b0f6d75472",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-tooling-core/2.3.10",
+    "dest-filename": "kotlin-tooling-core-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.10.2/kotlinx-coroutines-android-1.10.2.pom",
+    "sha512": "5c607bf7f1f5da9c7991cb9b8075b0acb8f24065c89b1336f1a433361eb56044b9f2100b707d8e8a1dccdd0b0f0c741728a246d6ecf5b14d2f16916e9360725a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.10.2",
+    "dest-filename": "kotlinx-coroutines-android-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.8.0/kotlinx-coroutines-android-1.8.0.pom",
+    "sha512": "9f10dcfcf35c2c4844f0ef88584e543baf4fea165d73ec387c2bab58e1c64966458358970a699f0b0334e671cf97f0ff6e571df071477ae33c88e00b9271361a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.8.0",
+    "dest-filename": "kotlinx-coroutines-android-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.10.2/kotlinx-coroutines-bom-1.10.2.pom",
+    "sha512": "019fd13ac4ed6829a32489afe003762936937d6894f16ac36f611beb2ef7e9fbb282e56479863da8daa156aa77f834c30420604e431b6e2e56311e3e0240b606",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.10.2",
+    "dest-filename": "kotlinx-coroutines-bom-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.8.0/kotlinx-coroutines-bom-1.8.0.pom",
+    "sha512": "1204d8fbc5b8bf19ea84a008e7b8d4c146ee3fd10bdc603168068b76e30f0e129c7a9ec5467b9de0bdede1b1bd9e65aa028db0769f994baf63effd4af2c6820a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.8.0",
+    "dest-filename": "kotlinx-coroutines-bom-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2/kotlinx-coroutines-core-jvm-1.10.2.jar",
+    "sha512": "238fd451f80e222480c880dd8bcfd76e9203b6833a0306a55483b3f9eb0b25651242a3e7beaf7510d5e39922f1d3d987fca79468d945eb35b0f07156a7887ba0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2/kotlinx-coroutines-core-jvm-1.10.2.module",
+    "sha512": "d105252b959981bf5a1accd86ff176d032eeed22d0e5647eb2d5c811e43019408743ba91a59a21250bcc2bdb0b135c545b57eeba345679ae749d241bec16df7b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2/kotlinx-coroutines-core-jvm-1.10.2.pom",
+    "sha512": "e146303a289ff4ca6e6b93470d37036816a4a77c6d72f7fe8200befe3ba9317dad18e6aa6ee216403a163146b3cc3f55e9a53beec582029fb734d363255f1522",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0/kotlinx-coroutines-core-jvm-1.8.0.jar",
+    "sha512": "081391dcc0b66e4f71401a0684c8f0fe0fa10f195ca5e50208419b4f6110d9b0f90250a43950114d75c79455b9d304afadc069b98c5bc86afa7701ddaed51af1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.8.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0/kotlinx-coroutines-core-jvm-1.8.0.module",
+    "sha512": "44fbb461d2e7d505915d94fd06d48660482aaf75f136862ff7567ec3dc868a84e645785b45710c2045ffe6087f86585b917703e25892d1c68093537dbab5a665",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.8.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0/kotlinx-coroutines-core-jvm-1.8.0.pom",
+    "sha512": "010eb8254d2ff842a039043fe297a3dda0189fbd8ce1a214773724d3fa5e8e8a6a67ed0cd2e72d563d53a061e33041c9745c87c38e2dc7ea98dffab0ee062b03",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2/../../kotlinx-coroutines-core-jvm/1.10.2/kotlinx-coroutines-core-jvm-1.10.2.module",
+    "sha512": "d105252b959981bf5a1accd86ff176d032eeed22d0e5647eb2d5c811e43019408743ba91a59a21250bcc2bdb0b135c545b57eeba345679ae749d241bec16df7b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2/../../kotlinx-coroutines-core-jvm/1.10.2",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2/kotlinx-coroutines-core-1.10.2.module",
+    "sha512": "a88eb8e578850c3ca9e12f9067d761287a3e70c99657f41df959085bd47a9fe7982f835ab37880ca55fe5ebf62e02dbc947794194aee9b03330bc1fb24ed9404",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2",
+    "dest-filename": "kotlinx-coroutines-core-1.10.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2/kotlinx-coroutines-core-1.10.2.pom",
+    "sha512": "63ec46c4f2af79f6c88184a39cd78f3ddd26cf25a89c01a9a2068c7a7d4cf44670def8462703e72505e8a1b0a6530e6b65426486b6d8098ad5a547086025f7ff",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2",
+    "dest-filename": "kotlinx-coroutines-core-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.8.0/kotlinx-coroutines-core-1.8.0.pom",
+    "sha512": "c9b309dcb8aee156210fff58c9fa01b74d186c78e5a6292d8fbbc42776f86cbe6a597e05ea2cd5759c3f93bdd2e4e4453f95dbf61abf994591c114e5cec61b9b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.8.0",
+    "dest-filename": "kotlinx-coroutines-core-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.10.2/kotlinx-coroutines-debug-1.10.2.pom",
+    "sha512": "62e88aa9c8399cb1550d8ffe6830768f00562383b0d8074c733945acd89ea1aed8664186a49a872ea521623a94183da217a2d0aa9a34d322f1cabf2464c20c13",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.10.2",
+    "dest-filename": "kotlinx-coroutines-debug-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.8.0/kotlinx-coroutines-debug-1.8.0.pom",
+    "sha512": "30503a6703bbce1a3909aab1a3456aa08ed7623520ed2992c92a739a2292dd198f238d7cec353ff1a1759d2593a32bfa38dcb6a064417bf78121a15ae2c5283a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.8.0",
+    "dest-filename": "kotlinx-coroutines-debug-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.10.2/kotlinx-coroutines-guava-1.10.2.pom",
+    "sha512": "2f5744e09018bf1fe6358e79d4e72ac0e0c040141e093490e3046402e4bacf8d5e228ab7576270e625753899c2f8e7c0732bd05d95b92c20e30724a67835023b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.10.2",
+    "dest-filename": "kotlinx-coroutines-guava-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.8.0/kotlinx-coroutines-guava-1.8.0.pom",
+    "sha512": "4d08ac866aead40123ef4804c958a06ec52bdc5af64ee2524d81a8c65d3cad6f9605854d79449a6e52e644b4217c6f750b6f474c8311e39a1034d985829b46cf",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.8.0",
+    "dest-filename": "kotlinx-coroutines-guava-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.10.2/kotlinx-coroutines-javafx-1.10.2.pom",
+    "sha512": "38dc16d847a1579c67781b50be82395eccec98ea02eb25b434457819259a3fd98d7a10cf29a40f4b2a49e77f10dea49acccf888c9950ce9dc8ee9dbfb0ce8620",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.10.2",
+    "dest-filename": "kotlinx-coroutines-javafx-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.8.0/kotlinx-coroutines-javafx-1.8.0.pom",
+    "sha512": "24c63b9d60d50352c287760407d91ea23493319a1bf87abf4519fe5a0b22e19148fac49c34da21ce2a4ce703e917c671264a1edae384db9c3ca819b26f653f3d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.8.0",
+    "dest-filename": "kotlinx-coroutines-javafx-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.10.2/kotlinx-coroutines-jdk8-1.10.2.pom",
+    "sha512": "ae0c0e8e79a390d815e5f50787cbc17ee5dffa1dfc99fd3c586b459748e97866176401c408d9d65db2ff0fcd064ed19b31316c03404e29846ced2798247b965a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.10.2",
+    "dest-filename": "kotlinx-coroutines-jdk8-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.8.0/kotlinx-coroutines-jdk8-1.8.0.pom",
+    "sha512": "86a60743fce1550331948226814887846ebd855091a40dae69e272c0c5492fb3218fa6f1f7fa4c47e3099f4edf1de064ee708273c24e971cf1c0e1f1f9d90295",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.8.0",
+    "dest-filename": "kotlinx-coroutines-jdk8-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.10.2/kotlinx-coroutines-jdk9-1.10.2.pom",
+    "sha512": "1d6dd9c33bd42d8170bc2196346ef84445f74ce11b47730b6194a1c5ec1e066fcfcf2ff11c071f24cc53476d917ab04773c7e478c054d26fac159ca4c3ce7230",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.10.2",
+    "dest-filename": "kotlinx-coroutines-jdk9-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.8.0/kotlinx-coroutines-jdk9-1.8.0.pom",
+    "sha512": "80972fd632e469e6e1688f0909ba50a473d1ff7332ac6ec09b5fde3b3fe98bb4684721efa916d8d9230a0c31ed4175c1e73ea878b71268ac053666ca7d707238",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.8.0",
+    "dest-filename": "kotlinx-coroutines-jdk9-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.10.2/kotlinx-coroutines-play-services-1.10.2.pom",
+    "sha512": "1d86a2fb6e27ad9c8f5f2650178151216097628491fdb2d1beaa1c4a8cfaf29ed0f54039ed005aa8923b57db807627cefc5c95f6476139b5d72a0d33184dbfad",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.10.2",
+    "dest-filename": "kotlinx-coroutines-play-services-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.8.0/kotlinx-coroutines-play-services-1.8.0.pom",
+    "sha512": "ff0a43339cc1e7b6359476afc2865a5a071c69564302f7d60497ef1585296c7412bdf4ea5c8d7be2691eddb7d78e577487760f94b6823baf09d661fbd629fef9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.8.0",
+    "dest-filename": "kotlinx-coroutines-play-services-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.10.2/kotlinx-coroutines-reactive-1.10.2.pom",
+    "sha512": "9ba65dfa502929f8916f57894b8ea6205bb52a44eb8aaa5cea0c5630837ce476747e4af8d72ac9df6cabbab8f34398106f825be985600c37fb77e79a9552d17a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.10.2",
+    "dest-filename": "kotlinx-coroutines-reactive-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.8.0/kotlinx-coroutines-reactive-1.8.0.pom",
+    "sha512": "091b384be0eb3d60a9d714276156d67c592fa4700af116a863281127f36656f913fc83e4269ac25daf78416e49ec92519d9706a265e6662fd077228f622237dd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.8.0",
+    "dest-filename": "kotlinx-coroutines-reactive-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.10.2/kotlinx-coroutines-reactor-1.10.2.pom",
+    "sha512": "f4d42f9d92dd3cf83b720df9032e417e661eaa9d52c6e6666f83f5560124675d7a3c82ff56cdaba00b5da64e30fe3fb61960c9de5faf1046bbb4e953fcd4a49c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.10.2",
+    "dest-filename": "kotlinx-coroutines-reactor-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.8.0/kotlinx-coroutines-reactor-1.8.0.pom",
+    "sha512": "72f18d5ca890a927d3e6ea4b0b51c9e8b7db8c74904a1b530743a22cb12a74d42dbe51c8a305f875357c1dc48ac67ecc1df78ffa0359354bfd0b8c0b473ba340",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.8.0",
+    "dest-filename": "kotlinx-coroutines-reactor-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.10.2/kotlinx-coroutines-rx2-1.10.2.pom",
+    "sha512": "19966b5d3355093806434a106588b8d988a23688e602ae9200a0dda5f159e04856049815509f5b7ab9bfeeb1929c700f0a9bc9b8f0848a27fdc19211e5dee711",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.10.2",
+    "dest-filename": "kotlinx-coroutines-rx2-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.8.0/kotlinx-coroutines-rx2-1.8.0.pom",
+    "sha512": "ca6e74249a744670e82908f9891395be3b0a2d4b3f1238f7e919fa833073cc27804e0df96b8d4799b7928f208ccaba6be99c7efdde17f5b67b40eb3e0c1ae68c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.8.0",
+    "dest-filename": "kotlinx-coroutines-rx2-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.10.2/kotlinx-coroutines-rx3-1.10.2.pom",
+    "sha512": "713797767bb99ea92ea9f1bd643a6abbfa957e4f54abaaeff8e2ef851ccece0e582204157b9d3f51887c92fa26190ecc9c2ceab0aa8c2413b954e5e24c182db4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.10.2",
+    "dest-filename": "kotlinx-coroutines-rx3-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.8.0/kotlinx-coroutines-rx3-1.8.0.pom",
+    "sha512": "7c41defe6cfe67e8ed6330be15553e641a75dada600b98c96fb1096cd3f484228d7c3034b523f13d0fa74e31a7bf5bd0dafc30080b176d898da69a93907d66fd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.8.0",
+    "dest-filename": "kotlinx-coroutines-rx3-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2/kotlinx-coroutines-slf4j-1.10.2.jar",
+    "sha512": "e0688d8b0d58774656d147c90438ca3bece9f2052c5ca8c6965817fc29c790e229751f81874a3d06b2291feacea004a7c1b8d7769d2cdd03cd3dc9ddaf5fa183",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2",
+    "dest-filename": "kotlinx-coroutines-slf4j-1.10.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2/kotlinx-coroutines-slf4j-1.10.2.module",
+    "sha512": "956e8b4b2a38dfca46012e1c6f1484d958f860ee57cb8d16767dc2c8c24ec4847c7271b911c30dd4b7e93470bcc3941a9c0d384dd53e41d0dc846394a9e097f4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2",
+    "dest-filename": "kotlinx-coroutines-slf4j-1.10.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2/kotlinx-coroutines-slf4j-1.10.2.pom",
+    "sha512": "e3aeda087f93866da540b152573520706daa7bd3f0cc46a18249f27cf35c17fa74f22203716e1f2ff91c7722fc9617bf7c8a1ce8a72992855ad52940be61bf30",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2",
+    "dest-filename": "kotlinx-coroutines-slf4j-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.8.0/kotlinx-coroutines-slf4j-1.8.0.pom",
+    "sha512": "9444df2629cf6f37bf94ac9daa3ea883f0de58108ad9ac0eb63a822ef78e9c7433e8016300644bbe96f2909e8887981eb32c51f9399a08ce4697221ee5c3f0bf",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.8.0",
+    "dest-filename": "kotlinx-coroutines-slf4j-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.10.2/kotlinx-coroutines-swing-1.10.2.pom",
+    "sha512": "b88bb52e56146233d4703c7a9695049605a9a21d85e3f075f278ededeac80f76e9cf2110f4336cbafb46ee475558da664d8f068f6d2e524b0b18f20483478977",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.10.2",
+    "dest-filename": "kotlinx-coroutines-swing-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.8.0/kotlinx-coroutines-swing-1.8.0.pom",
+    "sha512": "9615b57fcc82c87978371a03626f4d064ded28d2e7575db5f3e78bc31373da23fe86f0512fe9da29229591660e644d50886fe1307a8b684edc26d3790acdc548",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.8.0",
+    "dest-filename": "kotlinx-coroutines-swing-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.10.2/kotlinx-coroutines-test-jvm-1.10.2.pom",
+    "sha512": "646a554dc77ea050467c5cc43518459ce33e7c1b9103673c13a9f0288f5c1cbdbb43913bcf7e0fb1c02f2323b92a0feab17ddc223a1a919b8392431be65fca6d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.10.2",
+    "dest-filename": "kotlinx-coroutines-test-jvm-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.8.0/kotlinx-coroutines-test-jvm-1.8.0.pom",
+    "sha512": "d9c8947372a8d88f3b92d83eedac01013dee9f364d66441ad26daf5961944a868ed99d02b491a9855521b7f2e2baae96c8d195837ce423128c0c596cc2733503",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.8.0",
+    "dest-filename": "kotlinx-coroutines-test-jvm-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.10.2/kotlinx-coroutines-test-1.10.2.pom",
+    "sha512": "4d49f5a32e32558d490f6159be5740a361b2ed615f762a63623b430feca757d499934157e16c52669b07a14cbe5ffe42e192db26b81190b06e3b84963ddaaeed",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.10.2",
+    "dest-filename": "kotlinx-coroutines-test-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.8.0/kotlinx-coroutines-test-1.8.0.pom",
+    "sha512": "e473da72ff8b8362eb934d0a83af4dbfe286e56381402d795e5d530a6b2f587fcb59b0cb84d53e7d7e0dc562a431f7685c24a67248cf44f33dd753e98c7279de",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.8.0",
+    "dest-filename": "kotlinx-coroutines-test-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.7.1/kotlinx-datetime-jvm-0.7.1.jar",
+    "sha512": "1c7f560ae5ea82f5e874ebd517b44083a66556c821a5fb58216561568a97fc314355e81f5cf1940d6b67dfbb179c3191b59fc4252c11ba9de21ea3433ca27311",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.7.1",
+    "dest-filename": "kotlinx-datetime-jvm-0.7.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.7.1/kotlinx-datetime-jvm-0.7.1.module",
+    "sha512": "10f49a565636051725b4ce8a864b9266f2342496548274fc27c03225b193ffe955050e44180590966c0b8ae201c3c2bff8c853b7ae2bac0e66f948331f5684de",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.7.1",
+    "dest-filename": "kotlinx-datetime-jvm-0.7.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.7.1/kotlinx-datetime-jvm-0.7.1.pom",
+    "sha512": "f4d11a69cd3e825e805273369bfbc9cb4354b7bd9b58046e8387c2a374bd0b4354db87aa13eff755d51b4e16d52dfbfa8529e23efe96088caa0533c15891a515",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.7.1",
+    "dest-filename": "kotlinx-datetime-jvm-0.7.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-datetime/0.7.1/../../kotlinx-datetime-jvm/0.7.1/kotlinx-datetime-jvm-0.7.1.module",
+    "sha512": "10f49a565636051725b4ce8a864b9266f2342496548274fc27c03225b193ffe955050e44180590966c0b8ae201c3c2bff8c853b7ae2bac0e66f948331f5684de",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-datetime/0.7.1/../../kotlinx-datetime-jvm/0.7.1",
+    "dest-filename": "kotlinx-datetime-jvm-0.7.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-datetime/0.7.1/kotlinx-datetime-0.7.1.module",
+    "sha512": "a68209f7dc11f5f4dd0dccb41319b5544aafbe8672b6ecab327b8dc24d103380ccc59d2b40754d2786706b0688a6e886fe9f6cffc7b0dbfc5194e57e05f53c34",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-datetime/0.7.1",
+    "dest-filename": "kotlinx-datetime-0.7.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-datetime/0.7.1/kotlinx-datetime-0.7.1.pom",
+    "sha512": "25d011a5daa059f2d1ec282615dcc472fe38700661b0da2b93fee622dfa6f8b3441de0b126c281e71d2830c8c34c063f058e87dbf1be20c5521cfa4ebc765182",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-datetime/0.7.1",
+    "dest-filename": "kotlinx-datetime-0.7.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0/kotlinx-html-jvm-0.12.0.jar",
+    "sha512": "d54dd43230fe3f05296e44501f613a0242af9ca46900afca5e665287c49527a29e4adee48aac27c614326bbaf9a4d3923536608a2a47a51468360b26ac1b83a0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0",
+    "dest-filename": "kotlinx-html-jvm-0.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0/kotlinx-html-jvm-0.12.0.module",
+    "sha512": "f3839adaab991db417f3b26e70f91d1189d1e12070a45e14d8efee280e9519489b1e0e5d968571919400943a7fe70df352a7edbf2f49d4e35295a20a0781671d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0",
+    "dest-filename": "kotlinx-html-jvm-0.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0/kotlinx-html-jvm-0.12.0.pom",
+    "sha512": "5a888586314dbdbdf72d22abeedf78aff5300238c50c22afb9845589000f51acba08bceff5af82df7d19075ccd98ee83de64cb9135e6345d9febcfafe83d8f6c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0",
+    "dest-filename": "kotlinx-html-jvm-0.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2/kotlinx-io-bytestring-jvm-0.8.2.jar",
+    "sha512": "400f5deae09a285bea68bb00fcc247b9be4c76746584516b6aa5e612719783b6ee79979b497053f28d8878dd7d7514e91aa3611aaa1ce7ce369862f53f3a9c4b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-bytestring-jvm-0.8.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2/kotlinx-io-bytestring-jvm-0.8.2.module",
+    "sha512": "2d1ae5ce7a49681f9f48011301b4fea0bb11639ee4764cb698697576198a28f4e5d0dc446001d785ad882755dc020f1649231a0eb82679fb0610d75a0c133965",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-bytestring-jvm-0.8.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2/kotlinx-io-bytestring-jvm-0.8.2.pom",
+    "sha512": "7fd502441d8a7211df8a6732e321bc6aa5218c2f99ee3c155cf268837fdd70f7b34127c347326e405f9ceaf50959b74677ed704a6991ae5d9157286d7121b7cb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-bytestring-jvm-0.8.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2/../../kotlinx-io-bytestring-jvm/0.8.2/kotlinx-io-bytestring-jvm-0.8.2.module",
+    "sha512": "2d1ae5ce7a49681f9f48011301b4fea0bb11639ee4764cb698697576198a28f4e5d0dc446001d785ad882755dc020f1649231a0eb82679fb0610d75a0c133965",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2/../../kotlinx-io-bytestring-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-bytestring-jvm-0.8.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2/kotlinx-io-bytestring-0.8.2.module",
+    "sha512": "1245511dea7361b90b71211c16af13ba06f3c240abc7d60be367808680b9e291ad3f23bfa21f5421a05b8bae7e7e2db0779d97a7e80d013731013651ad0687f0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2",
+    "dest-filename": "kotlinx-io-bytestring-0.8.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2/kotlinx-io-bytestring-0.8.2.pom",
+    "sha512": "8d8734e25410a5a4926b0a1aee099c817076ad0a222db54cb4d5e150f7fc7b09a32d02aea05e9a029e9921849ac7899a8c7b777fff7c34f8252a477e481f8378",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2",
+    "dest-filename": "kotlinx-io-bytestring-0.8.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2/kotlinx-io-core-jvm-0.8.2.jar",
+    "sha512": "ccdc618cdead73b4702e1bffcdf503bda7c3e0eae3d4db65430442eff1c7b2fdaeb5838781994fc82e46310de81a806707b9c3c2e72e36bacc154da8a82214bd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-core-jvm-0.8.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2/kotlinx-io-core-jvm-0.8.2.module",
+    "sha512": "481d06019b6fd1c2135fc20ddf30d9fd00a421297af7b12eb783c2afcd0c1c58def59b2d8db61700ccfcc717e2eaabc9070e25eba0779858d996ab3d42841789",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-core-jvm-0.8.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2/kotlinx-io-core-jvm-0.8.2.pom",
+    "sha512": "12f0726310dccc60bb703fc13634e8719d01c80189a512faa7abe9107a51aefabebc04a47116d727473e84db2626c527b1338eead8f66becdb8793b95ea90687",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-core-jvm-0.8.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2/../../kotlinx-io-core-jvm/0.8.2/kotlinx-io-core-jvm-0.8.2.module",
+    "sha512": "481d06019b6fd1c2135fc20ddf30d9fd00a421297af7b12eb783c2afcd0c1c58def59b2d8db61700ccfcc717e2eaabc9070e25eba0779858d996ab3d42841789",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2/../../kotlinx-io-core-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-core-jvm-0.8.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2/kotlinx-io-core-0.8.2.module",
+    "sha512": "d1c88ea8b8aa77bbd213fb63c72b22108223cdddc0109ec6495a63c9305dbb5d5cc4f33140b7c49b8b7ab7b554a0b42f4b4d75e997751d2854f8c5fcd176fac2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2",
+    "dest-filename": "kotlinx-io-core-0.8.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2/kotlinx-io-core-0.8.2.pom",
+    "sha512": "f2c5a6d523358da2a0c994f1318c365285c710779f38a794a6cdea76c4a441271be4b5f0a61d0fdd72a0e6e7f2b7a158ddb4a115af5b39858d721e28f5082f1b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2",
+    "dest-filename": "kotlinx-io-core-0.8.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-bom/1.10.0/kotlinx-serialization-bom-1.10.0.pom",
+    "sha512": "fd2506eae3e81484e49f6e175387e12f81c58f00784e00d1f5dc771c7d5e351b737570e4a1b976eb6565ca3a9dedce37eac68513bb46a2f49c8242da4ac73fd8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-bom/1.10.0",
+    "dest-filename": "kotlinx-serialization-bom-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.10.0/kotlinx-serialization-cbor-jvm-1.10.0.pom",
+    "sha512": "d5a98637f0a3f29c7bf7a5b8c515ec34b9835b9ef011af4061d3b0930028698a2180d3cc684b2859983f993f33f2a5b936d6d4be14c60265f2baa9c1b998ea63",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-cbor-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-cbor/1.10.0/kotlinx-serialization-cbor-1.10.0.pom",
+    "sha512": "1fd0c8dfdb847d04adb209f1fb0ba2909d2f76f2a3b06b556a5892e15e25ec50abb55556cebf35954b1b11d8fe2db111c55e127bdf79ec6c7ad02a368023156d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-cbor/1.10.0",
+    "dest-filename": "kotlinx-serialization-cbor-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0/kotlinx-serialization-core-jvm-1.10.0.jar",
+    "sha512": "066f05d77e61a3519f2031f080c6872733f0d3d93b13d77911c302f45b2f975923cb4dfd2d85d6c81c64514181369782dc23aaccae4413b4ef0b7a872ed8896d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.10.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0/kotlinx-serialization-core-jvm-1.10.0.module",
+    "sha512": "19bb80223874dba5cf3899367d6eca4b351c6acf8a1bce54c9c58a53822f9d4b523ad6e6c74771f276529a2169a8d69ff83d9a66e70999ef89daef401193e095",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.10.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0/kotlinx-serialization-core-jvm-1.10.0.pom",
+    "sha512": "7d6d775cadac6dce9e0d66c12b0cea46f1496e1ae4725df93062860f8c268aa68b189872e119bcaa548c0fca2086249c10349f2b9e0300739bb29ddacf5641df",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.jar",
+    "sha512": "26e6fdf3dd6ed31b8d2d6799ce34c07ffaea9a8aed2c003fb6a7c68b23cd49f564d4f2ff1bd55456de6b0805225a644ea3d24eb152858284fd013ff04b18b981",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.4.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.module",
+    "sha512": "7c95b19ad9ddbe0cc594312b930c6c4ca99b7b859586d54e0990829715cb0ff3b85ab953d76859291411e363617834d2e275aae18f976a6ded27e47731259292",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.4.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.pom",
+    "sha512": "4139f92e8d3aec7e8a3df895c16c9fc231ef628502efc40e6a01f4a216d94461ba24b245646d5ba5e00068b3390533251bc0e458107f6ffe16737e540360350c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.4.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0/../../kotlinx-serialization-core-jvm/1.10.0/kotlinx-serialization-core-jvm-1.10.0.module",
+    "sha512": "19bb80223874dba5cf3899367d6eca4b351c6acf8a1bce54c9c58a53822f9d4b523ad6e6c74771f276529a2169a8d69ff83d9a66e70999ef89daef401193e095",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0/../../kotlinx-serialization-core-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.10.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0/kotlinx-serialization-core-1.10.0.module",
+    "sha512": "95f5d0c001cf8000b684c44020c5e4f3fe01ce8e0d9312653757c0b12261a113efb654957471bd337f0a40651039241350314d6dc648018d5cb080d4786a338e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0",
+    "dest-filename": "kotlinx-serialization-core-1.10.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0/kotlinx-serialization-core-1.10.0.pom",
+    "sha512": "823a296b5e341b2904576ba4116fbcfbfcb9ec4d1a885207da29ed7685b982030155da6dc4a67b281df8b832fca792b07a16ba954a0f9e6f3c7cdf147145530b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0",
+    "dest-filename": "kotlinx-serialization-core-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.4.1/../../kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.module",
+    "sha512": "7c95b19ad9ddbe0cc594312b930c6c4ca99b7b859586d54e0990829715cb0ff3b85ab953d76859291411e363617834d2e275aae18f976a6ded27e47731259292",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.4.1/../../kotlinx-serialization-core-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.4.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.4.1/kotlinx-serialization-core-1.4.1.module",
+    "sha512": "1fbe8529bdb84875a0e58b2910d1b9604c5e430a87174c3a124909d2ee6f2330e37d1672708655eb743186e26b43fdc241dd80e2ecc8c4d7e535252dea06b9a1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.4.1",
+    "dest-filename": "kotlinx-serialization-core-1.4.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.4.1/kotlinx-serialization-core-1.4.1.pom",
+    "sha512": "e73ec15072cd6ff9f83e34478d5602b24c9ebe092fff16876083dc2f99ae39d0079183f9f202c5d93b3c1de76150a86626ec620fd4be6b0dfb1dcc945a66e1d8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.4.1",
+    "dest-filename": "kotlinx-serialization-core-1.4.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-hocon/1.10.0/kotlinx-serialization-hocon-1.10.0.pom",
+    "sha512": "5230c7bd01df301df799355ecdf4aee783d4396a4229d50d7b35d3b96b28c28e4a264a09d0b647b18345f992c65457543647c68f6fa68ddedb7c0282bfe409e7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-hocon/1.10.0",
+    "dest-filename": "kotlinx-serialization-hocon-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.10.0/kotlinx-serialization-json-io-jvm-1.10.0.pom",
+    "sha512": "7d5905efe0ce9e35a2ab9706c564e1443430d68a5a96e1d503ee88a3e2353fca30d3352cf481f6f1214213fa161b2ab6612bce16259904b8e85880a557be726a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-io-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.10.0/kotlinx-serialization-json-io-1.10.0.pom",
+    "sha512": "11788d7796ec404498992e5d8d747962926b40b2f69973784a4fe118f8a1cad1821f2f4085472e297145b190e696e4327bff50a34a33f2261933bf005a1510a8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-io-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0/kotlinx-serialization-json-jvm-1.10.0.jar",
+    "sha512": "e51d563a6195bc0dccff4638039e1e3c34ccc28530c4ad192fc65faddcc8ef47585065d5826bb442814fdac04c9a8269dbceede9cd211c084cd320fbc80e9fdd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.10.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0/kotlinx-serialization-json-jvm-1.10.0.module",
+    "sha512": "ec8a87c1ee2282f06a2e33f33831d8c0602be9af8ecd024b6e0f0fcf916d0e7c837bd7ab39cf239babb2cd3650a7ed748678546eb2a20f8ead443688c51c13b7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.10.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0/kotlinx-serialization-json-jvm-1.10.0.pom",
+    "sha512": "48edd357df91446f0f7229b44d28be1f169ac6caf988d7f890173ff5241056f72ef00b61168dcc32d9933eddc4c2f981ff25381c69889a989317a5e7a92033f4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.jar",
+    "sha512": "a47c35e4c9a92044b7f54f3fd0cf208ceae08a3513b3d519e17387a0ab05390c8210e5b13853e21c6d0c8797cbc667143777cedee060f16964ff9ec353760f13",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.4.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.module",
+    "sha512": "0e14436ee1184626fcc1c67be0c6476f19f1c97ee2b070b6eefc2c93ee408024bbca3630f5ee078b82649485e15ef74d0ac62ad27fe23dd067615a4210073d70",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.4.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.pom",
+    "sha512": "f2f250578262912600cc0a4ed5c1ed14cedcd5985a4ee6c03404a634bbe81bdeec1be42ce7b8a8a2ad33dd09211dff1b162c76aaae906eb887002e475e66cbb6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.4.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-okio-jvm/1.10.0/kotlinx-serialization-json-okio-jvm-1.10.0.pom",
+    "sha512": "b834816001eb6709a2edb22d69e12a2351ef348b061007a458062dd52471e8306d59424a68d3a64e2dba181678814f1f858bbdc5f5d6b1bafe7462ce19f59451",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-okio-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-okio-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-okio/1.10.0/kotlinx-serialization-json-okio-1.10.0.pom",
+    "sha512": "acba739a7c00556bfdeefc941640f06f495cd06e3dd3ee50f1422213388d0af7174b35d54666fc6577b0a9823854b51f5ef365341029fd1e6901d32eb52e2236",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-okio/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-okio-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.10.0/../../kotlinx-serialization-json-jvm/1.10.0/kotlinx-serialization-json-jvm-1.10.0.module",
+    "sha512": "ec8a87c1ee2282f06a2e33f33831d8c0602be9af8ecd024b6e0f0fcf916d0e7c837bd7ab39cf239babb2cd3650a7ed748678546eb2a20f8ead443688c51c13b7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.10.0/../../kotlinx-serialization-json-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.10.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.10.0/kotlinx-serialization-json-1.10.0.module",
+    "sha512": "c14ec7e381a23342cf1b96f2d916be132ee6227509a0eeb143a3424b69b505fc94f8a9c264a07b391effee20395b92137e39526f8271bebe7eeea74fef8872fd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-1.10.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.10.0/kotlinx-serialization-json-1.10.0.pom",
+    "sha512": "0632339f667337e0a02b0b47daedcbf496296b9f56aaf3926a4f0eb2d68eef3a15756f939f534c18628b3fcba8ec3f254408b92652b617ba6bbb11e70fbd944d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.4.1/../../kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.module",
+    "sha512": "0e14436ee1184626fcc1c67be0c6476f19f1c97ee2b070b6eefc2c93ee408024bbca3630f5ee078b82649485e15ef74d0ac62ad27fe23dd067615a4210073d70",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.4.1/../../kotlinx-serialization-json-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.4.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.4.1/kotlinx-serialization-json-1.4.1.module",
+    "sha512": "104c013b5a6ea424d968e7dc27b9b13800e23ca76bb62b656adceba7dde7148dfd55e8e8c5d7d48adccf2bd44d4c43a7ab8b8ebf39c9924ce853222270900d3d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.4.1",
+    "dest-filename": "kotlinx-serialization-json-1.4.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.4.1/kotlinx-serialization-json-1.4.1.pom",
+    "sha512": "297a3f7a8a8af3155dcf1387a0b3ae6df9ff6a66a13f52d5aa9a0522087037a5dc011f310ff6ab1171d7ebc7d804f3cae15f822ce22d6bfc76900561e16b0989",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.4.1",
+    "dest-filename": "kotlinx-serialization-json-1.4.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-properties-jvm/1.10.0/kotlinx-serialization-properties-jvm-1.10.0.pom",
+    "sha512": "7018d746600988c2d80f8d55820218524810466f4918da4cbf89a9421fbf112cc638a11e4b768a4d8febb23f278ad05200b1353304b42d736924674615233524",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-properties-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-properties-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-properties/1.10.0/kotlinx-serialization-properties-1.10.0.pom",
+    "sha512": "1e92337b6177e70f8a0304cc5a642b0ed01fe57efb837cafb3547209a9db1d13af2234351806ce3b56bc7ba0a88c1812d0fb5a4c66b5b3da59488dc73ef6e3c5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-properties/1.10.0",
+    "dest-filename": "kotlinx-serialization-properties-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.10.0/kotlinx-serialization-protobuf-jvm-1.10.0.pom",
+    "sha512": "25253b58b0c94329e805f7294912d5da5420a117f011a995b9c0ff2a0b999b38452f02546c6352570147559ca4790983b9b5605950a955a6be520c457d135727",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-protobuf-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-protobuf/1.10.0/kotlinx-serialization-protobuf-1.10.0.pom",
+    "sha512": "f561276ae918a88e45f6a30ee795ea6b3190da998a9078067f6fee75d6ba68465f8632b9596a47e91ffe685767283ea07b651f3ce43b9452accfb75df8935d85",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-protobuf/1.10.0",
+    "dest-filename": "kotlinx-serialization-protobuf-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
+    "sha512": "efded31ef5b342f09422935076e599789076431e93a746685c0607e7de5592719ba6aacde0be670b3f064d1e85630d58d5bce6b34aed2a288fdb34f745efb7bc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jspecify/jspecify/1.0.0",
+    "dest-filename": "jspecify-1.0.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.module",
+    "sha512": "02669b1c62e0c6988dd812b89201acbe6dad796f3573d6e626d2f56d2194896e198bf3998f0618019b722c7b0c93f013528bff1118f835154f2bd61c17e67b77",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jspecify/jspecify/1.0.0",
+    "dest-filename": "jspecify-1.0.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.pom",
+    "sha512": "291d8fb333121ba18ebd427e7ee5e98694be797b8280a228be7c4958af934b2465f341957248dcd396f5ffbe99dd9a65aa61cef70ca772ee37a92c3d20e41f32",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jspecify/jspecify/1.0.0",
+    "dest-filename": "jspecify-1.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.10.1/junit-bom-5.10.1.pom",
+    "sha512": "1b9c3bcea64f5d98f5e39c88adab6d7a9bfcf0ee4e6639a8c146b4b7cb29a4a280b567c6e42a537c215590c557e86b9446a2c9dcf76191d0ecac1ad9bf16f7c8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/junit-bom/5.10.1",
+    "dest-filename": "junit-bom-5.10.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.11.4/junit-bom-5.11.4.pom",
+    "sha512": "303612e72adb3af46265aa7c60718dd51baccb576d4a9820ae3aa94c5119d6c9b3a3168993dd1a6692154786cbbd33eba99985842fc45125a18a1c44d490a8c1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/junit-bom/5.11.4",
+    "dest-filename": "junit-bom-5.11.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom",
+    "sha512": "e1c4acc68f7114cd501754d07e51a9345bc1106623ea9e38cd6d40b1886cea7f8f6fa227da9d71da608b6691ef1f9d75d11253567350fbb4a949770a1cb7023e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/junit-bom/5.13.1",
+    "dest-filename": "junit-bom-5.13.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.13.2/junit-bom-5.13.2.pom",
+    "sha512": "d557142227e27ecee6f3bdc77a7765cec614a2a4b7e88c9343dad30b53648708e8f17e422a9a2cec6aefa9c0c8bc07f573da23ed68211a399ea0a80426011489",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/junit-bom/5.13.2",
+    "dest-filename": "junit-bom-5.13.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
+    "sha512": "ec795b2f32982c1af8dccef57553aa9d959c13ee829aebd6459ba22b4ef434aeb4184aa89f63ad2f0d8c45d59cd020a15cd976ddb4bf20f1044b492a406e029e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/junit-bom/5.13.4",
+    "dest-filename": "junit-bom-5.13.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom",
+    "sha512": "a8f5b64af5387c0eab939f6af8c2d3a7dfe9930ccaf0a33db97a307fa2af2607dfecb520527f9579521d6296d7dc0029310ea410df753e6b3ad7a63ac00f12c9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/junit-bom/5.9.3",
+    "dest-filename": "junit-bom-5.9.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2.pom",
+    "sha512": "3058445ff0c96a9898f8b79e66a1b0af49a37da48bf39310696802f8cca3aa318f1ab8b5f3f209b64ed3a56134a1e2c20ca916e53908536430495c4e34e650f7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/jupiter/junit-jupiter-api/5.10.2",
+    "dest-filename": "junit-jupiter-api-5.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/jupiter/junit-jupiter-engine/5.10.2/junit-jupiter-engine-5.10.2.pom",
+    "sha512": "6fcc469a3d9f77cb6c0a61f0b63a441be1fd7a015eae3e4acd44493fbf93156b2f9a0bd48d39c88931656dc877336504d8a6cf31e3239b100b2bf99f55aef291",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/jupiter/junit-jupiter-engine/5.10.2",
+    "dest-filename": "junit-jupiter-engine-5.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/jupiter/junit-jupiter-migrationsupport/5.10.2/junit-jupiter-migrationsupport-5.10.2.pom",
+    "sha512": "77d95350596ac135b3d64f55be4b37efc241f435e40f90bdfeacf97ec5d1125f7d44b9582321317e423601d26968ab80ff3a44a2555cf1aa51a835c78caafc19",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/jupiter/junit-jupiter-migrationsupport/5.10.2",
+    "dest-filename": "junit-jupiter-migrationsupport-5.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/jupiter/junit-jupiter-params/5.10.2/junit-jupiter-params-5.10.2.pom",
+    "sha512": "9180a173c87c6bdf0a056f57b1ddc8f31bbb79226945f28eaa390d3e091d3bd61ba42fa6131b068734157991c94bcb3c34c0c44841c3c56b8a352b22a04a1132",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/jupiter/junit-jupiter-params/5.10.2",
+    "dest-filename": "junit-jupiter-params-5.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/jupiter/junit-jupiter/5.10.2/junit-jupiter-5.10.2.pom",
+    "sha512": "11cdf9cb24845eae5fe8935ea48f4274010ca49d8c7aba99f01974754b741c045903624c3fbee495772ad2cce97efa26b10a4c5b2a27705e646a06fc19f90d76",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/jupiter/junit-jupiter/5.10.2",
+    "dest-filename": "junit-jupiter-5.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/platform/junit-platform-commons/1.10.2/junit-platform-commons-1.10.2.pom",
+    "sha512": "7440a45b54cf9716de90cb003a9e1dc8d085e7b9ae656b04f55f268c1e4b2ee2919380daac544ece41b28bb7161ab2bee3d75b408f01bf1437a23211072eec65",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/platform/junit-platform-commons/1.10.2",
+    "dest-filename": "junit-platform-commons-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/platform/junit-platform-console/1.10.2/junit-platform-console-1.10.2.pom",
+    "sha512": "1514bc674713b8104df20a25e2448980970f5cd92c2aa38052911207d4b69baaf9ca6510e41d114e68761bcf16ab710effe15de5546195eaad36b4dbe8f8101f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/platform/junit-platform-console/1.10.2",
+    "dest-filename": "junit-platform-console-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/platform/junit-platform-engine/1.10.2/junit-platform-engine-1.10.2.pom",
+    "sha512": "3fb49e53f5e3a426d31806bcc1379ce7af2befd9e53690c9812ab6cbd13bcef15bd13edcfa7c9fbd934d643c9e0f176673b5900b8b24a576f3b0d95212dd918a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/platform/junit-platform-engine/1.10.2",
+    "dest-filename": "junit-platform-engine-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/platform/junit-platform-jfr/1.10.2/junit-platform-jfr-1.10.2.pom",
+    "sha512": "9877d4d101f735454e38ff6f91982e6024a2bb53adefe9459744bccf40e3fc049af0b6ccdd103118aba8e95643d869d346b527d7cbc16df8ef680b68c1abdf9f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/platform/junit-platform-jfr/1.10.2",
+    "dest-filename": "junit-platform-jfr-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/platform/junit-platform-launcher/1.10.2/junit-platform-launcher-1.10.2.pom",
+    "sha512": "2ad36f2a620e1c3c052ee8853c8a682c5028c658530071acab1409efdf42f8543818faf25d4e5d80398a4681a7406ab841b36c9e84551e1f20bed22b3d545f87",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/platform/junit-platform-launcher/1.10.2",
+    "dest-filename": "junit-platform-launcher-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/platform/junit-platform-reporting/1.10.2/junit-platform-reporting-1.10.2.pom",
+    "sha512": "b7d9e0f437786d97a3c768db3900071559c48181f6d62696a1f2fb53740f62b19632dee14434c4e2d8877262d247c4e964c0f7f7ddd0fca6cb0f976476df604b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/platform/junit-platform-reporting/1.10.2",
+    "dest-filename": "junit-platform-reporting-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/platform/junit-platform-runner/1.10.2/junit-platform-runner-1.10.2.pom",
+    "sha512": "3e244a330657cd7402e076d8223fde46e538f87864db5e2d3f5cada8444a3e68285e7027844f7e4d9b61395e03b23b37c4e4f9ed60888ab12db7ace3e1d9a7c9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/platform/junit-platform-runner/1.10.2",
+    "dest-filename": "junit-platform-runner-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/platform/junit-platform-suite-api/1.10.2/junit-platform-suite-api-1.10.2.pom",
+    "sha512": "40c6d8a0d56ed395d7d33fd8e6796c2e8881b51fae01ae230133a4445fe9175cd29f9d6ab1ab4a55a2525507a1f18f9b3638845d00ccbbff1b9df8da56a6de15",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/platform/junit-platform-suite-api/1.10.2",
+    "dest-filename": "junit-platform-suite-api-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/platform/junit-platform-suite-commons/1.10.2/junit-platform-suite-commons-1.10.2.pom",
+    "sha512": "eb882419b299389dd0478e7221859d078b6ea843112158c1c555dee14d6d30bb2e559619e44a051825b616a67b5041865b9cd571b466c9bae6d7e639f7d2f7dd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/platform/junit-platform-suite-commons/1.10.2",
+    "dest-filename": "junit-platform-suite-commons-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/platform/junit-platform-suite-engine/1.10.2/junit-platform-suite-engine-1.10.2.pom",
+    "sha512": "a6ac8a2a529e415decac5af5fc68e56a4b07cfbd5390dca638c0ed78ef1f011351e22d9e898f569b516566dc927f72d0c4511f8ff123476e86ae7883d114c9b8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/platform/junit-platform-suite-engine/1.10.2",
+    "dest-filename": "junit-platform-suite-engine-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/platform/junit-platform-suite/1.10.2/junit-platform-suite-1.10.2.pom",
+    "sha512": "1de59ad55e382ba889603791a67159041ca8b5a0cd04e154339b6c668cfa214b42fc3ff48c3e79702be78b2cb32002dce1ab78970e5a7ced67bb1e518101c706",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/platform/junit-platform-suite/1.10.2",
+    "dest-filename": "junit-platform-suite-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/platform/junit-platform-testkit/1.10.2/junit-platform-testkit-1.10.2.pom",
+    "sha512": "ac3c2a5119b50177e85e6aa564d9165a0a5bc800195efed1c0d4c58996584f06af27f2790b699b1f4d46d43214f96e163434c84cdf4de48562c0b1236177957e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/platform/junit-platform-testkit/1.10.2",
+    "dest-filename": "junit-platform-testkit-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/vintage/junit-vintage-engine/5.10.2/junit-vintage-engine-5.10.2.pom",
+    "sha512": "cb1d5a44035a03fafe0320766bdd407866bbd0822bdeb39a7dead5bbc49080fe279b5b933f897cadee0781937359fded07d4e23a5a7d3d0bd4b4babee66f99e7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/vintage/junit-vintage-engine/5.10.2",
+    "dest-filename": "junit-vintage-engine-5.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/mockito/mockito-bom/4.11.0/mockito-bom-4.11.0.pom",
+    "sha512": "6bdf2809a5a479f73975ddb87cb102db88dac702904b89e8dcd9b9057dbbce67abb85d9cfbefda79c152d928346122eced122d2af17617772abeae0c383cc16a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/mockito/mockito-bom/4.11.0",
+    "dest-filename": "mockito-bom-4.11.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.annotation.bundle/2.0.0/org.osgi.annotation.bundle-2.0.0.jar",
+    "sha512": "f16b8983240ba3c08d6bc78e2eae92e89eb528f32a705961d90b463def0a5ed1ba08cc3d0be38b5dcfb946c6f759df772e122fb769e58e8c20aa79a489a1fd21",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.annotation.bundle/2.0.0",
+    "dest-filename": "org.osgi.annotation.bundle-2.0.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.annotation.bundle/2.0.0/org.osgi.annotation.bundle-2.0.0.pom",
+    "sha512": "124183dc93b62622a92cbecfda01d728ac7466f7192897fbdf82bdf478f03e11436493884ec7e1dc2a019df995b95804252f1f92cf152477417109feffb37871",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.annotation.bundle/2.0.0",
+    "dest-filename": "org.osgi.annotation.bundle-2.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.annotation.versioning/1.1.2/org.osgi.annotation.versioning-1.1.2.jar",
+    "sha512": "a4c612bec624a168f25f0923d51925bbc914686673eeebd5b2442998b876f05855e2b0a6e6e9aca4a6533ed3156b0d24f94c3e508ee9778e1b2e469be318afa3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.annotation.versioning/1.1.2",
+    "dest-filename": "org.osgi.annotation.versioning-1.1.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.annotation.versioning/1.1.2/org.osgi.annotation.versioning-1.1.2.pom",
+    "sha512": "9ee84aa306441dcb9c02102b5fcaa6fc024f5ce931c9b020bbc6243b7e2bd518e86128986a2e65bf101df311d37a1fe2530d3ad3f67cc6bf96fb22e51f85f83e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.annotation.versioning/1.1.2",
+    "dest-filename": "org.osgi.annotation.versioning-1.1.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.resource/1.0.0/org.osgi.resource-1.0.0.jar",
+    "sha512": "4e798790856f83f50832db80bfab64dfceeff1c509d7dde43e74a9f9192ea7a7d5ea77b9b1e81291fa6ba3dcef5ab8fa791ca8093a72a08d7ca6f6499e13e506",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.resource/1.0.0",
+    "dest-filename": "org.osgi.resource-1.0.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.resource/1.0.0/org.osgi.resource-1.0.0.pom",
+    "sha512": "300a564c775d93966a22d887d8a1fea7d4a2d1db3f1868e13538d0ea0e303b45fe6cb7994d6ac2e3965d2bf82a981cdf4cf6392209f74b1f68170979d65e3dcb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.resource/1.0.0",
+    "dest-filename": "org.osgi.resource-1.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.service.serviceloader/1.0.0/org.osgi.service.serviceloader-1.0.0.jar",
+    "sha512": "a7def4cb7a8ed992645faa80a780e0b30bd39c1587b5bcb65fe170d10842d0d880c2849edd50c64807fe0e4b9cc0051337d1b161d0d390465d9e63a762861c49",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.service.serviceloader/1.0.0",
+    "dest-filename": "org.osgi.service.serviceloader-1.0.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.service.serviceloader/1.0.0/org.osgi.service.serviceloader-1.0.0.pom",
+    "sha512": "0c971694c707dacbbf0304741ddaed4cc107f7b4c0fdfc0c6cd2a85910df10733185f14e5c3243c0dea545bca2f6a7aeeeb7c048324af5908c96fe0f5484955b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.service.serviceloader/1.0.0",
+    "dest-filename": "org.osgi.service.serviceloader-1.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.pom",
+    "sha512": "16bd0ad91a8094fb042f7c4248fcb9737f5827573d97e2c8ce84bd82a234a9247ccd9c1444cf25f5df4c379e8bcd12e732777ad2b1e2a1375bc45b8ff700b767",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/slf4j/slf4j-api/2.0.13",
+    "dest-filename": "slf4j-api-2.0.13.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar",
+    "sha512": "9a3e79db6666a6096a3021bb2e1d918f30f589d8de51d6b600f8ebd92515a510ae2d8f87919cc2dfa8365d64f10194cac8dfa0fb950160eef0e9da06f6caaeb9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/slf4j/slf4j-api/2.0.17",
+    "dest-filename": "slf4j-api-2.0.17.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.pom",
+    "sha512": "462872ccda241179a77ebc89c3f7be93870fffae344e09d3cccc33d6448336dc77affc9572f420d7da788b3f0eb072b7facc9b7e609b33742ed48f4bb467cb70",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/slf4j/slf4j-api/2.0.17",
+    "dest-filename": "slf4j-api-2.0.17.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/slf4j/slf4j-bom/2.0.17/slf4j-bom-2.0.17.pom",
+    "sha512": "cb2db4597b98b9981959413e3ffcd5882f8e267d3d51f989c396807c36893296065cbe443a173029e8d3a0851eced25f5149dc2dafa0dd2c29fca737180a7029",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/slf4j/slf4j-bom/2.0.17",
+    "dest-filename": "slf4j-bom-2.0.17.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/slf4j/slf4j-parent/2.0.17/slf4j-parent-2.0.17.pom",
+    "sha512": "5b16a209843c18a478a0a16dff83ae1c75eedbdeadc15a958d536a36631d4d39a9998e085c165a79ced8ad187f021e2f3cd4068856ca174db35657ef5a473c5a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/slf4j/slf4j-parent/2.0.17",
+    "dest-filename": "slf4j-parent-2.0.17.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/slf4j/slf4j-simple/2.0.13/slf4j-simple-2.0.13.pom",
+    "sha512": "84257236a096c2ac22fa80cc423624fc46b297bb941693c0bacef6b3ec9bf236100e8ff993f4710d17aad600da98da4378cac79129633946aa06aa9ae12c777e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/slf4j/slf4j-simple/2.0.13",
+    "dest-filename": "slf4j-simple-2.0.13.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.jar",
+    "sha512": "2e5ab51ee5e170a4ea01c1586e07610fc63fb00e51321a35d04609ca78326d4bf6b7fb3c32b45a9388349cce3c0453a20d77213e33cb9b65b8244c7c54c80e4c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/snakeyaml/snakeyaml-engine/2.10",
+    "dest-filename": "snakeyaml-engine-2.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.pom",
+    "sha512": "c5677ea77c3b2c98f54de73f1223fa13514a7d6d1bf8f42686e2a9889e40ad2a2b481a87f698cf295025aef6aaf43cbc90e6b6a05fd00c4600b797f93c78c531",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/snakeyaml/snakeyaml-engine/2.10",
+    "dest-filename": "snakeyaml-engine-2.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom",
+    "sha512": "63b0951f793ee9d25239ee44760e4d51de3b8503e438e567862306f2d175019d8617eb854bc4ee2374c39f385e0a1094c3c7097f899b2074e4acda14fe6030fb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/sonatype/oss/oss-parent/7",
+    "dest-filename": "oss-parent-7.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom",
+    "sha512": "1c4f18cacd3a9f99a168bd20845d12d94824e66b5caebe57c164b6ac3dc89803508f60e35c4d1da81d3f3866c89ed407826f0d108f1e624c2d8a258e01e1064a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/sonatype/oss/oss-parent/9",
+    "dest-filename": "oss-parent-9.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/springframework/spring-framework-bom/5.3.39/spring-framework-bom-5.3.39.pom",
+    "sha512": "3cdfeab209e770d9b555bb759c958f816a4313413f8deb4060954aa72a2170de5f2e90e6b076cd185e853cdc02f5bd7356720084c90a3cbe5847bd6d04e5017c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/springframework/spring-framework-bom/5.3.39",
+    "dest-filename": "spring-framework-bom-5.3.39.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/vafer/jdependency/2.14/jdependency-2.14.jar",
+    "sha512": "eb704fbbc780aeaf98670abe161d821867ae1fa4cd8819dd47fe5c8f2e8c54159010f1059a81d3da30d791fbe2c3aa89c44e77b8ad48d3e5793e654a184af7e5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/vafer/jdependency/2.14",
+    "dest-filename": "jdependency-2.14.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/vafer/jdependency/2.14/jdependency-2.14.pom",
+    "sha512": "b10af164ce210da787682c28e1b5cc2433a7bdb3c5941f2d6f47090cfa4e46b7dd7bbcaeba929d9e838844b53c6070f666696aa19ceb86643520ca54b4d43094",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/vafer/jdependency/2.14",
+    "dest-filename": "jdependency-2.14.pom"
+  }
+]

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     // The shared code is located in `buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts`.
     id("buildsrc.convention.kotlin-jvm")
     alias(libs.plugins.detekt)
+    alias(libs.plugins.flatpakGradleGenerator)
     alias(libs.plugins.kotlinPluginSerialization)
     alias(libs.plugins.kover)
 }
@@ -27,4 +28,10 @@ dependencies {
     implementation(libs.openai)
 
     testImplementation(kotlin("test"))
+}
+
+tasks.flatpakGradleGenerator {
+    outputFile = file("flatpak-sources.json")
+    downloadDirectory = "${rootProject.projectDir}/offline-repository"
+    excludeConfigurations = listOf("testCompileClasspath", "testRuntimeClasspath")
 }

--- a/core/flatpak-sources.json
+++ b/core/flatpak-sources.json
@@ -1,0 +1,4496 @@
+[
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/biz/aQute/bnd/biz.aQute.bnd.annotation/7.1.0/biz.aQute.bnd.annotation-7.1.0.jar",
+    "sha512": "b29e68403ff0b0cd0efacf23a466390b922ef464f79b49c25518864839a1cd86329ace0a7214c6f0ce99056019d857301994bbb71dea0c35dd94511edd789ca4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/biz/aQute/bnd/biz.aQute.bnd.annotation/7.1.0",
+    "dest-filename": "biz.aQute.bnd.annotation-7.1.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/biz/aQute/bnd/biz.aQute.bnd.annotation/7.1.0/biz.aQute.bnd.annotation-7.1.0.pom",
+    "sha512": "10ec365640b4974ecbf49e842187601d526c9110e60aaf5067884af603440a3ee261cbfd027f004c201824b1077132ab09e314a2f52af83c3a0fc4012f56ce36",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/biz/aQute/bnd/biz.aQute.bnd.annotation/7.1.0",
+    "dest-filename": "biz.aQute.bnd.annotation-7.1.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java-client-okhttp/2.12.0/anthropic-java-client-okhttp-2.12.0.jar",
+    "sha512": "1d80ac5368c4aecb89e71babc31fe2aa09b4cafc3ab2ff1894962bf94cd7c6a191410212409d32a53cf330a265258cfb6d2de10510333671691c6b89cd90fea2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java-client-okhttp/2.12.0",
+    "dest-filename": "anthropic-java-client-okhttp-2.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java-client-okhttp/2.12.0/anthropic-java-client-okhttp-2.12.0.module",
+    "sha512": "c6dfa9aa46a2ba95c11332c6e54f26329963ad4000592c40e5a7c5a1509b28df5e2fc2043b24ff0e9eb348b9babb5e9c6980d22188391da101db7c292d71f984",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java-client-okhttp/2.12.0",
+    "dest-filename": "anthropic-java-client-okhttp-2.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java-client-okhttp/2.12.0/anthropic-java-client-okhttp-2.12.0.pom",
+    "sha512": "2e4ae5314307d8dca4f49ba0cc4d46b725f34a2925833e92de97614ddd16e9ce1d8553aed325e1f65415c383461be2ae8b975cdf46ade9d56a458099ce7b635d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java-client-okhttp/2.12.0",
+    "dest-filename": "anthropic-java-client-okhttp-2.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java-core/2.12.0/anthropic-java-core-2.12.0.jar",
+    "sha512": "92af9894470d1c361d93b2b63dbc5ee16837f1416dec09905deaaad88b28c21bd9d5bd3f95b37d1ab6358f321b02fa5be8b465c92886ee642ceb90384e6faab1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java-core/2.12.0",
+    "dest-filename": "anthropic-java-core-2.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java-core/2.12.0/anthropic-java-core-2.12.0.module",
+    "sha512": "555a222f08cad026e98415ac1506f88e91fdd821122492b9a4845f8384ef267be00b7b4525c3dac87a220e3214e45ee5aff29449e6a8e8881b28b799126dca01",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java-core/2.12.0",
+    "dest-filename": "anthropic-java-core-2.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java-core/2.12.0/anthropic-java-core-2.12.0.pom",
+    "sha512": "a2044b42b95184df08aa620f89efe0273d16d80ad9e979f53039b22218198d59baf8f4a335269cc8a109fba169a7d253a1ce8b48c00f60bfbd3752b2fec440dc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java-core/2.12.0",
+    "dest-filename": "anthropic-java-core-2.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java/2.12.0/anthropic-java-2.12.0.jar",
+    "sha512": "56d346bf0d987cb3f5c837450d2bef6598f32feb7fb55efff68473eacf771ec077c0ff22a125dee87cdfd11f162ca2b69bc7ad55b10c9f35dd47155eecb110f3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java/2.12.0",
+    "dest-filename": "anthropic-java-2.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java/2.12.0/anthropic-java-2.12.0.module",
+    "sha512": "0435af5cb1b214d7f1fc45ec61c2661aa533c7d6ba886ddfae94bfc89110c40c8fca161a6271cf1e6ceb427f0734036819f70d814f4830a44343f717b57fc12b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java/2.12.0",
+    "dest-filename": "anthropic-java-2.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/anthropic/anthropic-java/2.12.0/anthropic-java-2.12.0.pom",
+    "sha512": "004ccc1dbfc9608f663182d2a6384a747f4d20d3f16095678836f9466c61f7023d54caf05c56afeacdab49a9cce000461cd12dc459922c7b12012c5725ac9e37",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/anthropic/anthropic-java/2.12.0",
+    "dest-filename": "anthropic-java-2.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/classmate/1.7.0/classmate-1.7.0.jar",
+    "sha512": "6761a0a8efe5ba89a812e49d8f7d2a9e1a100d4edd63ede79ee9a6d22758b2e2511653ea5964b4b9a2e5567ea062337ab581960acbe710aacac055770fbbcefd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/classmate/1.7.0",
+    "dest-filename": "classmate-1.7.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/classmate/1.7.0/classmate-1.7.0.pom",
+    "sha512": "8e9fa6da466091dc9292eb7deeee71ee43dbc81bb22d1183a5e8dcbf04692350128d6c4008db31080a37d7ac1da04b4b560f94a0a9cb5d4492a08ff3e86a39ce",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/classmate/1.7.0",
+    "dest-filename": "classmate-1.7.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-annotations/2.18.2/jackson-annotations-2.18.2.jar",
+    "sha512": "d375e5761052e202e409400637cdc9ce0f45cf01a90628f36ca3c81757ac30695cc6e60146cbf14685c5c50912ad932564eb794ea76ab8461ce1786a02eab867",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-annotations/2.18.2",
+    "dest-filename": "jackson-annotations-2.18.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-annotations/2.18.2/jackson-annotations-2.18.2.module",
+    "sha512": "0fc74c9f6a2ac3fd2a709fe85b5068bcd2a0185a07cf113bcd75ab7a129ef93e9da2dc6f2626fecd11901695a38e780aff5b90c853c572b3ee186d0bcf11529d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-annotations/2.18.2",
+    "dest-filename": "jackson-annotations-2.18.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-annotations/2.18.2/jackson-annotations-2.18.2.pom",
+    "sha512": "4d7832be241e3d910de7468d00fb12d10f85b6c970b7c4473ea5fc6951e69a843b2b84513bb9842e69807d4a8148a02de647801300a14d4db4019e4c87f5fdd3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-annotations/2.18.2",
+    "dest-filename": "jackson-annotations-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-core/2.18.2/jackson-core-2.18.2.jar",
+    "sha512": "2223f6d8235c6831b488dd2723a4569e4dab6c2371f0e39f867b57a3a443e093d1fce05dc070a350fa306d7e952888cb09c7c816254147b01083d122964fc3a5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-core/2.18.2",
+    "dest-filename": "jackson-core-2.18.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-core/2.18.2/jackson-core-2.18.2.module",
+    "sha512": "8f95c7940be185d209864af410d88b84787a05d38195ae0a9e1afb65443a7133bcfd26e6638a034839593db8638023b1a848ba36365281916acc4af8fe9d3a31",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-core/2.18.2",
+    "dest-filename": "jackson-core-2.18.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-core/2.18.2/jackson-core-2.18.2.pom",
+    "sha512": "4f72d09f9f6adfd344914f6bc535468e4e53d3789f72e728df886691b5626707062de6cdc056d6034cca56e757ddb4b78f6dbfa94c003d7f3476c98907ae9575",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-core/2.18.2",
+    "dest-filename": "jackson-core-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-databind/2.18.2/jackson-databind-2.18.2.jar",
+    "sha512": "bbdfaaffaaab2a032a754cd9dade06552e9f79fd39ae396873315415219b37e0675fde0a02953efe0701e17be4c282b118a96fcb752f53ca37ab89624f0a52ac",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-databind/2.18.2",
+    "dest-filename": "jackson-databind-2.18.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-databind/2.18.2/jackson-databind-2.18.2.module",
+    "sha512": "69ed0c95a48335d66f15935c3290c0bbeea6f09a870063112de5858ab06b943eab965c58ff40f19c951c0415924947a4fc5091c61d59e58c55816cc17aeca8b2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-databind/2.18.2",
+    "dest-filename": "jackson-databind-2.18.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-databind/2.18.2/jackson-databind-2.18.2.pom",
+    "sha512": "026780d41cf9089c6904d5cc803de65a69c089cc9c337d0c0b27cd2a170149ce1c4f2ee43994ec8573207410edb50c1e5a6bd0e2fc53deb0f2c8881d50d6162c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/core/jackson-databind/2.18.2",
+    "dest-filename": "jackson-databind-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-avro/2.18.2/jackson-dataformat-avro-2.18.2.pom",
+    "sha512": "f04275e22fb184679bd0ffb375c1fa9fc221c3c6e760c7ebdf1de33eb8ee8d605512f8b7a2b1b8cecd47e90e8c41af9cb34632783f1bb9dbb90ede20fa4a537b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-avro/2.18.2",
+    "dest-filename": "jackson-dataformat-avro-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.18.2/jackson-dataformat-cbor-2.18.2.pom",
+    "sha512": "1622cbde549edd55618ac28c83be83fac64a881945308bbed282e3bf38b85a6afa901f96bb7266452352e50c12ccaef0e2525dd4786da8c876b7b92dccff6c83",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.18.2",
+    "dest-filename": "jackson-dataformat-cbor-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-toml/2.18.2/jackson-dataformat-toml-2.18.2.pom",
+    "sha512": "099f6b2db55122caa48060e24df1e6394c7347c13ef0c4b061255018a4de2ae8183ca145de0c04e8a77263f7fd8ddab21ba97a21ba3991fe67d4fe44f135afe1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-toml/2.18.2",
+    "dest-filename": "jackson-dataformat-toml-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-hibernate6/2.18.2/jackson-datatype-hibernate6-2.18.2.pom",
+    "sha512": "50d7ecf05132b2d27417c58cbcd567c0fa5b451e855f273880a1ef1ec89a8e37a228a8ef0528fecc649411077763abe433986c5fe510d799d60710f69f6a5f77",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-hibernate6/2.18.2",
+    "dest-filename": "jackson-datatype-hibernate6-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.18.2/jackson-datatype-jdk8-2.18.2.jar",
+    "sha512": "50b79ee59b1f98b607978adcfbcd339f7c260b8f9717c91527fcfb51440509750c5da6afdf595d84a28dbe93c2a53115383a84c139a9f0293bbae64d7f0fb166",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.18.2",
+    "dest-filename": "jackson-datatype-jdk8-2.18.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.18.2/jackson-datatype-jdk8-2.18.2.module",
+    "sha512": "4dafd4b958d79892271ecf9fb8bbb369b9060c887b19bf3772584cb52ce661818b1c5257319c04da8a698f24593c430cfe19f67dc1de11e734fea4a31e131a0d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.18.2",
+    "dest-filename": "jackson-datatype-jdk8-2.18.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.18.2/jackson-datatype-jdk8-2.18.2.pom",
+    "sha512": "5f141872be9e847f070d496c32cf0e83632dd6d54347aa450d713e27a7fbfe34b29a1a93f0791fa3ca841b48e4d6b27bbde17a098d0fc6a1b9f7c1a40d12c0b0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.18.2",
+    "dest-filename": "jackson-datatype-jdk8-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.18.2/jackson-datatype-jsr310-2.18.2.jar",
+    "sha512": "bc1cb3e193996ba0b876baefa99122672bbe617f2de582f5208609efb1bb5886832857406de5b0fd7969fce8c07dba0a672b3f077bac2f7efbc3d0cc252c1ee9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.18.2",
+    "dest-filename": "jackson-datatype-jsr310-2.18.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.18.2/jackson-datatype-jsr310-2.18.2.module",
+    "sha512": "25e5fd0ac798db663c689bc5b382730a3a4b280e7a3db287ce6343f31423a2035c69d9b6c3f041a083940b527974df57083d25dae699846b249fdc7841fbf7c8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.18.2",
+    "dest-filename": "jackson-datatype-jsr310-2.18.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.18.2/jackson-datatype-jsr310-2.18.2.pom",
+    "sha512": "457c0e5cde43e3f8f3f3a2fee0e13dd2f5bb3d3aa9187e227f399bd18788c50112cf7c36f5277f95cf9c2aac08369ebfb5da7d378585e8f037e1b302dbb8ebf4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.18.2",
+    "dest-filename": "jackson-datatype-jsr310-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-base/2.18.2/jackson-base-2.18.2.pom",
+    "sha512": "06f50257724de15b301001e01bfba6daf5dffb361b98989deef27940c8e104419e25bf677f4135e8bd095d4019d20c31c797aa04ae5c916d967395c3336e429d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-base/2.18.2",
+    "dest-filename": "jackson-base-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-bom/2.17.2/jackson-bom-2.17.2.pom",
+    "sha512": "f05a8b021a85f86e760ec291eacd3bc1b76dbc0aadeecaa32394c689a21660c26a0fb72eeaca3c982e04306e3b962aec0bcad3e282ab51b12ed7bd33030f3e10",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-bom/2.17.2",
+    "dest-filename": "jackson-bom-2.17.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-bom/2.18.2/jackson-bom-2.18.2.pom",
+    "sha512": "1621725b517af085cbca45fd123905e1d1ccca34c3c6555ed86ed0e1425229db9e650bc4681b05ac4b91bb366726001115bcac88ddd5ce1fb69bfea2f116e87c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-bom/2.18.2",
+    "dest-filename": "jackson-bom-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-bom/2.19.1/jackson-bom-2.19.1.pom",
+    "sha512": "4a2c1a8b9a99049b80dccb672cdff0c7de7223401edfae708d9c5a217bbcef86f424f3099bf83dd47c036137129d52066a1ba332ac022ca4c7bf55e87b694933",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-bom/2.19.1",
+    "dest-filename": "jackson-bom-2.19.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-parent/2.17/jackson-parent-2.17.pom",
+    "sha512": "889bce47f091857fa87083867de570a4fb4e2f20e0a409aee77fa6ae962d15239287edcabed19488459cb5cedd7e3a5d817634085ead9b75e0cc367809d2e9f9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-parent/2.17",
+    "dest-filename": "jackson-parent-2.17.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-parent/2.18.1/jackson-parent-2.18.1.pom",
+    "sha512": "f8e24c8676736bb78c4a46a68e6042b78a86b99470790ccc549e2609063a4b725a37df51901d8c0d9da5c24c5cb4c27af1139a248e38e3bf7f88e428a9bd0d6d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-parent/2.18.1",
+    "dest-filename": "jackson-parent-2.18.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-parent/2.19.2/jackson-parent-2.19.2.pom",
+    "sha512": "8c4a0dca3ed71ca97d44ea6665025a4d3059d9ac64f6065e7cfa4a51ef7dd45c7cee374157148e3a07aa0cf0532dc9b22486bf3805bae5025c139e299b112f0a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/jackson-parent/2.19.2",
+    "dest-filename": "jackson-parent-2.19.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-kotlin/2.18.2/jackson-module-kotlin-2.18.2.jar",
+    "sha512": "7e2ef964be79568f13992f9a8108921471809796801b7b0ada6cbf481f6109fade9e7dcdef908b66c95f7dde336bcc8bef1dbe2a6862fae9956b0b1cdd0d807a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/module/jackson-module-kotlin/2.18.2",
+    "dest-filename": "jackson-module-kotlin-2.18.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-kotlin/2.18.2/jackson-module-kotlin-2.18.2.module",
+    "sha512": "d1844414f38814634d60830936b9ecf067f4cab12206797afc1f6886bd7d049152a8d6ca5b70e2b8bbf6c93583b119fe3ec966fa48d720e7d5af1fdbbef61b7b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/module/jackson-module-kotlin/2.18.2",
+    "dest-filename": "jackson-module-kotlin-2.18.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-kotlin/2.18.2/jackson-module-kotlin-2.18.2.pom",
+    "sha512": "d0dc61d6e2646950a4fb4dd5356795d2757d469c3520025c29220d43cb24f0eecc5cc1e62085d8b4bc6efea86d0f65f008bef15c772e9c81101c095e0100fa4f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/module/jackson-module-kotlin/2.18.2",
+    "dest-filename": "jackson-module-kotlin-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-modules-java8/2.18.2/jackson-modules-java8-2.18.2.pom",
+    "sha512": "d82f9a41ca67065610927e3667f2d8eeb05e2702b394b0d035c376947ad71dadb2c1172445179a2f3b0fcf0e901d954e7d3755e615091085ace0f4578ae8c967",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/jackson/module/jackson-modules-java8/2.18.2",
+    "dest-filename": "jackson-modules-java8-2.18.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/oss-parent/56/oss-parent-56.pom",
+    "sha512": "15c6a21926b0ee0172ed9544bf2cd8154ce96ea85f42a89e1fa29e3571ceb736879298763efac5e0e6541c81bd1877513a41bff6cb91ecf8e0fd8f957ba490b8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/oss-parent/56",
+    "dest-filename": "oss-parent-56.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/oss-parent/58/oss-parent-58.pom",
+    "sha512": "8b56185b2d67a26d95e913a1a613083cd0499ea03b4036796542ea7a8beabb6f5182f83596856425deb6b16826bb3d1672b4d4204fb9f351c01e3ef8e5e9d39b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/oss-parent/58",
+    "dest-filename": "oss-parent-58.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/oss-parent/61/oss-parent-61.pom",
+    "sha512": "24731b163cd4c1a3758c0dd8d743937fa1b36d37a58ca60d5487fc48d3e46e4c33b8e1374ee2952be972ff1c9a2fc8c551edf207f2d7fb312dafc33901316271",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/oss-parent/61",
+    "dest-filename": "oss-parent-61.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/oss-parent/68/oss-parent-68.pom",
+    "sha512": "7c9d51b7fd00d0ea30d00d048ce2e9ab3ec1bae3073f9f52d034a66572d5e6680992e42695e649d826c1a3f4b8f089460df8d2549afd15afe45488b6f9984528",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/fasterxml/oss-parent/68",
+    "dest-filename": "oss-parent-68.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/hypfvieh/dbus-java-core/5.2.0/dbus-java-core-5.2.0.jar",
+    "sha512": "f774fb5c55312ef13f9c31d5115330d318ab93a484e8b52a06b16f60b6e226a67a1732d3bb565397ecd6fe94e8bbe19b16b04df37b68d6aaf466832427445275",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/hypfvieh/dbus-java-core/5.2.0",
+    "dest-filename": "dbus-java-core-5.2.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/hypfvieh/dbus-java-core/5.2.0/dbus-java-core-5.2.0.pom",
+    "sha512": "f36b2cc09392300347d168423e4d6af9a605fb4849814a96338c121f8ad67b7826bde35f753b71144bb0fcf171d061fc64c718c5f0731c42b505e05741f47a4d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/hypfvieh/dbus-java-core/5.2.0",
+    "dest-filename": "dbus-java-core-5.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/hypfvieh/dbus-java-parent/5.2.0/dbus-java-parent-5.2.0.pom",
+    "sha512": "a7c89a9ac5c62bef0a3e96dad4d2fb36380498c5eb2b49806c8bc99866a75af01933d54b4b56caebbc9d6a2d74c7ca9e8d04dcd3b6e5b82f5ed47924f223fa6f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/hypfvieh/dbus-java-parent/5.2.0",
+    "dest-filename": "dbus-java-parent-5.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/hypfvieh/dbus-java-transport-native-unixsocket/5.2.0/dbus-java-transport-native-unixsocket-5.2.0.jar",
+    "sha512": "65f952e1f9789a1765b5c62d1a144019434ae8d9dd86fb894b1231735a383cd3be4226fa9f7b4c3363277676437a96f1f7264b7ad421ce2d5355e8c66f676f2f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/hypfvieh/dbus-java-transport-native-unixsocket/5.2.0",
+    "dest-filename": "dbus-java-transport-native-unixsocket-5.2.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/hypfvieh/dbus-java-transport-native-unixsocket/5.2.0/dbus-java-transport-native-unixsocket-5.2.0.pom",
+    "sha512": "e1a7b87c86b7c23aed5a8f5b4c75d3f3694bd050dd7a06c3604e6dbdae1295c1d651b42fa4be9645382a7f1c5f5007693eb35a16d84dd36416d228a8d2b26464",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/hypfvieh/dbus-java-transport-native-unixsocket/5.2.0",
+    "dest-filename": "dbus-java-transport-native-unixsocket-5.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-generator-bom/4.38.0/jsonschema-generator-bom-4.38.0.pom",
+    "sha512": "21b1eeb12b77a34e362698c9d1a57c7227af3568edbae169db56dc96326135dbdab84ad5daff460ce957dc622c93bba1e661104749ab96bdcff397a760fa136f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-generator-bom/4.38.0",
+    "dest-filename": "jsonschema-generator-bom-4.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-generator-parent/4.38.0/jsonschema-generator-parent-4.38.0.pom",
+    "sha512": "4684a3bcf6d99aa90ee382b960ecc82fabe2d349d7a7d9cf8046ac8dad0686e5b2f79854992d901bc318e325c594e9b5f1a1f316a8d2f3db72370f792724692e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-generator-parent/4.38.0",
+    "dest-filename": "jsonschema-generator-parent-4.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-generator/4.38.0/jsonschema-generator-4.38.0.jar",
+    "sha512": "78da88c528d51314e1e2a69ed197671e8d37c676dfc715513859c4735decddab38c0a75a7f4eefd42659f69b8553b7d928b93358a5bc486db2bd01fa57774b85",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-generator/4.38.0",
+    "dest-filename": "jsonschema-generator-4.38.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-generator/4.38.0/jsonschema-generator-4.38.0.pom",
+    "sha512": "44649d6680cab5eab9795630f72d2019c4eb69fa4c12feddf6155c359a91abd3d586403fea9ed6e12a616f7d702443f5d523261a6a2eee3460d86318515cddd6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-generator/4.38.0",
+    "dest-filename": "jsonschema-generator-4.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-module-jackson/4.38.0/jsonschema-module-jackson-4.38.0.jar",
+    "sha512": "d2d3b08a3367a0f35ae774aab0f90c77954dea5d5664105126e509643c63a5fbc471b88def4f0f3eb7d1a9585050521e914f6c34e92f8fb533ab9de318952903",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-module-jackson/4.38.0",
+    "dest-filename": "jsonschema-module-jackson-4.38.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-module-jackson/4.38.0/jsonschema-module-jackson-4.38.0.pom",
+    "sha512": "3492082adb84ec7953d2f105263fbe8371d94013734a3b9215ef0e1b37606a92dcc56af723e0c4a76736901b74b6015e6a7e95195c0b44eb6930494dbb4d5216",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-module-jackson/4.38.0",
+    "dest-filename": "jsonschema-module-jackson-4.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-module-swagger-2/4.38.0/jsonschema-module-swagger-2-4.38.0.jar",
+    "sha512": "0c5ff0fe4582262bdf16c47ecbf1d8cc384dd66252089345a3a3815a48b51ff3d143953c03d8a6022559da5fff016201550ee6f2d697eb2bf7e500fa10c3dde6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-module-swagger-2/4.38.0",
+    "dest-filename": "jsonschema-module-swagger-2-4.38.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/victools/jsonschema-module-swagger-2/4.38.0/jsonschema-module-swagger-2-4.38.0.pom",
+    "sha512": "59ab50f711ac91e418c4d4e2ab637b8bbc6945463444f0b9dd5a4feb0abe846c8f12999643f6665d6aa8370762445c34cd95ad1bf9a712bcbda8362525c8e8bd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/victools/jsonschema-module-swagger-2/4.38.0",
+    "dest-filename": "jsonschema-module-swagger-2-4.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.1.0/stargate-0.1.0.jar",
+    "sha512": "0a965471e65b0357e44670cd0c111c1716f6751c77566aa65a7a3023458ef27ca1d05d539ccb4e49d2a5ba85c47b70556df08f7aec522b50a5ca6bc7d915dfc2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/zugaldia/stargate/0.1.0",
+    "dest-filename": "stargate-0.1.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.1.0/stargate-0.1.0.module",
+    "sha512": "0626ce5c21f14e123c2c8e0eb24853d83ca42f28dab7c687887e385f1839f64d6392186f8d35c49c0ce5d4d0bd740494711aa70bcf298cf38e0b4384d899747d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/zugaldia/stargate/0.1.0",
+    "dest-filename": "stargate-0.1.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.1.0/stargate-0.1.0.pom",
+    "sha512": "b194bf0af4e00608be82ecbd86253114af7c1e4390ff5eb3824566c2ed43908a109792558212bfc2c867cb9748d10171c1499fcd0c1bee44de1a706baf70c81f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/github/zugaldia/stargate/0.1.0",
+    "dest-filename": "stargate-0.1.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/api/api-common/2.45.0/api-common-2.45.0.jar",
+    "sha512": "3c61e1b4ebfe6b19b1c3ba7c0d674e59083cc50866fd91131525c57d57b1f4ac1bc01a6330223648a18ac98aca449843b1a412fcc4c7b345e965a2c4b78da82a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/api/api-common/2.45.0",
+    "dest-filename": "api-common-2.45.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/api/api-common/2.45.0/api-common-2.45.0.pom",
+    "sha512": "f01260b0ee1198f0cd9d548aef56a73dd446462cc74505bac670063139c3fad29fd8b7d3dabe3431e979583ca55bc8b9c450b219548b78812a05fd867a6c2b12",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/api/api-common/2.45.0",
+    "dest-filename": "api-common-2.45.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/api/gapic-generator-java-pom-parent/2.54.0/gapic-generator-java-pom-parent-2.54.0.pom",
+    "sha512": "1365d798c2b1ccff6ed3528b3ccba984213cff7a4814eeb05571bc1e6774e411da5ff2a1fe6386d38ed4055cc05e0397262663841eb94db0ce1d4252cc29f90e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/api/gapic-generator-java-pom-parent/2.54.0",
+    "dest-filename": "gapic-generator-java-pom-parent-2.54.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auth/google-auth-library-credentials/1.33.0/google-auth-library-credentials-1.33.0.jar",
+    "sha512": "767012b41b0b7f384c42423aed282c09ee11d0e663ac28100206fc65665990b38b165fd1566a32b835581dc7c380e5db51e2d402eafbf89b18f72f1eb6c86422",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auth/google-auth-library-credentials/1.33.0",
+    "dest-filename": "google-auth-library-credentials-1.33.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auth/google-auth-library-credentials/1.33.0/google-auth-library-credentials-1.33.0.pom",
+    "sha512": "173cb50ca30b394d7b0416bf54aff41b13bab525072658cd2f87c1d1a32da8221f3b8132203c7e98c12c07e39d29709f726cfd6404e207aa5ad906e054d84ffe",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auth/google-auth-library-credentials/1.33.0",
+    "dest-filename": "google-auth-library-credentials-1.33.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auth/google-auth-library-oauth2-http/1.33.0/google-auth-library-oauth2-http-1.33.0.jar",
+    "sha512": "9215321a579668ed7b0e3700010d2d3a06dafe19b965861d3ae5b994740b2c65f84de186106133e0d689c4d45f9b9fff2faecf427a40c61ea7bb6ff80e21996f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auth/google-auth-library-oauth2-http/1.33.0",
+    "dest-filename": "google-auth-library-oauth2-http-1.33.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auth/google-auth-library-oauth2-http/1.33.0/google-auth-library-oauth2-http-1.33.0.pom",
+    "sha512": "00cb1e7dc13e42ca0fc4f4fac6da4a643d8ee2c749a46b914777fd282ec2e9f634f6be5dbe09a3a307f4f17c1ad0c8f7216ac459b085def717d162f1f3228a8b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auth/google-auth-library-oauth2-http/1.33.0",
+    "dest-filename": "google-auth-library-oauth2-http-1.33.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auth/google-auth-library-parent/1.33.0/google-auth-library-parent-1.33.0.pom",
+    "sha512": "f12a18a8f80198aa8722d8744cd0f926655c7892478b875583af1ca47922ada2b187971cc71e9b2afaddbfabafe62c6c0598b6049606e9f4d17f5d195e281002",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auth/google-auth-library-parent/1.33.0",
+    "dest-filename": "google-auth-library-parent-1.33.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auto/value/auto-value-annotations/1.11.0/auto-value-annotations-1.11.0.jar",
+    "sha512": "339742a85491c0fe529e97668cd86d9c3a7a80061d226e1a51eae45fb9c466e10ee2a4d4fc3b502b96aa473ac4e03850aef8a3b744d3972a934b279ceb80816e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auto/value/auto-value-annotations/1.11.0",
+    "dest-filename": "auto-value-annotations-1.11.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auto/value/auto-value-annotations/1.11.0/auto-value-annotations-1.11.0.pom",
+    "sha512": "93e3171b6ee7078400896bd975f245cf4fcbe8375bd12e73f3be07ffdf19f06d0c5e0d49ef2ba1186f5524a6f586cbca8501e177d1504100c910e95722fe0d5a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auto/value/auto-value-annotations/1.11.0",
+    "dest-filename": "auto-value-annotations-1.11.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/auto/value/auto-value-parent/1.11.0/auto-value-parent-1.11.0.pom",
+    "sha512": "f8e40aad8ade476e8c779a97948816309ca6cd9620324e138b8db1f189fd25f0f3e0a50b6921a48b6c0693513e38adf08520af0207e0fc3beccaec9f8877045e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/auto/value/auto-value-parent/1.11.0",
+    "dest-filename": "auto-value-parent-1.11.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/google-cloud-shared-config/1.14.3/google-cloud-shared-config-1.14.3.pom",
+    "sha512": "72a483cc8da9fe1d982e00e24ad94e7e5e225fdba0692856d8276807e832f90861eb7fd5a04e1c4018ed8b4d9c73bd97511a4ddd75869d949ee505874756267b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/google-cloud-shared-config/1.14.3",
+    "dest-filename": "google-cloud-shared-config-1.14.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/google-cloud-shared-config/1.14.4/google-cloud-shared-config-1.14.4.pom",
+    "sha512": "97652c65ccf8e1c827b7e74e97de6e93659de130b9d8f32f141f9a611b7f02ae8ea921d4378d3104bc66e143db6e7060679ae70a82ace7eab5a9bebcb39a8df3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/google-cloud-shared-config/1.14.4",
+    "dest-filename": "google-cloud-shared-config-1.14.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/google-cloud-shared-config/1.15.0/google-cloud-shared-config-1.15.0.pom",
+    "sha512": "a8fdf3d5375862b6d642502c8fb8fb79ce963db6ae8d8e1f289955bb0cb7c96e195524e6ed7cc081442800a05936a24aa7df6660efefbf71eff6b98b3a944811",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/google-cloud-shared-config/1.15.0",
+    "dest-filename": "google-cloud-shared-config-1.15.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/native-image-shared-config/1.14.0/native-image-shared-config-1.14.0.pom",
+    "sha512": "bb179c7d390d44f347a47df474853343bb758a565afee1924a9f40714ade8812828fe496f9db3094c52e17f0119baa8f6159ba1bb8f7d3fda8e1e7cc51cbe237",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/native-image-shared-config/1.14.0",
+    "dest-filename": "native-image-shared-config-1.14.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/native-image-shared-config/1.14.3/native-image-shared-config-1.14.3.pom",
+    "sha512": "2ab6223b327619f56776c815507c7e1cd19551e63405252c1b2ff25e44468211d12c23f3363288d134e0db9a90a65508029d081f914137a4f96b997e21514f3a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/native-image-shared-config/1.14.3",
+    "dest-filename": "native-image-shared-config-1.14.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/native-image-shared-config/1.14.4/native-image-shared-config-1.14.4.pom",
+    "sha512": "cd2823bb0a8dfc64ebbc9a9c11bb9d3ce564c767f251df9dadcdcc6cbcee518c0896e43337520b73d764154c030601a1a0e0e3bd75373d577edb00e4ea8ed851",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/native-image-shared-config/1.14.4",
+    "dest-filename": "native-image-shared-config-1.14.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/native-image-shared-config/1.15.0/native-image-shared-config-1.15.0.pom",
+    "sha512": "b6cba2b6a2277d27207b936cf6aea934d9dc815783fb49bc3dfa2f7f22b868cc7aa8aad9eea86df1935ccd3f98ad450a9dd73ee7dd4b34141f0c86ae8ccb1cc3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/native-image-shared-config/1.15.0",
+    "dest-filename": "native-image-shared-config-1.15.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/cloud/sdk-platform-java-config/3.45.1/sdk-platform-java-config-3.45.1.pom",
+    "sha512": "c7095ae6e78c848d34df976ebfeae3bc5485696b9eba226c33793ca12238aaff647b494474e14d8cb553f95eb4e512dd143e654f2bb52b8d90ce143d4e6a1f58",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/cloud/sdk-platform-java-config/3.45.1",
+    "dest-filename": "sdk-platform-java-config-3.45.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+    "sha512": "bb09db62919a50fa5b55906013be6ca4fc7acb2e87455fac5eaf9ede2e41ce8bbafc0e5a385a561264ea4cd71bbbd3ef5a45e02d63277a201d06a0ae1636f804",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/findbugs/jsr305/3.0.2",
+    "dest-filename": "jsr305-3.0.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom",
+    "sha512": "08e1cc341a153f64b670d87831eedfe79a150b8fb7e3a4afbaef54deaa28d2767ae86d12b4f0c5404184360ab8e48a3655e610f3bf2fe6c97a06e9fc3df49b37",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/findbugs/jsr305/3.0.2",
+    "dest-filename": "jsr305-3.0.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/gson/gson-parent/2.12.1/gson-parent-2.12.1.pom",
+    "sha512": "e099a89999f863e95465baceeba2490fec16032a4eedf0955e3ec230ede9d5e2e6658a3f527a34a651ff3f3121713148e4afd4a03a97f8b0e145f152dae199b7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/gson/gson-parent/2.12.1",
+    "dest-filename": "gson-parent-2.12.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/gson/gson-parent/2.13.2/gson-parent-2.13.2.pom",
+    "sha512": "e6524dbb8aa13707fa51df7413a8b247a4de248812e212702e4e5888d0df29c6ebe39a3b1e09aefb12a1a095c42d19d074756a30918bfc4c1fe55c39b9a7c1fa",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/gson/gson-parent/2.13.2",
+    "dest-filename": "gson-parent-2.13.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/gson/gson/2.12.1/gson-2.12.1.jar",
+    "sha512": "fafc369544e2d4a89f32c353dcbd012410a64a315a3cae9165d4ead6f8960aef5f77ced84c374d6a09af117748adca571b0426eb0e2864f584debb59707ebc03",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/gson/gson/2.12.1",
+    "dest-filename": "gson-2.12.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/gson/gson/2.12.1/gson-2.12.1.pom",
+    "sha512": "49aca8b17b4b4377dd358a356aec85d2105b5c8fca2a88fd4f5b5454a7f7e952980e0754e070adfa7136d01b9442c6efacc989c8a25d9928267c9fe3e869c61f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/gson/gson/2.12.1",
+    "dest-filename": "gson-2.12.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/gson/gson/2.13.2/gson-2.13.2.jar",
+    "sha512": "8974a052656d2e5ec968b6bac2edf51413ffc62040fdc65f14f00597e738ab544d22487f8579ba90618b5a7f94ef33773510fac67b408fee6ed274b38f3d9947",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/gson/gson/2.13.2",
+    "dest-filename": "gson-2.13.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/code/gson/gson/2.13.2/gson-2.13.2.pom",
+    "sha512": "c0d089089bf0d6bcfae008f329dcc2db2538d02654f8bc7690cb8db2ec94fe0d2aa069ac1d70a111a28cced0ffd7742ac8db29a884d64d9413ebf9b2af5dab82",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/code/gson/gson/2.13.2",
+    "dest-filename": "gson-2.13.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_annotations/2.36.0/error_prone_annotations-2.36.0.jar",
+    "sha512": "bd6f5650902526d3db06aa1cc7bd36723658166acfabb823aca27d0b2c3814e83ae24a8217ce915c3e194c2c696a102580b4c21ef5dba61f7610bcb8d580f566",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_annotations/2.36.0",
+    "dest-filename": "error_prone_annotations-2.36.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_annotations/2.36.0/error_prone_annotations-2.36.0.pom",
+    "sha512": "0c1d663f70a1bec083cdd007b1ee673df144bbfbd4d065c7cad0edba8410bcd1f578902133155a534a1506a82d6a6aa211b4e6c907c4df25b0da4c781caa9008",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_annotations/2.36.0",
+    "dest-filename": "error_prone_annotations-2.36.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_annotations/2.38.0/error_prone_annotations-2.38.0.jar",
+    "sha512": "b13fdb7e06ec1f12ea1d63b0ff942c239e4decb391d736a1f7d46c9aa9e2744e9391be4398a02a78d551a96969622e65b75bbd31e5bf67a5938716765f451f3a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_annotations/2.38.0",
+    "dest-filename": "error_prone_annotations-2.38.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_annotations/2.38.0/error_prone_annotations-2.38.0.pom",
+    "sha512": "acf440b0491fb1f1a48562479254642941f1f98a09f0aa9d204ba55c79cc4a335ca0e7717ad11812518e19f041b76f2bb3a761132cb1d865426157d89d81027d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_annotations/2.38.0",
+    "dest-filename": "error_prone_annotations-2.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_annotations/2.41.0/error_prone_annotations-2.41.0.jar",
+    "sha512": "e2eb4bf9f36f95a4d4c5ea344db5cd90a456e63bef8e52932b8f6f4ecfdd59cb2f6c2ce9e67b0070c82177e42885688b95afef591b16001f789b378f18afdf30",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_annotations/2.41.0",
+    "dest-filename": "error_prone_annotations-2.41.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_annotations/2.41.0/error_prone_annotations-2.41.0.pom",
+    "sha512": "07bb0fc1b8659cd8c9ffb49563d4ec5f86bb30f5515eb6951e272de83e64670b0490f2e40b33ff6673f0d603719430c3378630478686d5849242028285204cdc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_annotations/2.41.0",
+    "dest-filename": "error_prone_annotations-2.41.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_parent/2.36.0/error_prone_parent-2.36.0.pom",
+    "sha512": "8157ba706ab6932cb428ebd295693477491a7439341c95994f492a10cc3b3222b30a3777e61a9f208fcd1623fc613a3a7fd3cc22c95c56c64e3dbb9d3ca5aeed",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_parent/2.36.0",
+    "dest-filename": "error_prone_parent-2.36.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_parent/2.38.0/error_prone_parent-2.38.0.pom",
+    "sha512": "d2fabe3762adddea6b7696d8f18246eb22e6d0a873fa7e5073f631053742e7d8884ceedf2fa7059488cc644e53fac788184d773bd028ad9ccedf1961cb5392ba",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_parent/2.38.0",
+    "dest-filename": "error_prone_parent-2.38.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/errorprone/error_prone_parent/2.41.0/error_prone_parent-2.41.0.pom",
+    "sha512": "ab85819cbab15554b3dbc1fd75eac6a13440178ee8c92a2b0fceeecac970f464d3aafc017842a2f7a692d15e7875389eb31ae9c0e08844990d7104f6c2f23f2a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/errorprone/error_prone_parent/2.41.0",
+    "dest-filename": "error_prone_parent-2.41.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/genai/google-genai/1.37.0/google-genai-1.37.0.jar",
+    "sha512": "b9925cfc8a9c0b677d7fa6c0bce5ed5e9badfa26af666faf674be744643ee044c690bdc3ffad41d757b5e4a16b4559487c367975cc61ad51fc3f93541d33bc7a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/genai/google-genai/1.37.0",
+    "dest-filename": "google-genai-1.37.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/genai/google-genai/1.37.0/google-genai-1.37.0.pom",
+    "sha512": "441ae61bf9f9bc9695cbb609c76300c652a44036490a1117d9684bccca17ca1cf46cbbb126414197b0ecdaef58d4f69b394a84f16f9f1c2f574b0b6984b203ea",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/genai/google-genai/1.37.0",
+    "dest-filename": "google-genai-1.37.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/failureaccess/1.0.2/failureaccess-1.0.2.jar",
+    "sha512": "ff4ee76aa661708989d53d45576cff3beea9ebbd86481dbbf2ee8c81bb22f882097b430588312b711025f0e890f22c6799d722ccd422a6a7278de08660fe2f51",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/failureaccess/1.0.2",
+    "dest-filename": "failureaccess-1.0.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/failureaccess/1.0.2/failureaccess-1.0.2.pom",
+    "sha512": "4e5144a31143d0ee374dc323752d57c28d7a0117abcf75a67397ba1a26c93dcf2c248c357d52c4ce75e2fe7c366df909a0a77db5775cc30c92c4e72a433566af",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/failureaccess/1.0.2",
+    "dest-filename": "failureaccess-1.0.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom",
+    "sha512": "1d786f14fbfa5c90eedcc160d1e0a71acb2141f372049b22ce62b0bd1e883c17cc24a59dc8b00e5037e959cccdb54d4d8dc8f252302d4bb7ce82dfdaff764476",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/guava-parent/26.0-android",
+    "dest-filename": "guava-parent-26.0-android.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/guava-parent/33.4.0-jre/guava-parent-33.4.0-jre.pom",
+    "sha512": "0182ac06632a0d7e9329d101b1e2a18b27f34eae0f83f24c195d76d4a9ffc6fcc3ba0a74d1abfae630a399d956135a02777832782d0b7b292565801554927dba",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/guava-parent/33.4.0-jre",
+    "dest-filename": "guava-parent-33.4.0-jre.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.jar",
+    "sha512": "778bd20c3ad83dd17d742368814cf97f28f3ec5723ef952a634290dbe0b4ced8c2a8f878d710fed10223d4393c510df39583c78921c592f605a0bb7003d98f84",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/guava/33.4.0-jre",
+    "dest-filename": "guava-33.4.0-jre.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.module",
+    "sha512": "435bb752f9daa0c25c8e3a8e5c87313c47cd7e2c6a6cb859a6d642f5ca9ec97e3b3a4dd62260fe022011d2b71e1866263e61b830317aaa8fcafd1af81457972f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/guava/33.4.0-jre",
+    "dest-filename": "guava-33.4.0-jre.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.pom",
+    "sha512": "7117b4c5001f3bee46475748299c19f3df4a0645f875770a1468261ee49705d2bb889efad52e8594e7c8bea5377cbc82fd404efe5c7a2911c3f1f06818da630d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/guava/33.4.0-jre",
+    "dest-filename": "guava-33.4.0-jre.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+    "sha512": "c5987a979174cbacae2e78b319f080420cc71bcdbcf7893745731eeb93c23ed13bff8d4599441f373f3a246023d33df03e882de3015ee932a74a774afdd0782f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava",
+    "dest-filename": "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom",
+    "sha512": "140544970539199c860d5e7e2d8096bbccd55980602773f29e8d74ab4f3e24c43aa369b0c7d06b026ba7a9db3353be285d7ffb9cd94b2bedf62820c3fdfd1d5f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava",
+    "dest-filename": "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/http-client/google-http-client-bom/1.46.2/google-http-client-bom-1.46.2.pom",
+    "sha512": "35e013584b8b70f38c89fad7b26abb2f899172f680509d8a239d8fea990e587ea409c51335e1f346a6b0dcf351eb485bd52d6274fa019fd415f1e7563268af7c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/http-client/google-http-client-bom/1.46.2",
+    "dest-filename": "google-http-client-bom-1.46.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/http-client/google-http-client-gson/1.46.2/google-http-client-gson-1.46.2.jar",
+    "sha512": "c964c5c1425309916153ffa889113d61412236632bd7dc3607fe1cb5b5439e0bb57ba8b95caf88090d8aa739874b9ba9a95019e268b6076786a14f93d44548be",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/http-client/google-http-client-gson/1.46.2",
+    "dest-filename": "google-http-client-gson-1.46.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/http-client/google-http-client-gson/1.46.2/google-http-client-gson-1.46.2.pom",
+    "sha512": "80ac890bd8bd1ea33465f9311ee3e97203bd390833090bdbc1131601b5ea3b3179fb191b62f6617ff9cfcc6022354197b6a11f7bb58aab4ff703d6a20fb69b5e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/http-client/google-http-client-gson/1.46.2",
+    "dest-filename": "google-http-client-gson-1.46.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/http-client/google-http-client-parent/1.46.2/google-http-client-parent-1.46.2.pom",
+    "sha512": "5c5dc3500287eb3e8d60b7179a90780808eee47daea0ce4860d11421b9ad513089f28a3c00699b6b4cf131497d8d7f7c350e59ec12e3d993d5bb32d558365512",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/http-client/google-http-client-parent/1.46.2",
+    "dest-filename": "google-http-client-parent-1.46.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/http-client/google-http-client/1.46.2/google-http-client-1.46.2.jar",
+    "sha512": "fbe51026af2291da20e5961ed28a1f84744ea0dfbec970856f1644ae48bce4fea1d2786f2604215e52349cde54c2cd74f681089b86e7dc51d26ed342e2b326f8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/http-client/google-http-client/1.46.2",
+    "dest-filename": "google-http-client-1.46.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/http-client/google-http-client/1.46.2/google-http-client-1.46.2.pom",
+    "sha512": "482a8548c2dcd8911920bca761d72f2c6d3808d9b8c1760bc88a7ae7a029840c6a32c12e7c254708c7df61b37f6ff04243f248cda7b614a2f24e0625e6199c1f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/http-client/google-http-client/1.46.2",
+    "dest-filename": "google-http-client-1.46.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.jar",
+    "sha512": "1406b1aa53b19f8269129d96ce8b64bf36f215eacf7d8f1e0adadee31614e53bb3f7acf4ff97418c5bfc75677a6f3cd637c3d9889d1e85117b6fa12467c91e9f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/j2objc/j2objc-annotations/3.0.0",
+    "dest-filename": "j2objc-annotations-3.0.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.pom",
+    "sha512": "3c0f19b8e1275dbbaf8a0d02f9ef27a7edbb73ffdd75ae2c9fd334b5dbc373e8420f896b962c86f5d3540007c07acd1995eed8d119d7c6e7068305e9c12f0181",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/j2objc/j2objc-annotations/3.0.0",
+    "dest-filename": "j2objc-annotations-3.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/protobuf/protobuf-bom/3.25.5/protobuf-bom-3.25.5.pom",
+    "sha512": "b900a81cfd33a1e85c903ef0eeea375a1e5d85cc6ccb3470b7bbbcceaf928e9e8670405a546aafe2cd0e7e9ed565628eb0990bcb1ae643e0c394f2745cd84007",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/protobuf/protobuf-bom/3.25.5",
+    "dest-filename": "protobuf-bom-3.25.5.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/protobuf/protobuf-java/3.25.5/protobuf-java-3.25.5.jar",
+    "sha512": "432d8a9359e614d38fe416b7a4564aed3e358fd5f3c2c4f22caf97945a0f3e5cbd2220b690d6b822504e7bcbbd67458eb12d232232dd113f804683a172f8eb71",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/protobuf/protobuf-java/3.25.5",
+    "dest-filename": "protobuf-java-3.25.5.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/protobuf/protobuf-java/3.25.5/protobuf-java-3.25.5.pom",
+    "sha512": "2e9ea8539bf92bf9ab89e08614fdccd4a663db1f2cf5b4e35f59ec7276a34d9e83e57da51bcd7ef5959016072768a9ba105f78d6c1334dbc9e61f90b37103810",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/protobuf/protobuf-java/3.25.5",
+    "dest-filename": "protobuf-java-3.25.5.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/google/protobuf/protobuf-parent/3.25.5/protobuf-parent-3.25.5.pom",
+    "sha512": "7470211ceeff2ee79ac892d9f1ed22e698a0f9e07ac1546943bd5abd20e0133de075ec00a5bb230d16ffe900995ef028ff950c7395887ba3108c59ecf1074456",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/google/protobuf/protobuf-parent/3.25.5",
+    "dest-filename": "protobuf-parent-3.25.5.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java-client-okhttp/4.17.0/openai-java-client-okhttp-4.17.0.jar",
+    "sha512": "7a7cde2976ccbd7771eb4d59840c7e8ce0328c354dc87525979e2cfd1b8db29d3767d598ca9eb031845e5af626c8582384dd385e3fc273cbf51b7b9c2b27ff47",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java-client-okhttp/4.17.0",
+    "dest-filename": "openai-java-client-okhttp-4.17.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java-client-okhttp/4.17.0/openai-java-client-okhttp-4.17.0.module",
+    "sha512": "f18c1c41a060909ffff7067684704945b1606f17553c3da3f800bd65a3f211c9b59b00f29ca3e3def26ec91823e5d9f6310eac87e504977de115f5983e8f1b71",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java-client-okhttp/4.17.0",
+    "dest-filename": "openai-java-client-okhttp-4.17.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java-client-okhttp/4.17.0/openai-java-client-okhttp-4.17.0.pom",
+    "sha512": "fa501f37c5a531a8303a1af38e26e0aa3d422246c3dc0c9c700bf0f107d15ca26cf525c14670b5c1bbb685cfe70934ab24948c13da4bb9037d83ea7e5b0a0a34",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java-client-okhttp/4.17.0",
+    "dest-filename": "openai-java-client-okhttp-4.17.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java-core/4.17.0/openai-java-core-4.17.0.jar",
+    "sha512": "5c6ac5757be72f7e46cee2e03a98c35fc6bf95c0cbfbd6aca54d66d2848a4db5d0db3c7729919aa635822fe96b2d2f1f945f3dc663f2ca9b7ab38337020f2286",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java-core/4.17.0",
+    "dest-filename": "openai-java-core-4.17.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java-core/4.17.0/openai-java-core-4.17.0.module",
+    "sha512": "a3c9e79dc2d0e118f54b6ab43a9a6c1d8b9949d374098ed41cfa5492625d18d54037190d0d2f1f862e3e9a40d083100a2a6cb76a64b7cea615942f77cd60cce9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java-core/4.17.0",
+    "dest-filename": "openai-java-core-4.17.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java-core/4.17.0/openai-java-core-4.17.0.pom",
+    "sha512": "d02298143edd62a56047270c4c8c3fa2ebb6123011785fc449a593decafe0263180759d3c27c36abf15edd67362d6d2b89c59b21b2267176d65ae7decf5be6bd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java-core/4.17.0",
+    "dest-filename": "openai-java-core-4.17.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java/4.17.0/openai-java-4.17.0.jar",
+    "sha512": "c15ec7473125b89764895a6f25f734135e5ec6f83aaea86308f92c0f5b62298ea0ab29ecc34746da16c07b999aeb12f7b59e35483c31773f9cd632240aa33a1e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java/4.17.0",
+    "dest-filename": "openai-java-4.17.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java/4.17.0/openai-java-4.17.0.module",
+    "sha512": "78e806b23e62408aa89a1f6ef3f641c6ba28b6b5306f3d429e6fb5789f2b2fc5749c8f3fc5e3157977b9efed9028019aa7236f61cc0b8a77965fc24488802935",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java/4.17.0",
+    "dest-filename": "openai-java-4.17.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/openai/openai-java/4.17.0/openai-java-4.17.0.pom",
+    "sha512": "e42d3eba7ea7759954a49d8d412c96be669932d49d6ba481995260986a0308ab903814e7111d065af478789dcaf71ba8e51b49a14a28b0411afec0b1c34e9dd7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/openai/openai-java/4.17.0",
+    "dest-filename": "openai-java-4.17.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okhttp3/logging-interceptor/4.12.0/logging-interceptor-4.12.0.jar",
+    "sha512": "a3c77d43197b0277204e5954d3bfb37921a1d9e388bbac66e7a35f8d5f5081805645c09119be2a7037dc41a18695cbd06d7599f111c97f8a1e37196b8f38a03c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okhttp3/logging-interceptor/4.12.0",
+    "dest-filename": "logging-interceptor-4.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okhttp3/logging-interceptor/4.12.0/logging-interceptor-4.12.0.module",
+    "sha512": "3bf588ed8c05dcbd81d55b81b1acb8d45146e925a086f5bcd6b43a6890be007ffe0bcc60a272c5bc1526202459bf6151b00cc0f5c425e441fac756b95e7781ac",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okhttp3/logging-interceptor/4.12.0",
+    "dest-filename": "logging-interceptor-4.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okhttp3/logging-interceptor/4.12.0/logging-interceptor-4.12.0.pom",
+    "sha512": "d5b0fb517ad53814285b9a7f619ed4a9c2f3670855b87457c3742919c9911e6fa250e14e01a3f8179058e9ea854f13f4d4ea549249730f318a026500ab0ec02b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okhttp3/logging-interceptor/4.12.0",
+    "dest-filename": "logging-interceptor-4.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okhttp3/okhttp/4.12.0/okhttp-4.12.0.jar",
+    "sha512": "da63f77c1cae377b40f6fd00cfbbe8177e760e4e622ae2c66860fffd3bbbdf605c8e8e415762e9263445b2289ee834100237c63949f2e01c30b6704315dd8f7b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okhttp3/okhttp/4.12.0",
+    "dest-filename": "okhttp-4.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okhttp3/okhttp/4.12.0/okhttp-4.12.0.module",
+    "sha512": "650297e5804bfbd9878179cfd3e3538bb4e1fc0cc3f9b4690b36853d6c8942b27c429cf67d076c26c4757c22203bd891576d4343760dc0898276ef0b9d3192a0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okhttp3/okhttp/4.12.0",
+    "dest-filename": "okhttp-4.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okhttp3/okhttp/4.12.0/okhttp-4.12.0.pom",
+    "sha512": "bef467d5298848782c944facac82e3f1b043675acfd3b62912a89de3a82778c0d0fe7dc623e4f324a90c5d4b390ed66bb18e2d71739e1dac99acdb9a848449fc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okhttp3/okhttp/4.12.0",
+    "dest-filename": "okhttp-4.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okio/okio-jvm/3.6.0/okio-jvm-3.6.0.jar",
+    "sha512": "a592e93651fb5e335212bb25c1cf474c1b1076eda68d53cbdc82c383cbdd60114a62b698ca92a3b4b5e416d637a70f2ddabbf8a05551c62d59a240c3e3c3d2c6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okio/okio-jvm/3.6.0",
+    "dest-filename": "okio-jvm-3.6.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okio/okio-jvm/3.6.0/okio-jvm-3.6.0.module",
+    "sha512": "3c5a57a33fb90618710b298e233ae81cdcdbeed204328e9dc55fe0aaf63eb3fa24e58f4d489f5dde48e2ff716b16e0c47882d8be61bd3bd579b3e23ee3034ce3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okio/okio-jvm/3.6.0",
+    "dest-filename": "okio-jvm-3.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okio/okio-jvm/3.6.0/okio-jvm-3.6.0.pom",
+    "sha512": "e723f3262137f7a892a6f6fe277272b0e457b48aa035651b52d9f598d9f98ca285217c74356a90dcf8a34800797fe458f6e1c461dbf69f9c8d8fe4e66dbdfdfb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okio/okio-jvm/3.6.0",
+    "dest-filename": "okio-jvm-3.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okio/okio/3.6.0/../../okio-jvm/3.6.0/okio-jvm-3.6.0.module",
+    "sha512": "3c5a57a33fb90618710b298e233ae81cdcdbeed204328e9dc55fe0aaf63eb3fa24e58f4d489f5dde48e2ff716b16e0c47882d8be61bd3bd579b3e23ee3034ce3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okio/okio/3.6.0/../../okio-jvm/3.6.0",
+    "dest-filename": "okio-jvm-3.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okio/okio/3.6.0/okio-3.6.0.module",
+    "sha512": "2942511ac0f204af6261b9b254adeefc432518e8ad123957875f8ff95c9994c2564a019f3edebc3499a8404700e031d8d95eb8c084bee58c535ff9ccc383f19e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okio/okio/3.6.0",
+    "dest-filename": "okio-3.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/squareup/okio/okio/3.6.0/okio-3.6.0.pom",
+    "sha512": "b28fab6b6ec5b72759815673e6ee9e8dfff3e9940a016588e671f4ef4e2f936117c7cef31c38459a5d702b217e57c47f91bea693a9b9072b3422b84515133fe6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/com/squareup/okio/okio/3.6.0",
+    "dest-filename": "okio-3.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-codec/commons-codec/1.19.0/commons-codec-1.19.0.jar",
+    "sha512": "d98a7a1cfcc08aa9cce4f7778e3f37ecb99da7b1da01944e5fa8faf06fbf9f969f2efb0b416832f419d53085250f711c071f1dac9fa0968483c37034198367fb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-codec/commons-codec/1.19.0",
+    "dest-filename": "commons-codec-1.19.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-codec/commons-codec/1.19.0/commons-codec-1.19.0.pom",
+    "sha512": "876e711b79565c3878ea4f0799f5209b53daa08f370e8aac286cced03ef494e2c24c89eb425d68850b5d920c98fe6f813e80c318ee4900dcc9b3271b2860f307",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-codec/commons-codec/1.19.0",
+    "dest-filename": "commons-codec-1.19.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-io/commons-io/2.20.0/commons-io-2.20.0.jar",
+    "sha512": "fea08e150473673b0608eaee3ae1cb4e73834039db80d3b758710d6baf3a5840a0878a4eb64739ae9bb21ccc7148c8520fe873616a3f6d5cdb4305deabdd015c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-io/commons-io/2.20.0",
+    "dest-filename": "commons-io-2.20.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-io/commons-io/2.20.0/commons-io-2.20.0.pom",
+    "sha512": "db6bfb4d59e6d05d89ec5cca7ceb89c7493398c8b047046066a19db01cd9b4b32873bcce1be531fea85be4be651b836ad2cb698072b5705fd3491c0743884758",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-io/commons-io/2.20.0",
+    "dest-filename": "commons-io-2.20.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+    "sha512": "ed00dbfabd9ae00efa26dd400983601d076fe36408b7d6520084b447e5d1fa527ce65bd6afdcb58506c3a808323d28e88f26cb99c6f5db9ff64f6525ecdfa557",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-logging/commons-logging/1.2",
+    "dest-filename": "commons-logging-1.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/commons-logging/commons-logging/1.2/commons-logging-1.2.pom",
+    "sha512": "75bef548eea62ab04569791f2fdeed3d0a61edae0534aa035a905dc1d011988fc0f06f52bde377f44e94e6afd4380197148120b152b7a4d20628fb6236cc7261",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/commons-logging/commons-logging/1.2",
+    "dest-filename": "commons-logging-1.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-api/2.0.0-alpha.2/detekt-api-2.0.0-alpha.2.jar",
+    "sha512": "f92689ca7394737ea274c33fe7896bf6e43d0f6fc8bffdef6c285d5bbf397dae9cd97da03ff21159de3769353c2f9e35a44142efba0460d169a622c18e29547e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-api/2.0.0-alpha.2",
+    "dest-filename": "detekt-api-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-api/2.0.0-alpha.2/detekt-api-2.0.0-alpha.2.module",
+    "sha512": "606b291c895754ac12c5c69912c2e4ef2ff0e97df6685d9d7cef8d55b9732472477f6eabbe12dbd67fe148fa07f6c446be6dacc9413fe652c6cf7ac22e7e1b6f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-api/2.0.0-alpha.2",
+    "dest-filename": "detekt-api-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-api/2.0.0-alpha.2/detekt-api-2.0.0-alpha.2.pom",
+    "sha512": "e944f352ad343c0891fdfb64fc84617698ceb65b819807f000878b15247ee7b1daeaabca51cfd74cb5c115493ef4f243dc66ec97feff15747b5bdda00ff756ef",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-api/2.0.0-alpha.2",
+    "dest-filename": "detekt-api-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-cli/2.0.0-alpha.2/detekt-cli-2.0.0-alpha.2.jar",
+    "sha512": "57d1f3c7ed2f509e31b3a174bb6411978e62a88663ef495d5481cf92dc68c6242260c098e34845c7d3f83bb48589933361b5b793a1c8ab41609090cf01b02db5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-cli/2.0.0-alpha.2",
+    "dest-filename": "detekt-cli-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-cli/2.0.0-alpha.2/detekt-cli-2.0.0-alpha.2.module",
+    "sha512": "05d42afdc938b1471db70107f615d0183ab0640c1f937337598bb221a076a66298c331d9163cfd8d716cdefc16ee2d8665971bd8c59c36ae8617c02e8d6ab8d3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-cli/2.0.0-alpha.2",
+    "dest-filename": "detekt-cli-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-cli/2.0.0-alpha.2/detekt-cli-2.0.0-alpha.2.pom",
+    "sha512": "eba9fff1065d166099c2812e699be25cfc43844451f12eb37e33aa31b8154c244354e11b64a969a85a2c2184fe3f2b9976c59b9383adca44b3a70f49db20cad7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-cli/2.0.0-alpha.2",
+    "dest-filename": "detekt-cli-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-core/2.0.0-alpha.2/detekt-core-2.0.0-alpha.2.jar",
+    "sha512": "01a70f541d2710e47a0e667ff653679b095a360ca8df4d621a90d5269d1689a1e57ac4dfd94c47fcbbb4272596a377a9f59551a808991173feb3fa19c93c0d8c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-core/2.0.0-alpha.2",
+    "dest-filename": "detekt-core-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-core/2.0.0-alpha.2/detekt-core-2.0.0-alpha.2.module",
+    "sha512": "551ad364524ddbb10e452ee55be023632b3fb104f0feca293857c11fe772c148de1ad083e7523eef46226d70946ed04a1cc4bc02a89d198ec86afba8eb383880",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-core/2.0.0-alpha.2",
+    "dest-filename": "detekt-core-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-core/2.0.0-alpha.2/detekt-core-2.0.0-alpha.2.pom",
+    "sha512": "a9e0d9ff48ff7967d426e476c929b313c26e2b4f8b1f46f5360dcf8a2c058eeeb419a118fa11fb82aa331982c167a4d341bdb4012f19b67224e89344b1a42b03",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-core/2.0.0-alpha.2",
+    "dest-filename": "detekt-core-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-gradle-plugin/2.0.0-alpha.2/detekt-gradle-plugin-2.0.0-alpha.2.jar",
+    "sha512": "2e577b61f89fcbcf159daab4dc67a672e73d416a147907ac79df51943322eaaf83d504137952205fd6b87947d28a03ac172271d58f9a379ba0ce93b9d4eae3ec",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-gradle-plugin/2.0.0-alpha.2",
+    "dest-filename": "detekt-gradle-plugin-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-gradle-plugin/2.0.0-alpha.2/detekt-gradle-plugin-2.0.0-alpha.2.module",
+    "sha512": "f0d9e232e5b440809df15ca1f0a2d2e09a66ef6ad1c6c7d27e7d13ffd4c32a2512805bc30124770ab255f2690f37dd7aaff1b66ae74c821f72ed5ec737f43dc5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-gradle-plugin/2.0.0-alpha.2",
+    "dest-filename": "detekt-gradle-plugin-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-gradle-plugin/2.0.0-alpha.2/detekt-gradle-plugin-2.0.0-alpha.2.pom",
+    "sha512": "9ffc7312775a8edccdcf958983fe76e610b122278ab4592c376326438cb9f95960d26ff88c4a4a62e7c2d4d7eae53c631a4f1467e01df88f4a8302f7f17e55eb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-gradle-plugin/2.0.0-alpha.2",
+    "dest-filename": "detekt-gradle-plugin-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-kotlin-analysis-api-standalone/2.0.0-alpha.2/detekt-kotlin-analysis-api-standalone-2.0.0-alpha.2-all.jar",
+    "sha512": "9b343666fb895f0765207a29fb9eafa2ae1d06d2cadc6dccfe000f6b828278d7ff4b3362a69e754008e2c2cf788f0feee0f14ac6aa51555ae73b4740f412ed5b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-kotlin-analysis-api-standalone/2.0.0-alpha.2",
+    "dest-filename": "detekt-kotlin-analysis-api-standalone-2.0.0-alpha.2-all.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-kotlin-analysis-api-standalone/2.0.0-alpha.2/detekt-kotlin-analysis-api-standalone-2.0.0-alpha.2.module",
+    "sha512": "36ae3bd3032ced0169052bd692ecbc47e084b6cfc9d2cd9533e093ee5f174f7597ce5061d627c737278df1ff81a01720af4a8eeb5279be73fa02351e7853eb2b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-kotlin-analysis-api-standalone/2.0.0-alpha.2",
+    "dest-filename": "detekt-kotlin-analysis-api-standalone-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-kotlin-analysis-api-standalone/2.0.0-alpha.2/detekt-kotlin-analysis-api-standalone-2.0.0-alpha.2.pom",
+    "sha512": "989418630bd8a9a90c8bc1d89416527a5eaec2d66e67a3262c506fb0c02ec973dbbba98bd5ceb6ba92d6f4b0c31fcbf2ad4c7d12e3dbb5801cfaaefe528909ce",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-kotlin-analysis-api-standalone/2.0.0-alpha.2",
+    "dest-filename": "detekt-kotlin-analysis-api-standalone-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-kotlin-analysis-api/2.0.0-alpha.2/detekt-kotlin-analysis-api-2.0.0-alpha.2-all.jar",
+    "sha512": "d7e1291ddc50a0117ed43b9eaec75efee985cc91575de20c62391b6a6e3aef3fbacee9d55ec455b2c436a34a48dbe10a61f500d223ab844588921ba99f89d34e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-kotlin-analysis-api/2.0.0-alpha.2",
+    "dest-filename": "detekt-kotlin-analysis-api-2.0.0-alpha.2-all.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-kotlin-analysis-api/2.0.0-alpha.2/detekt-kotlin-analysis-api-2.0.0-alpha.2.module",
+    "sha512": "a9e2018ff3aca245739313c2472912dd8ccf9bfc3a440ea8686d49d5a632e57b687f8dd344720dc46983894b0d3fe7548ee101d38672f51a9bdbadb8c1d31ff2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-kotlin-analysis-api/2.0.0-alpha.2",
+    "dest-filename": "detekt-kotlin-analysis-api-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-kotlin-analysis-api/2.0.0-alpha.2/detekt-kotlin-analysis-api-2.0.0-alpha.2.pom",
+    "sha512": "9fbf59d2ae763230312b67d4370889af0b958049a675ab3716e0947e7c42e2c5fcd05c6673ca282f6c8e632938f1a8d4ed6b79f6420613e7f093c1b8fd3991ae",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-kotlin-analysis-api/2.0.0-alpha.2",
+    "dest-filename": "detekt-kotlin-analysis-api-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-metrics/2.0.0-alpha.2/detekt-metrics-2.0.0-alpha.2.jar",
+    "sha512": "187878249cb44ea70c9812e9f419f43de4b11276a7cc642fb0c796a0ecae860bd13ef33a7fcfe8f4a1a9cbafb798f3b4865fee69bbebd48ce0b14da2903e3f65",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-metrics/2.0.0-alpha.2",
+    "dest-filename": "detekt-metrics-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-metrics/2.0.0-alpha.2/detekt-metrics-2.0.0-alpha.2.module",
+    "sha512": "265874aa5f736a99534633d6003507fad2ad37c42647ebd2479e5ed8a8fe32c3d2b790fae259f7dd43c0f2f383402913b1047d7d09cad565c5d18269efcd11ac",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-metrics/2.0.0-alpha.2",
+    "dest-filename": "detekt-metrics-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-metrics/2.0.0-alpha.2/detekt-metrics-2.0.0-alpha.2.pom",
+    "sha512": "7888a7fec038af3a697f40cfcc909670e76dcc1936bc7c0d12f5e7422cb35e203ef8053cd3f4102e92f612ec5bf7bb1636eedaa4b00741480f5271817d7a6749",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-metrics/2.0.0-alpha.2",
+    "dest-filename": "detekt-metrics-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-parser/2.0.0-alpha.2/detekt-parser-2.0.0-alpha.2.jar",
+    "sha512": "fd78fe027efae4843d5bedd7b16927fc2cece256688ab5fae69e44947414f32798a1f0b56d1435d36e4726c843426aabf5456cfcfcfeac9b203e574392a3f9d5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-parser/2.0.0-alpha.2",
+    "dest-filename": "detekt-parser-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-parser/2.0.0-alpha.2/detekt-parser-2.0.0-alpha.2.module",
+    "sha512": "6eddf1845b7087a0ad62df9ab7c14b203bd8bd47a36633faaf3c7c505364ac06c1b9a43d6292e13cea53a315a1379c7cade534837f2eba067af0910d6133290d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-parser/2.0.0-alpha.2",
+    "dest-filename": "detekt-parser-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-parser/2.0.0-alpha.2/detekt-parser-2.0.0-alpha.2.pom",
+    "sha512": "ff99d51847d0dd496e3cae512e7d859a0541848903d3b585004334d33a2b2c3a5d597e9725508912fada1b349d150df78184478894a164ffd667ae23f623d2a5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-parser/2.0.0-alpha.2",
+    "dest-filename": "detekt-parser-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-psi-utils/2.0.0-alpha.2/detekt-psi-utils-2.0.0-alpha.2.jar",
+    "sha512": "30d30513acaec8d33d22a62e6f5f8cfeba459e04eaaa783d6373fe0f86fea7f278b96c77daa62f2115b4a04cdd54872ad5a71f6ad2fce7f260ce945f0b925d65",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-psi-utils/2.0.0-alpha.2",
+    "dest-filename": "detekt-psi-utils-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-psi-utils/2.0.0-alpha.2/detekt-psi-utils-2.0.0-alpha.2.module",
+    "sha512": "446d8ea2ad5117063d5a060853c0abd98cea1a8480b109664ef3a4c7d56174fd62754053dbfc37181a918f286c99fc26e9a5637b94d8a118cb032bb439d1e6d5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-psi-utils/2.0.0-alpha.2",
+    "dest-filename": "detekt-psi-utils-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-psi-utils/2.0.0-alpha.2/detekt-psi-utils-2.0.0-alpha.2.pom",
+    "sha512": "9cb2f9deb0af2c66ecaa95dad907d1b3cbd0f94299f0c1399271bcf4f117c8245be0efd01756875f7485f3ebfca5c07c9767ce04f2a8628392073de5550c850e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-psi-utils/2.0.0-alpha.2",
+    "dest-filename": "detekt-psi-utils-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-checkstyle/2.0.0-alpha.2/detekt-report-checkstyle-2.0.0-alpha.2.jar",
+    "sha512": "5141a71fbb8a0e6ec8148009915586fb147b2d974173d744ee3b42310b91125d8412cfccbfd5d08776676f181511f16b8c9509ed3de6e288f470dadd72c5cfd8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-checkstyle/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-checkstyle-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-checkstyle/2.0.0-alpha.2/detekt-report-checkstyle-2.0.0-alpha.2.module",
+    "sha512": "c0457adb87ae47fac3144017aaeae8ecb1c99ea9b3a912d1368d1913080fd32526dbc1951082f896531380531793ab68b14a19ed39ccda349fe3213c36c19e16",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-checkstyle/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-checkstyle-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-checkstyle/2.0.0-alpha.2/detekt-report-checkstyle-2.0.0-alpha.2.pom",
+    "sha512": "8628406e3fa8ac0f6c7c7ee0bffaf78c6f1d86a30c9f5b33fe8b7b84acc5f33017e829f595b491e02c410c1329f567138b88ca03bafb2b71f3ca77e37c486d99",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-checkstyle/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-checkstyle-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-html/2.0.0-alpha.2/detekt-report-html-2.0.0-alpha.2.jar",
+    "sha512": "1d871c4e8cbaf6a1eb80638416785539ecae709324f0f0c697a1f38c7e2b6838f94c3ae3406ad69090d20f62265b912ea9ec7f99848825989d89ba162d8a1b75",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-html/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-html-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-html/2.0.0-alpha.2/detekt-report-html-2.0.0-alpha.2.module",
+    "sha512": "1868b1c8cc6768678945857cea31debeef485fd790f421aa49ddcfbb5188f3282d99df7c421ef19978d69202cce1c2c09618ce8f42d8a8c71fc790b464002ff0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-html/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-html-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-html/2.0.0-alpha.2/detekt-report-html-2.0.0-alpha.2.pom",
+    "sha512": "cc956d94a570b0eb22239bbfc15cb32fd93241a3b7bc51867741a908ab4c1236724eb7396f649498b19bfd1c07ee92a8858eedb4f4cada3a79dcab855d35a482",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-html/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-html-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-markdown/2.0.0-alpha.2/detekt-report-markdown-2.0.0-alpha.2.jar",
+    "sha512": "6fac22bf6401ae24e4a2b48f82732ed9ecce16013701b06651744ed0462931419f00eae761a0a4e60718abda8f6fa860416755235b450c0725b2a4bcaedb58c9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-markdown/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-markdown-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-markdown/2.0.0-alpha.2/detekt-report-markdown-2.0.0-alpha.2.module",
+    "sha512": "7fec75d8fca549133c94282f4b99c6a9424e2a82afc09d6c42f0b81d67514b9cc7677c9ce01f63d99541d59d65a00106d24c7aa610c942f6f28e0333ae5ce5f9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-markdown/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-markdown-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-markdown/2.0.0-alpha.2/detekt-report-markdown-2.0.0-alpha.2.pom",
+    "sha512": "1606e1929a8a74f2997ff7e1b25b811fbdda17e378cfe972fc37c7cb56d67a54149cbe2c215dc2b4912cd667e187ee857c268939aceb5922fe15939449bddacb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-markdown/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-markdown-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-sarif/2.0.0-alpha.2/detekt-report-sarif-2.0.0-alpha.2.jar",
+    "sha512": "6b66db75561f0550fb7303f0cb4e105c4b8cb46226694e8431447345620c0510182427d1405018059bffeac25bbf3e51ce9645aa5d722bfa5f274ecff0a870c4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-sarif/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-sarif-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-sarif/2.0.0-alpha.2/detekt-report-sarif-2.0.0-alpha.2.module",
+    "sha512": "2b3b4d4153832f37b1372bde5dcae5b46db7a7c61a88d2b208070fc3488dbf69451de59c5f5eb95c891354a7e83fb6f4af5f0915d8b4cdff0e6051d743bc161b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-sarif/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-sarif-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-report-sarif/2.0.0-alpha.2/detekt-report-sarif-2.0.0-alpha.2.pom",
+    "sha512": "353cf21bd023e792e43268d6cc77d2dd67ec1b5246ea6cc9ead306d1dcf413582a7aee711eedf13584fe28319ee041614a37f7d2ee111c3cd13c70dafe63a102",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-report-sarif/2.0.0-alpha.2",
+    "dest-filename": "detekt-report-sarif-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-comments/2.0.0-alpha.2/detekt-rules-comments-2.0.0-alpha.2.jar",
+    "sha512": "d7c82c6eadf7762b4fd0f0b5ba40df846a3940168e6fac5ae18f7903fdc65379239ce2eb2a611670ebb7c96e8de67b8d6c9f4625e78be3246faeecfce05831b8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-comments/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-comments-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-comments/2.0.0-alpha.2/detekt-rules-comments-2.0.0-alpha.2.module",
+    "sha512": "8efdc4662ec1797ee536b9038cf526ff6f09f5515d5fb9f971d569f0b04f21dac6b8a278b59570b0e4be430b10666a86cc10469b0d41510b011e484fb78e6172",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-comments/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-comments-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-comments/2.0.0-alpha.2/detekt-rules-comments-2.0.0-alpha.2.pom",
+    "sha512": "cdce5f5fb2387f74c246c8d2721e4ef835c36b670ac14796be0636de1424fca772393de5f3b468d0140a8d4a7bc09ad2504e0f901b8e7b409f924b4c3b206bd3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-comments/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-comments-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-complexity/2.0.0-alpha.2/detekt-rules-complexity-2.0.0-alpha.2.jar",
+    "sha512": "b135ed082cd968b0ac073585cfc99e6176fcf5268ba4f580bd53440556a1f77771b1d428b7e5a3162be485107f57a868b17733718851eb2ab3d20b013a933c89",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-complexity/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-complexity-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-complexity/2.0.0-alpha.2/detekt-rules-complexity-2.0.0-alpha.2.module",
+    "sha512": "2bca45c343f778bd221f60da08e1b4d8e9caa330c55dd27d00f4a8dad3409ed0bbf5d0fc3adf28e2807f9fbfb1e1884a0f88cb4cba2a4d9c6cd20925284b1b0c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-complexity/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-complexity-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-complexity/2.0.0-alpha.2/detekt-rules-complexity-2.0.0-alpha.2.pom",
+    "sha512": "fe0b1a68f3629612944a7e2182b8777b9db30828da6832f5fb3ca14017b5516c9c905009beba5e8e8c959f07ade2d143edd2527d1c20a1a94b11deafb64efd44",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-complexity/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-complexity-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-coroutines/2.0.0-alpha.2/detekt-rules-coroutines-2.0.0-alpha.2.jar",
+    "sha512": "d3b94f9c3a9f10cb913f23c4777786719bce3a59c3271e4c7e509852de73aa8a952377d7041142459dbd4a58bbcb1671a138ad2912183c3ca176f2724b1e0631",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-coroutines/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-coroutines-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-coroutines/2.0.0-alpha.2/detekt-rules-coroutines-2.0.0-alpha.2.module",
+    "sha512": "1994f4cba047b44f47fed1e7da35f53c392bfe0a5635e125a07dc1e2e22c5139f3fa590e01a32f8d3f10aab9090039ff86b65b394c0a3c5e072716964ae24b2f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-coroutines/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-coroutines-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-coroutines/2.0.0-alpha.2/detekt-rules-coroutines-2.0.0-alpha.2.pom",
+    "sha512": "39b203f66a52ba19dfd256776876947beaf49b259dc22150077dcc72a2a2d8b9bbbb9800d8ae607b8212ebd2332e7ebc06c71c0e91302a619c5ef0eee6e4c93d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-coroutines/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-coroutines-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-empty-blocks/2.0.0-alpha.2/detekt-rules-empty-blocks-2.0.0-alpha.2.jar",
+    "sha512": "91d159ccf1416a1b697920621ceba878ea63a7d5caa656807f1aa090adcc736fdfb39dd0b668a521f9308bfb81fdadfb2aa7c5722b53148dfb30c002f82b6c16",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-empty-blocks/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-empty-blocks-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-empty-blocks/2.0.0-alpha.2/detekt-rules-empty-blocks-2.0.0-alpha.2.module",
+    "sha512": "fe10cba7e53ae99f9cfb634aea9bcc1c61620d61d8e1f20b6e7cbdd66bcab9d61473fb9ffdfaeab793e0b0228be8b70662ae99be1703936af33eb09b9aed9ae4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-empty-blocks/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-empty-blocks-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-empty-blocks/2.0.0-alpha.2/detekt-rules-empty-blocks-2.0.0-alpha.2.pom",
+    "sha512": "ee50ffeb3d1ddce52d0687b96cabd710f46664d9602b74cc75d0e524d9d8b12acaf019005a70be7234d06c58f36a28aeb4012818a7acce23c27efbb208f748bf",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-empty-blocks/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-empty-blocks-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-exceptions/2.0.0-alpha.2/detekt-rules-exceptions-2.0.0-alpha.2.jar",
+    "sha512": "cd3d1060e92e8eb416c2baad815787b798eeb2b342c41368d43b448952f876eaf83d33dc3fb104acbaa78db72b2930427ed6f86db0059b46bdb2c862de26d557",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-exceptions/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-exceptions-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-exceptions/2.0.0-alpha.2/detekt-rules-exceptions-2.0.0-alpha.2.module",
+    "sha512": "d4883c8b503f0664db886397d9ef16605ee7d2ffa2822f7bb327e5e34ee65d19b4b7a942ee42acb5bd418f1ec94b799052c09f21d7864a6376867cf490d1c4c0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-exceptions/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-exceptions-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-exceptions/2.0.0-alpha.2/detekt-rules-exceptions-2.0.0-alpha.2.pom",
+    "sha512": "b9fdc6764d5799643148d8041d1f071bf217283e70b25de079521ca2e1d8760f808ea9640c7507c3d2f32cd760bf7ffb34d24d3271ecd08187ece8139e528a27",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-exceptions/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-exceptions-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-naming/2.0.0-alpha.2/detekt-rules-naming-2.0.0-alpha.2.jar",
+    "sha512": "a4aaee7220180f7fdb2e0a9358aacc73356ff8e5022cbd7083610503beaaff2b5370ae68a08a263ee3bdfa1a5d5ce1956467df0b3d80bec092c9eade6a9696d5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-naming/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-naming-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-naming/2.0.0-alpha.2/detekt-rules-naming-2.0.0-alpha.2.module",
+    "sha512": "eb4bd51f615e7b8ecc7b91afc804eba794f68bdcbc62ae7b2228b14c72ed8be6128e1f8d9488c0241e755ce3dd34ed8e986fbf477adc07c34a15ca5c97b61917",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-naming/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-naming-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-naming/2.0.0-alpha.2/detekt-rules-naming-2.0.0-alpha.2.pom",
+    "sha512": "681d8370aa01d330449e321a93f35f4dc654e092860bdd7f7d6cfd8d77e9206cf9c1feb4d54a5678b43fa71eae3fd3c9d18cb2d530a0fc04b0a245be34781c7c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-naming/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-naming-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-performance/2.0.0-alpha.2/detekt-rules-performance-2.0.0-alpha.2.jar",
+    "sha512": "364df0aebca79a978878e0ac1a20f91096876c9d867db6756a363e885ae86c558232c4f11f80b35cce8fe579c06f817a0247d0171ef30e6adb945f365bb27654",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-performance/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-performance-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-performance/2.0.0-alpha.2/detekt-rules-performance-2.0.0-alpha.2.module",
+    "sha512": "777d78f44f3510e959866d75489b0840e87ae5cef701fbe2538b7b03829f1acb05996500a5fefe9137ae524b8cfd693fadfd9294171f4647443a3fcd75f58b52",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-performance/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-performance-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-performance/2.0.0-alpha.2/detekt-rules-performance-2.0.0-alpha.2.pom",
+    "sha512": "9173cc5c4fc88de2337b273667182e6bffc8ebbfb533e41eb9e43453b0a2131c54cb3b5098c8e149fd2865572466bb37fd50b3e08e56157d5f54da606f043a89",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-performance/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-performance-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-potential-bugs/2.0.0-alpha.2/detekt-rules-potential-bugs-2.0.0-alpha.2.jar",
+    "sha512": "4b883a0acaeafec44d59629f56992101c0a134ceebdc4003a1fdb9508b8aabb15ae8af0e5369be6e3bc4ac4d992fe4cd46cde6ca5b9330dca65236fede19801c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-potential-bugs/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-potential-bugs-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-potential-bugs/2.0.0-alpha.2/detekt-rules-potential-bugs-2.0.0-alpha.2.module",
+    "sha512": "7968bb82385a53fcfb3080b14c67b919cddca053ac6787b4aac8585ea2b4714b6af39afda3729ed455263e7be0339b654b92a2e98c176471efc0feb46e6d6811",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-potential-bugs/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-potential-bugs-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-potential-bugs/2.0.0-alpha.2/detekt-rules-potential-bugs-2.0.0-alpha.2.pom",
+    "sha512": "77744a2a0dcdd4ad0444372f6eda83a56e307b7b640a737933fa706c187b73e2b789cf7c0af457c0263ee6746488bf3567a795f8c37209f8dd8e4646a0c56c7f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-potential-bugs/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-potential-bugs-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-style/2.0.0-alpha.2/detekt-rules-style-2.0.0-alpha.2.jar",
+    "sha512": "43a92593951e67037aa8e168d0fc5c523145e73e405894ccd37d0c12e1272e39dc1cfb78d8ebf708fc46c56e6cd6a18a2ac043f054291a3b564afd0ab0a1c608",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-style/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-style-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-style/2.0.0-alpha.2/detekt-rules-style-2.0.0-alpha.2.module",
+    "sha512": "bfd53e31296ace3411c3c3fe5af2cd041b24dc75936eab0e992ec0da82080690d4d9b9142b3d6a13423b352d1e3766fc3ca9603a4eea7ac7713439c971f95f7d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-style/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-style-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules-style/2.0.0-alpha.2/detekt-rules-style-2.0.0-alpha.2.pom",
+    "sha512": "7dd159c3aa3ffcba95e4da075750763f2f27285a56e0e91230dad86759b5d5b5c39f846d5b84cf1e743571d6adcf91c8cb0da5f173b2b28fbb4e5f6a2ad4bd31",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules-style/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-style-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules/2.0.0-alpha.2/detekt-rules-2.0.0-alpha.2.jar",
+    "sha512": "1487e5a20c9e4d74f298e07c42e96a61be11b7a768c3fbc199ee138cd68e1fc2267d1cfe3f11f288acc05df755315344d052cc5f6f751f126ab4fe1caa5125ea",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules/2.0.0-alpha.2/detekt-rules-2.0.0-alpha.2.module",
+    "sha512": "c31b2b2485651ae28a1e240212d7c4869fef450a0f80c7c364323d43359551c39903736c6c5496a4b86159f23cc2e8aad4858030bae13208510cef8a7346d915",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-rules/2.0.0-alpha.2/detekt-rules-2.0.0-alpha.2.pom",
+    "sha512": "261d913632c5e996bfd534e55f66417e63aeb32a0042935f1a99fc0cfb7c17adeed32c9d3650b109ded2ffb0891fee3dfa9c5be030f78faf65a1e9512923647f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-rules/2.0.0-alpha.2",
+    "dest-filename": "detekt-rules-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-tooling/2.0.0-alpha.2/detekt-tooling-2.0.0-alpha.2.jar",
+    "sha512": "77af5970cac6f432c7f3a0b39485c8df8e943d1b529edda9518afe94d539ce4ae8b2ec560419838771172381eef03ee827a16ba6acd9ecfd876005a338ecf741",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-tooling/2.0.0-alpha.2",
+    "dest-filename": "detekt-tooling-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-tooling/2.0.0-alpha.2/detekt-tooling-2.0.0-alpha.2.module",
+    "sha512": "69d4a955547522b26875a8339bad82d06e2bcbb2c9591a0f92115a48da184e716c88b277c00e8d18deb42d0d2805299448c1b577fb423578eb9ceca5bcf4e00e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-tooling/2.0.0-alpha.2",
+    "dest-filename": "detekt-tooling-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-tooling/2.0.0-alpha.2/detekt-tooling-2.0.0-alpha.2.pom",
+    "sha512": "7a827a5625fcb6677c38901588d2d18c0975b723e0a2c68a3d99b139016fb9a0d608b75f20a2056bc8064830a698a741ef6eb8d2f8c021fd2766a564b37bc9d5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-tooling/2.0.0-alpha.2",
+    "dest-filename": "detekt-tooling-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-utils/2.0.0-alpha.2/detekt-utils-2.0.0-alpha.2.jar",
+    "sha512": "0840be78882bb10690cfd623e75a56c7373e12eb1306c100bdec01c492bb2b2802778bb6d5dee665da140ecae8a41a351281f7aae7317d1d67628b35b1b03543",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-utils/2.0.0-alpha.2",
+    "dest-filename": "detekt-utils-2.0.0-alpha.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-utils/2.0.0-alpha.2/detekt-utils-2.0.0-alpha.2.module",
+    "sha512": "fa8135b77d32c87a75b50b7159775f30599933a386027fcbf9cc9ecdaec31b44b29f19ed812061399a9043dcc0dcccb09268a889f92388ae39190a2f1a7ac269",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-utils/2.0.0-alpha.2",
+    "dest-filename": "detekt-utils-2.0.0-alpha.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/detekt-utils/2.0.0-alpha.2/detekt-utils-2.0.0-alpha.2.pom",
+    "sha512": "031f11821a02bc8deee5a30ea6e28682e7521be7f5ca9dc6bda14b2afe9a3d8d5dacd135866f485cd8f9cb39be2900c2dcd55f1ec8151e15adf66a196211c79c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/detekt-utils/2.0.0-alpha.2",
+    "dest-filename": "detekt-utils-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/detekt/dev.detekt.gradle.plugin/2.0.0-alpha.2/dev.detekt.gradle.plugin-2.0.0-alpha.2.pom",
+    "sha512": "9142bda2e3b8075031d7f70850b9ab00e73c2fcfd31b6b79a65f8d544e3e0d801912a29e885a13ebe9cc8bf1054c50fcc3e027722fbf23a5ae1329290811a125",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/detekt/dev.detekt.gradle.plugin/2.0.0-alpha.2",
+    "dest-filename": "dev.detekt.gradle.plugin-2.0.0-alpha.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/drewhamilton/poko/poko-annotations-jvm/0.21.1/poko-annotations-jvm-0.21.1.jar",
+    "sha512": "fce3f02184999f5843c63b43482e411815fdaf103d4a7fd0102afcf959eba00dc364a2adae3918debd0ce7fc52fd4b22da809a82562aaccfa473bb1ecf8441e0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/drewhamilton/poko/poko-annotations-jvm/0.21.1",
+    "dest-filename": "poko-annotations-jvm-0.21.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/drewhamilton/poko/poko-annotations-jvm/0.21.1/poko-annotations-jvm-0.21.1.module",
+    "sha512": "3afcf82f3e8b2e4cc4c771a0f5d66ac89ae9b5bbb629444228e7a043d35c9b114ab88a5606f547f0b08decea76f146b1a6c491a5dd1435af8088ca57a7ca2a92",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/drewhamilton/poko/poko-annotations-jvm/0.21.1",
+    "dest-filename": "poko-annotations-jvm-0.21.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/drewhamilton/poko/poko-annotations-jvm/0.21.1/poko-annotations-jvm-0.21.1.pom",
+    "sha512": "df5ab6c62a87bcdc953cd0d37b9c3510c8ef298b9c75b65369a5f09d02f7456004dd8bd3a7b53b0889c9ba5e95aca1a56781e2f05f36799e7b704f7298a4c12a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/drewhamilton/poko/poko-annotations-jvm/0.21.1",
+    "dest-filename": "poko-annotations-jvm-0.21.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/drewhamilton/poko/poko-annotations/0.21.1/../../poko-annotations-jvm/0.21.1/poko-annotations-jvm-0.21.1.module",
+    "sha512": "3afcf82f3e8b2e4cc4c771a0f5d66ac89ae9b5bbb629444228e7a043d35c9b114ab88a5606f547f0b08decea76f146b1a6c491a5dd1435af8088ca57a7ca2a92",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/drewhamilton/poko/poko-annotations/0.21.1/../../poko-annotations-jvm/0.21.1",
+    "dest-filename": "poko-annotations-jvm-0.21.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/drewhamilton/poko/poko-annotations/0.21.1/poko-annotations-0.21.1.module",
+    "sha512": "891fdb48c5b3afe9bf63dac10763342a313ffbc562211386f04b33fbe65cf6e0df2182145cb2040f59767d9e537e8b7508849058e5f899cb13f5372e29805bfd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/drewhamilton/poko/poko-annotations/0.21.1",
+    "dest-filename": "poko-annotations-0.21.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/dev/drewhamilton/poko/poko-annotations/0.21.1/poko-annotations-0.21.1.pom",
+    "sha512": "c30eef3f9c06efa1f7c78b70e5d30916daaa69115c8bc49442e432c42aef026362bc3943afa7de34cbb43465d95d723eb74f6f06da65259270df3083a8028559",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/dev/drewhamilton/poko/poko-annotations/0.21.1",
+    "dest-filename": "poko-annotations-0.21.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.jar",
+    "sha512": "96499a151e1250bf976db95def8caf8949ab1464b59dc8a233f12ced64e815635a806e77f81fec846a44d51832628703f64ce5c83313843f90093dc49b9b6353",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0",
+    "dest-filename": "sarif4k-jvm-0.6.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.module",
+    "sha512": "0dce653298ad8dab783148e2259d2029eb66bad6a54b9685b5a25e6e36ee7290b035833cf07be8051018333afd477bd207b44cbe2c5da2c6a6b511bbd2d4ba99",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0",
+    "dest-filename": "sarif4k-jvm-0.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.pom",
+    "sha512": "dd77f3d7d236ab57741fa7540a5ff6d2f3fe69444e619a2fef0dd105f271f4bbfb320649edb2114dc31a0d019e6c3411d0e247956400daa1b340bf03fd1d887f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0",
+    "dest-filename": "sarif4k-jvm-0.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/detekt/sarif4k/sarif4k/0.6.0/../../sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.module",
+    "sha512": "0dce653298ad8dab783148e2259d2029eb66bad6a54b9685b5a25e6e36ee7290b035833cf07be8051018333afd477bd207b44cbe2c5da2c6a6b511bbd2d4ba99",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/detekt/sarif4k/sarif4k/0.6.0/../../sarif4k-jvm/0.6.0",
+    "dest-filename": "sarif4k-jvm-0.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/detekt/sarif4k/sarif4k/0.6.0/sarif4k-0.6.0.module",
+    "sha512": "f5c3ca971084e0fe4f011764f86c91e2bd3b6c0e5667c67d40e0a82e90622c77d9ac49d4079899a1f309e45ce0de6948df12f126b895b75c31b8021dba77755e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/detekt/sarif4k/sarif4k/0.6.0",
+    "dest-filename": "sarif4k-0.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/detekt/sarif4k/sarif4k/0.6.0/sarif4k-0.6.0.pom",
+    "sha512": "f0cb71efc54db1266cc8851b31a446cc0b5909c5dd7b536eef11d5bef920f9b357f615bb6c43350510bb6555dc969215caded2d3f885bfc2bcda3de566b5de0e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/detekt/sarif4k/sarif4k/0.6.0",
+    "dest-filename": "sarif4k-0.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/java-diff-utils/java-diff-utils-parent/4.12/java-diff-utils-parent-4.12.pom",
+    "sha512": "67476b78236fac9cf37c521a4ec52365ac0cdff510083af8b272a13b669900c4800dfd5ce263ee0769297357edc41769647c272f9283ac50aff69dcf1971eeed",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/java-diff-utils/java-diff-utils-parent/4.12",
+    "dest-filename": "java-diff-utils-parent-4.12.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar",
+    "sha512": "df950eaccfc24641ba7957e42e0bd54024bafe07450cfed8404b8e9efb00931bb96b2518c582310f98508ac550c34d38cde49a220fc9d743bbc52d0fd25feb53",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/java-diff-utils/java-diff-utils/4.12",
+    "dest-filename": "java-diff-utils-4.12.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.pom",
+    "sha512": "4e3f08b0636b7a6c499f91408561dd30403ba94e2fc6c1e11678b2d138991414e6ccdcfc5e110a95700a8e2e5eaa9a656a6af692ba4187e604274edd9964e4e3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/java-diff-utils/java-diff-utils/4.12",
+    "dest-filename": "java-diff-utils-4.12.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/jwharm/flatpak-gradle-generator/io.github.jwharm.flatpak-gradle-generator.gradle.plugin/1.6.0/io.github.jwharm.flatpak-gradle-generator.gradle.plugin-1.6.0.pom",
+    "sha512": "fbe6480fc584f081469ca53936edaae0597f91e973c761b3a51332c3f89486c27c7c37b7c6493846b072ce5b38d78daa7a64c0b2da1da02ef3b43678cd2c74cc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/jwharm/flatpak-gradle-generator/io.github.jwharm.flatpak-gradle-generator.gradle.plugin/1.6.0",
+    "dest-filename": "io.github.jwharm.flatpak-gradle-generator.gradle.plugin-1.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/jwharm/flatpak-gradle-generator/plugin/1.6.0/plugin-1.6.0.jar",
+    "sha512": "a3ea69f67a305030a02f5818a5349753522a382fe36bc22140ac7b63998c14bdb211810b43859e91be0203723490a5de2c1f5e968f696019ec5a31e92d42843e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/jwharm/flatpak-gradle-generator/plugin/1.6.0",
+    "dest-filename": "plugin-1.6.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/jwharm/flatpak-gradle-generator/plugin/1.6.0/plugin-1.6.0.module",
+    "sha512": "aa1756741388b43d5d07bd65934b1cbbb746085bc4df8f98c506f2d5bc367276fd4b0c01e51540d981a5be37715f5ae3d64dcc29b9157b602f59bd929560d1ec",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/jwharm/flatpak-gradle-generator/plugin/1.6.0",
+    "dest-filename": "plugin-1.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/github/jwharm/flatpak-gradle-generator/plugin/1.6.0/plugin-1.6.0.pom",
+    "sha512": "3149ff19058093c6665f5d0d5f36ca174250a5cad22a38710502071cfaa7520645dc00546e3b5190437c496ddb630d13815477934221ac7672e65a5b60ad8f6b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/github/jwharm/flatpak-gradle-generator/plugin/1.6.0",
+    "dest-filename": "plugin-1.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/grpc/grpc-api/1.70.0/grpc-api-1.70.0.jar",
+    "sha512": "011e0ce3870ade374954e5818f3a03ab22bd19fbbf171d2873bdf1ecdbdefae183a512043f9155aa120dce3e1c902680372b18c3dcf1bb64ae508ecfa7631677",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/grpc/grpc-api/1.70.0",
+    "dest-filename": "grpc-api-1.70.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/grpc/grpc-api/1.70.0/grpc-api-1.70.0.pom",
+    "sha512": "7fc13aacac59fe2fa298807055f796fa52e659f4db41334ec7b2dd1091d2ad3f57a8234155bdb785daa997093994fa0de348bc796de8b8ae41c2bef7872eb6e3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/grpc/grpc-api/1.70.0",
+    "dest-filename": "grpc-api-1.70.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/grpc/grpc-context/1.70.0/grpc-context-1.70.0.jar",
+    "sha512": "430cd53a07173fcfe8ac65d0b6f682a30eb7a50df9c33850a39dd2d48a159e63afec1e430471aeeb00c9c88e2354d4d5c456e451309ef5640c91a73def197fb7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/grpc/grpc-context/1.70.0",
+    "dest-filename": "grpc-context-1.70.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/grpc/grpc-context/1.70.0/grpc-context-1.70.0.pom",
+    "sha512": "27e9abc7de5cfb5fc6d70bc038e4adf281ad8a35c2625d5ed4f1f47f448cf389cbfb1248f8db053b57da1305c091c833fba48c26fd531665bf1905ec2560313f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/grpc/grpc-context/1.70.0",
+    "dest-filename": "grpc-context-1.70.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-cio-jvm/3.4.0/ktor-client-cio-jvm-3.4.0.jar",
+    "sha512": "bcc2537a2d7a9be7cf39fe84e0a47a45b49d1e22dc8b0810039b97c8a6cea77585c5b9d723901beaff64bc59ee214f9f65fa5310d35deed3aa0f68db2930e093",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-cio-jvm/3.4.0",
+    "dest-filename": "ktor-client-cio-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-cio-jvm/3.4.0/ktor-client-cio-jvm-3.4.0.module",
+    "sha512": "ca998f3d21c11b0e3af8bac46ff8c3e32d88d75d2d1fcd2590ee79fc86c4c017dbc94e99eb3c746cab9754c5560641ec33ae3febe09ff51c13f271968fa21cbc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-cio-jvm/3.4.0",
+    "dest-filename": "ktor-client-cio-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-cio-jvm/3.4.0/ktor-client-cio-jvm-3.4.0.pom",
+    "sha512": "1807de9887750e59e5a1287713191c65ea1710739fc14f77fd801b9c6522618e267eabaeae4bbe701193cb8a4a46c9d94901a6978f981b8ef9cd74de05b5894c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-cio-jvm/3.4.0",
+    "dest-filename": "ktor-client-cio-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-cio/3.4.0/../../ktor-client-cio-jvm/3.4.0/ktor-client-cio-jvm-3.4.0.module",
+    "sha512": "ca998f3d21c11b0e3af8bac46ff8c3e32d88d75d2d1fcd2590ee79fc86c4c017dbc94e99eb3c746cab9754c5560641ec33ae3febe09ff51c13f271968fa21cbc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-cio/3.4.0/../../ktor-client-cio-jvm/3.4.0",
+    "dest-filename": "ktor-client-cio-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-cio/3.4.0/ktor-client-cio-3.4.0.module",
+    "sha512": "8636ed10df53caf2f69d2f807bf6a4decefe384769a765ff16f9d2e6d4977ea0cb36e8e3dd1d33afd4ceabf413fd88b31858b477246156aa6524df89ecfcbbac",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-cio/3.4.0",
+    "dest-filename": "ktor-client-cio-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-cio/3.4.0/ktor-client-cio-3.4.0.pom",
+    "sha512": "3986a365f255093fd3e9738cb2fdc2ee4358f2f49d9e57c64e2e6f8f61133130a0bc629d94f67b68d149a516d9bee4a390f69077479589f4a0f9a338a100b8f0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-cio/3.4.0",
+    "dest-filename": "ktor-client-cio-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-core-jvm/3.4.0/ktor-client-core-jvm-3.4.0.jar",
+    "sha512": "93127c846b605117238ab3cfa1786c69a0d4233e817c76270e3001db4a6c4a28c4561186af21bf2b181e56d4cf4f7d7c0334cf9eddcd3d6371a657b5d645d0c2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-core-jvm/3.4.0",
+    "dest-filename": "ktor-client-core-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-core-jvm/3.4.0/ktor-client-core-jvm-3.4.0.module",
+    "sha512": "454fc0c777d851164dc055cf8a0ea91dd56adf87015e9702484ede7dbc7b260df2ad7d2a050e529551b2cb4f835bac9e8185ddb8572a290833a283ce732952e2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-core-jvm/3.4.0",
+    "dest-filename": "ktor-client-core-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-core-jvm/3.4.0/ktor-client-core-jvm-3.4.0.pom",
+    "sha512": "d4d505410728910c8a19b0d915d266fde7848e8f5beb6b951971ba0a184178c3d12d441f110cfadf3e86f766adaf4bc6f8b84d2518aaced0a0c11ae4ebb0974d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-core-jvm/3.4.0",
+    "dest-filename": "ktor-client-core-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-core/3.4.0/../../ktor-client-core-jvm/3.4.0/ktor-client-core-jvm-3.4.0.module",
+    "sha512": "454fc0c777d851164dc055cf8a0ea91dd56adf87015e9702484ede7dbc7b260df2ad7d2a050e529551b2cb4f835bac9e8185ddb8572a290833a283ce732952e2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-core/3.4.0/../../ktor-client-core-jvm/3.4.0",
+    "dest-filename": "ktor-client-core-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-core/3.4.0/ktor-client-core-3.4.0.module",
+    "sha512": "4ca0ac613a363bda093e082a69443e677ba655503d0f81302ef254659ae286ace0d8169ae1b620f32b2b50b0dd2c71f2409137ee2b3cce41847342e803fa161e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-core/3.4.0",
+    "dest-filename": "ktor-client-core-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-client-core/3.4.0/ktor-client-core-3.4.0.pom",
+    "sha512": "514ca419c3901a77fdd265525fd8739a5be97af626cb4a3a721a07a2456be3d23c9b0e30f03602ce0cd951d1764143895d294274942616ad9006ae4001889fff",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-client-core/3.4.0",
+    "dest-filename": "ktor-client-core-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-events-jvm/3.4.0/ktor-events-jvm-3.4.0.jar",
+    "sha512": "33864efe33f3c6f91d8d2f0c1dd48c5c5bf491505ae38a3f59a7e891c1dd48c28b30fe6e0d11f5fc2702ca0833eebbbcd467d6fecff1f6cda2cb32c1e33fd3d4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-events-jvm/3.4.0",
+    "dest-filename": "ktor-events-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-events-jvm/3.4.0/ktor-events-jvm-3.4.0.module",
+    "sha512": "6511e76da8c31517298cf665f49785e29a03d70ba00a5d4ee62fc914beb7576fe092cd95b4b6ef8f3970e4c1e342bdf6cd80110af618afd698e7e2193668c29a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-events-jvm/3.4.0",
+    "dest-filename": "ktor-events-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-events-jvm/3.4.0/ktor-events-jvm-3.4.0.pom",
+    "sha512": "2eb12963f0473c9dde6b06c07494ef50557c559a563c45c88e2c22ed65447655a98f06e94da0ee39328810e90dd267d13e1994ac13587f7498fe5de1e71b2c20",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-events-jvm/3.4.0",
+    "dest-filename": "ktor-events-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-events/3.4.0/../../ktor-events-jvm/3.4.0/ktor-events-jvm-3.4.0.module",
+    "sha512": "6511e76da8c31517298cf665f49785e29a03d70ba00a5d4ee62fc914beb7576fe092cd95b4b6ef8f3970e4c1e342bdf6cd80110af618afd698e7e2193668c29a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-events/3.4.0/../../ktor-events-jvm/3.4.0",
+    "dest-filename": "ktor-events-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-events/3.4.0/ktor-events-3.4.0.module",
+    "sha512": "233c614a4124355b4aeb49eb5d931a3739e76bc5cd52a4381bda6080fcff96221f3629a5e31cc58d4bdb69a2f24cb67fb1373f30d48abf70ec56a049c640e461",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-events/3.4.0",
+    "dest-filename": "ktor-events-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-events/3.4.0/ktor-events-3.4.0.pom",
+    "sha512": "51cd3d52e98e430bbb5f9a7ade3e0d9c21e68ef262c14debc67c3c90c31216058d7462f58d5d5bc40ede4102ea107117359650a565e14c9525f7bb9c4ee99f0f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-events/3.4.0",
+    "dest-filename": "ktor-events-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-cio-jvm/3.4.0/ktor-http-cio-jvm-3.4.0.jar",
+    "sha512": "e0f008ac63ae08ad2b1f11b4a6f5ef11fc6e2f47cd0bf01669c2ba299ff45894bcecd5fe8203b68aec3fe0d94d799d939afbeb11cf172096ecdc8229b32d4f46",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-cio-jvm/3.4.0",
+    "dest-filename": "ktor-http-cio-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-cio-jvm/3.4.0/ktor-http-cio-jvm-3.4.0.module",
+    "sha512": "907c05600c54c5a2a9ecc982466dcbf39d1d153f9681e4fa0102a7fd5723e1598086015fd2f91fcb81aa9332771664b2ca535666381a741e53f8e8cd686fe9f0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-cio-jvm/3.4.0",
+    "dest-filename": "ktor-http-cio-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-cio-jvm/3.4.0/ktor-http-cio-jvm-3.4.0.pom",
+    "sha512": "6569892c75edda0dff2f3b97116c9daaa172230f46b6e43aa0ab914e93de2e1055cb1955fa38b695303fca15655eeb94f4c56ee36d1558509fc34f0117a03d2e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-cio-jvm/3.4.0",
+    "dest-filename": "ktor-http-cio-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-cio/3.4.0/../../ktor-http-cio-jvm/3.4.0/ktor-http-cio-jvm-3.4.0.module",
+    "sha512": "907c05600c54c5a2a9ecc982466dcbf39d1d153f9681e4fa0102a7fd5723e1598086015fd2f91fcb81aa9332771664b2ca535666381a741e53f8e8cd686fe9f0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-cio/3.4.0/../../ktor-http-cio-jvm/3.4.0",
+    "dest-filename": "ktor-http-cio-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-cio/3.4.0/ktor-http-cio-3.4.0.module",
+    "sha512": "c6c26925584c49f2f40c4d884afa6f280eb8e2c3155a06b20f4f7ff5b00fbaee7615550a21ca9ef887b0cfefcccd5c12451b73658736a35497615a77135dcb25",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-cio/3.4.0",
+    "dest-filename": "ktor-http-cio-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-cio/3.4.0/ktor-http-cio-3.4.0.pom",
+    "sha512": "5406516493e1f9012df5a58de1ec67b10ca5044a35a21360a3ef447f14bae628bda6cb3eac8592d69ef95d082cdcc57916a60d0e176afa93df16e1493e371d90",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-cio/3.4.0",
+    "dest-filename": "ktor-http-cio-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-jvm/3.4.0/ktor-http-jvm-3.4.0.jar",
+    "sha512": "86002ecc21b98677f3926a0b6361216cbe5a77f605531280985805d95f3964766be5ffd2c2b8c7db53ffe2acd50f1136cb271f4416ad0dcda5e487c2b7b551d8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-jvm/3.4.0",
+    "dest-filename": "ktor-http-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-jvm/3.4.0/ktor-http-jvm-3.4.0.module",
+    "sha512": "c0d5ee8e6e90e44d492487605b998c22f03f9c4cf12c7b8e10808001852de7141ba482a511f4a0827a5fb5b780d0bf2f6e4301dfbf26d2887de0c348700e2293",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-jvm/3.4.0",
+    "dest-filename": "ktor-http-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http-jvm/3.4.0/ktor-http-jvm-3.4.0.pom",
+    "sha512": "57ddb41e0961edaa57800163d6245fd40df429a91c7e0ca1b8ec1bb9b94b3da53cdfeae2016a75cf3062fa396a1c7af9aa02bb103aa4181515d276c96f1ac9af",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http-jvm/3.4.0",
+    "dest-filename": "ktor-http-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http/3.4.0/../../ktor-http-jvm/3.4.0/ktor-http-jvm-3.4.0.module",
+    "sha512": "c0d5ee8e6e90e44d492487605b998c22f03f9c4cf12c7b8e10808001852de7141ba482a511f4a0827a5fb5b780d0bf2f6e4301dfbf26d2887de0c348700e2293",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http/3.4.0/../../ktor-http-jvm/3.4.0",
+    "dest-filename": "ktor-http-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http/3.4.0/ktor-http-3.4.0.module",
+    "sha512": "9828795873d6581ca747d50166eb328d0bbae339a8cf70d18650f919a83eda78a8597a3b834b2e1b65a082637ccd881dbcada0eaed6fef81c2832c0fa30e6948",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http/3.4.0",
+    "dest-filename": "ktor-http-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-http/3.4.0/ktor-http-3.4.0.pom",
+    "sha512": "67dee2380feaada6a07aa6432745c0005367776fb1ab0b0cb425dbe9519b7667caeb3c142184ea01598e03fdde9ae66518631f17a16db6ba1667b5448d6b03c6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-http/3.4.0",
+    "dest-filename": "ktor-http-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-io-jvm/3.4.0/ktor-io-jvm-3.4.0.jar",
+    "sha512": "493b6339009e27d63be548b834e5f8adbcad59876feb1b5551600c333d2fbe834cc512da2ea34643dcff756d331b0bacf7dc00e673630eefe436a444d84f2007",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-io-jvm/3.4.0",
+    "dest-filename": "ktor-io-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-io-jvm/3.4.0/ktor-io-jvm-3.4.0.module",
+    "sha512": "7ad34833659bab526659ec0cb10f3b7a3e6cb957ce3e74d8c4935c133df7cd5de5ef2ff906c606cf345908d20f5dae2b1cf24165eadaeaf3e9eaa6cb10dd381a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-io-jvm/3.4.0",
+    "dest-filename": "ktor-io-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-io-jvm/3.4.0/ktor-io-jvm-3.4.0.pom",
+    "sha512": "bf66bf42736a0d1bf50087fdd02eb0ed2e77eb462a3590cb50d6206ccc86a5476f8e556df71f4d19796f558512fc88caff8a025705b5811b3fbf083ea2b31219",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-io-jvm/3.4.0",
+    "dest-filename": "ktor-io-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-io/3.4.0/../../ktor-io-jvm/3.4.0/ktor-io-jvm-3.4.0.module",
+    "sha512": "7ad34833659bab526659ec0cb10f3b7a3e6cb957ce3e74d8c4935c133df7cd5de5ef2ff906c606cf345908d20f5dae2b1cf24165eadaeaf3e9eaa6cb10dd381a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-io/3.4.0/../../ktor-io-jvm/3.4.0",
+    "dest-filename": "ktor-io-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-io/3.4.0/ktor-io-3.4.0.module",
+    "sha512": "72aad672cf73ad92324de5b6e2d923fe143ddd160ee8fe3de7a515eca1f93d2f0202896b10412835c9cc976a81e59f278765e6d3b4f0aa1d6115358bc9eedc19",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-io/3.4.0",
+    "dest-filename": "ktor-io-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-io/3.4.0/ktor-io-3.4.0.pom",
+    "sha512": "69361b1b2f6e74e9d0a87f552a6a605b117f88a4735d5b18266c88e96d10951111ea8afcc385612ba51156f8d1b89ebdae20a193f84660219244c16e065fde04",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-io/3.4.0",
+    "dest-filename": "ktor-io-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-jvm/3.4.0/ktor-network-jvm-3.4.0.jar",
+    "sha512": "4bddc6d36b5bed26f6182a21634bed70a64c5ddfec6d46c8f9ee921baafa6ea3dc3590e31c05a50813b3d1588b1e826ead91c6bc1fcad9415d1322c30a5ef7f7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-jvm/3.4.0",
+    "dest-filename": "ktor-network-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-jvm/3.4.0/ktor-network-jvm-3.4.0.module",
+    "sha512": "7a0d5a8e0413e5bda278741cfe69e0af910ff2fdc58dfafbda567734b47a39f03d6de0e59112d7113a8cea1edd1fdce33109aa0e5d99b3820ba7f3a1d5bb13e7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-jvm/3.4.0",
+    "dest-filename": "ktor-network-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-jvm/3.4.0/ktor-network-jvm-3.4.0.pom",
+    "sha512": "fa5908c584671f65303e14cd4b9718515d8672f9d37973bc94befe4840bb9e20b04a61ee9e0b4a3aca5e99d59600e900d4c398796da2fdd35310d32c8cb08cd7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-jvm/3.4.0",
+    "dest-filename": "ktor-network-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-tls-jvm/3.4.0/ktor-network-tls-jvm-3.4.0.jar",
+    "sha512": "3ffd2dcc1400f4147209b3526d5a1da75cd8c14a3e81236615973ff4beecd5ca8e581186ba1384d950c937315cf9601ee7b8e5b6be84adcf3620544a559950d1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-tls-jvm/3.4.0",
+    "dest-filename": "ktor-network-tls-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-tls-jvm/3.4.0/ktor-network-tls-jvm-3.4.0.module",
+    "sha512": "5db670ac72a543694a2e759ecc962a1d1520d203c6884092af9c7e27dd84201a0115f8e4de77e22768a509822c136655e6f5941291db307651d66e0eb7522cef",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-tls-jvm/3.4.0",
+    "dest-filename": "ktor-network-tls-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-tls-jvm/3.4.0/ktor-network-tls-jvm-3.4.0.pom",
+    "sha512": "de1ef605fda675576d93113cc0c36c87f95f0736b83c0c576ef349c2ade07973ca68b12ad825dabf5b9b26d3e99461495342d54fb795340c6d30a01f53833c38",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-tls-jvm/3.4.0",
+    "dest-filename": "ktor-network-tls-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-tls/3.4.0/../../ktor-network-tls-jvm/3.4.0/ktor-network-tls-jvm-3.4.0.module",
+    "sha512": "5db670ac72a543694a2e759ecc962a1d1520d203c6884092af9c7e27dd84201a0115f8e4de77e22768a509822c136655e6f5941291db307651d66e0eb7522cef",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-tls/3.4.0/../../ktor-network-tls-jvm/3.4.0",
+    "dest-filename": "ktor-network-tls-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-tls/3.4.0/ktor-network-tls-3.4.0.module",
+    "sha512": "e1af93ba29162c476b712e768edc5fc73315228c210bc25c95120070e0e558883c7547c72a0d480fbda81b63d66f41c1c05341448bf8aab4d716da7dab8360d9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-tls/3.4.0",
+    "dest-filename": "ktor-network-tls-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network-tls/3.4.0/ktor-network-tls-3.4.0.pom",
+    "sha512": "c0a529b0a5e42570ae6b03ee8662e3c2d222206587592ef91fda296a508f0977afa86467b6f2214398ca9290b47071ee8015a754e5d0338a486adc25d756d606",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network-tls/3.4.0",
+    "dest-filename": "ktor-network-tls-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network/3.4.0/../../ktor-network-jvm/3.4.0/ktor-network-jvm-3.4.0.module",
+    "sha512": "7a0d5a8e0413e5bda278741cfe69e0af910ff2fdc58dfafbda567734b47a39f03d6de0e59112d7113a8cea1edd1fdce33109aa0e5d99b3820ba7f3a1d5bb13e7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network/3.4.0/../../ktor-network-jvm/3.4.0",
+    "dest-filename": "ktor-network-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network/3.4.0/ktor-network-3.4.0.module",
+    "sha512": "d8818ab270760a5fff352e269f21265d9bca90f59c1d9620fc828c4332dcade0458b93f8e73612de211acd4f24f49e9f1d514d6890cb3dc0d8b6a64c72b4e7c0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network/3.4.0",
+    "dest-filename": "ktor-network-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-network/3.4.0/ktor-network-3.4.0.pom",
+    "sha512": "15c8a0b53c21ae39c8c53eb1c6c3a4322014db80f7eb88f6534d67e7babb8ac1ae61297178f319963259ddb157d57d2561d8f57358fd2e996e0ab0479d5b4c21",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-network/3.4.0",
+    "dest-filename": "ktor-network-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-serialization-jvm/3.4.0/ktor-serialization-jvm-3.4.0.jar",
+    "sha512": "2835cf8f605f89cfdac308dc775998a6c82a1291bdb5aaa74ca4da91b08b4bf5ac43f11e4c586a2cc74a7e4202760be842e50ebc24acca485ed1cb11a495a077",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-serialization-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-serialization-jvm/3.4.0/ktor-serialization-jvm-3.4.0.module",
+    "sha512": "d690d301b2db9e32a16490661d27c08d6c7dbc563ee0f49398f481fdf889e3adf0d1114f845722dca79dfc2e5baff0dbff808c2159a1e718e161a090cd2cb5b4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-serialization-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-serialization-jvm/3.4.0/ktor-serialization-jvm-3.4.0.pom",
+    "sha512": "587d2eada3cc8f0fddbfcb476d53e78392607e525c9d325d55a21aff632ff5c7d31bd760a6d8d9b2cb3e7c08ca661171a208bc1fd994b61d7dc5d58f48fe51d5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-serialization-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-serialization/3.4.0/../../ktor-serialization-jvm/3.4.0/ktor-serialization-jvm-3.4.0.module",
+    "sha512": "d690d301b2db9e32a16490661d27c08d6c7dbc563ee0f49398f481fdf889e3adf0d1114f845722dca79dfc2e5baff0dbff808c2159a1e718e161a090cd2cb5b4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-serialization/3.4.0/../../ktor-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-serialization-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-serialization/3.4.0/ktor-serialization-3.4.0.module",
+    "sha512": "d97157b0b0d0d28908b8273f93fa62cbbbec09c115a2fdfec1c9d98437b07190c8b6c1bf70b95378b14947a1463334d47af33369691abe277f9ca5dc98990784",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-serialization/3.4.0",
+    "dest-filename": "ktor-serialization-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-serialization/3.4.0/ktor-serialization-3.4.0.pom",
+    "sha512": "0a69b4110c4248f49a8f10e2eda97051b66d044bc8289ee8531e85b6015bc62aa301de6480a2c44bddc769b80ccca886568b8f4f12bedd8e6e2ee377f48a545c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-serialization/3.4.0",
+    "dest-filename": "ktor-serialization-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-sse-jvm/3.4.0/ktor-sse-jvm-3.4.0.jar",
+    "sha512": "70c8873934e6567d26d38b0dcea32bd39ec7d0f2088df168f1bb5b159956ec1d8e43f775c4987e8042062b1826324bf9da86f458debc62cc49897e878c1675d6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-sse-jvm/3.4.0",
+    "dest-filename": "ktor-sse-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-sse-jvm/3.4.0/ktor-sse-jvm-3.4.0.module",
+    "sha512": "c6f4e5a313b521d71edbc7c61abe823370d4df606e7fa07b92aa5409e5ada2ae5ae9737a0df85919f4e1d6a7c25e9855c2818474b79818fe200796a5a28e553b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-sse-jvm/3.4.0",
+    "dest-filename": "ktor-sse-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-sse-jvm/3.4.0/ktor-sse-jvm-3.4.0.pom",
+    "sha512": "1e336075c24c6093e629d7e5ddf8ab30647f2fe596c84885a3d205487809049de00d4069575e84a4f0fb5241e1a4bf337c788e11589388caa287c22b08da9719",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-sse-jvm/3.4.0",
+    "dest-filename": "ktor-sse-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-sse/3.4.0/../../ktor-sse-jvm/3.4.0/ktor-sse-jvm-3.4.0.module",
+    "sha512": "c6f4e5a313b521d71edbc7c61abe823370d4df606e7fa07b92aa5409e5ada2ae5ae9737a0df85919f4e1d6a7c25e9855c2818474b79818fe200796a5a28e553b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-sse/3.4.0/../../ktor-sse-jvm/3.4.0",
+    "dest-filename": "ktor-sse-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-sse/3.4.0/ktor-sse-3.4.0.module",
+    "sha512": "03be1cc20473ae761d68d9bede830792d4bfc7c64a72572b494eb9aa251dd891ce4dd982702be71e89538a57f6b551dec2ec82303fd8519337c9378205bc21fa",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-sse/3.4.0",
+    "dest-filename": "ktor-sse-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-sse/3.4.0/ktor-sse-3.4.0.pom",
+    "sha512": "f3414006401f12c9209d69457406d074bf557f28750dbeed3e2fc499fe12b1527a0fe61a37b70677887b9e837391acba2b361b56e389761ea50e07eba3c5cd7c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-sse/3.4.0",
+    "dest-filename": "ktor-sse-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-utils-jvm/3.4.0/ktor-utils-jvm-3.4.0.jar",
+    "sha512": "167a52204a8008cfad13b0483b42660bff1802e8990e63f63c22d1f6372b63b8955c6c947b7222d7e12eb6fb371221f2bf2fa17c34249bee5535d7290cc487c7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-utils-jvm/3.4.0",
+    "dest-filename": "ktor-utils-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-utils-jvm/3.4.0/ktor-utils-jvm-3.4.0.module",
+    "sha512": "6e73198e9e9329ae35f711196d8c0606e1819a011f6b83a2f505e407411e9c2c434e4d1a524e410b47ff33d41627086323b99ce7628bba0b2020e3c2549d8d41",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-utils-jvm/3.4.0",
+    "dest-filename": "ktor-utils-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-utils-jvm/3.4.0/ktor-utils-jvm-3.4.0.pom",
+    "sha512": "aee39cafff63c4252648e39d0694a38892fae1b31b84db1756bf39ddb8de4a84b428b54f8d77813851fdc1761b7f2441fafe678f1c80b713e40f3aa763842dee",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-utils-jvm/3.4.0",
+    "dest-filename": "ktor-utils-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-utils/3.4.0/../../ktor-utils-jvm/3.4.0/ktor-utils-jvm-3.4.0.module",
+    "sha512": "6e73198e9e9329ae35f711196d8c0606e1819a011f6b83a2f505e407411e9c2c434e4d1a524e410b47ff33d41627086323b99ce7628bba0b2020e3c2549d8d41",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-utils/3.4.0/../../ktor-utils-jvm/3.4.0",
+    "dest-filename": "ktor-utils-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-utils/3.4.0/ktor-utils-3.4.0.module",
+    "sha512": "e923bf27ebe2fc08eaefc6d93f11d4c62b9e9407f396fb919573ff2b70cda5d67510eeb25157bb36179b9b45a0cf4d1142c7780120f31b16b429a611f06e7ed2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-utils/3.4.0",
+    "dest-filename": "ktor-utils-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-utils/3.4.0/ktor-utils-3.4.0.pom",
+    "sha512": "55468d197489538c3844a4b6032aaa81bb8d299289efdefaabf128e9d1ff26e72d04a333a6d7312e4447fc231d1c5212f90035d345858ebf688a32963e1475ee",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-utils/3.4.0",
+    "dest-filename": "ktor-utils-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websocket-serialization-jvm/3.4.0/ktor-websocket-serialization-jvm-3.4.0.jar",
+    "sha512": "3e895604a08d959d70a4019b4d96f767be3c8ef6569952039ad5eb5bd90d7f86d288a477e355dc2556ba65cab793ed3946a6db8b71d9f315cc67bcf95330f728",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websocket-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-websocket-serialization-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websocket-serialization-jvm/3.4.0/ktor-websocket-serialization-jvm-3.4.0.module",
+    "sha512": "e94fbe3344b7aa861f843354af88e5235c1fb2ed094eb5280c1d749b66a25ad6e78fb7d0ab84fa05a7eb42bcfc0652d798a8997962ef0a19e5338b4ae0595b3e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websocket-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-websocket-serialization-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websocket-serialization-jvm/3.4.0/ktor-websocket-serialization-jvm-3.4.0.pom",
+    "sha512": "27d1f240459e977fb9c0eb8fcb3882713233753fe4d1c2ae55b69794b8546dd016ca51e78c5fd8a0998e7ae358a0c923369d5c2dbd943c9cbf59ef6dddb2695e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websocket-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-websocket-serialization-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websocket-serialization/3.4.0/../../ktor-websocket-serialization-jvm/3.4.0/ktor-websocket-serialization-jvm-3.4.0.module",
+    "sha512": "e94fbe3344b7aa861f843354af88e5235c1fb2ed094eb5280c1d749b66a25ad6e78fb7d0ab84fa05a7eb42bcfc0652d798a8997962ef0a19e5338b4ae0595b3e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websocket-serialization/3.4.0/../../ktor-websocket-serialization-jvm/3.4.0",
+    "dest-filename": "ktor-websocket-serialization-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websocket-serialization/3.4.0/ktor-websocket-serialization-3.4.0.module",
+    "sha512": "d4c78750c040a2014c8ef5b4b43d710b937febd84861ac584bc3b28955553be07fd86061afb1323576da52382154cadccf5edb96fa5b7810a113d750a17c6f5e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websocket-serialization/3.4.0",
+    "dest-filename": "ktor-websocket-serialization-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websocket-serialization/3.4.0/ktor-websocket-serialization-3.4.0.pom",
+    "sha512": "ca47291ae49f4af6b15afd228caf2c88b7b835a9124f1ee3a8aa67fcf22f28abd2b0e744143f00a4ffd16a67d3645c73edfa51ac476239cdbccf041ee509cb12",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websocket-serialization/3.4.0",
+    "dest-filename": "ktor-websocket-serialization-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websockets-jvm/3.4.0/ktor-websockets-jvm-3.4.0.jar",
+    "sha512": "c5e632d9ed52ac978789dc3add02f05e05676ac9475947ebf917a5115286f1e7fc66b0e3d36f224357209e1cf722f2162f99347f72cfe3cc4a083782656d64a1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websockets-jvm/3.4.0",
+    "dest-filename": "ktor-websockets-jvm-3.4.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websockets-jvm/3.4.0/ktor-websockets-jvm-3.4.0.module",
+    "sha512": "6eb9c0117c004790629e7e559b4b001a62a6980da182d537c14a652b45a2a1a971e840d09c04b4b1a6eb218e0f8ec99e5fc68b1d2d14437b7b958fbe02e85f09",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websockets-jvm/3.4.0",
+    "dest-filename": "ktor-websockets-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websockets-jvm/3.4.0/ktor-websockets-jvm-3.4.0.pom",
+    "sha512": "8fce88d2f1e8cd471280dad402bb41026ec350923fc3ded7c7afc2a78fd29a73f695f930b8f7c6783867311df28220eb8406cfd064e9ef4368a757f8f605b538",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websockets-jvm/3.4.0",
+    "dest-filename": "ktor-websockets-jvm-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websockets/3.4.0/../../ktor-websockets-jvm/3.4.0/ktor-websockets-jvm-3.4.0.module",
+    "sha512": "6eb9c0117c004790629e7e559b4b001a62a6980da182d537c14a652b45a2a1a971e840d09c04b4b1a6eb218e0f8ec99e5fc68b1d2d14437b7b958fbe02e85f09",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websockets/3.4.0/../../ktor-websockets-jvm/3.4.0",
+    "dest-filename": "ktor-websockets-jvm-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websockets/3.4.0/ktor-websockets-3.4.0.module",
+    "sha512": "c3fbc677a5920245d6a1d4760d7d6c6f749ca9e2081127543260d230d260c15a341d302d0518170a1fa0804ace90b102f98ff12106868e3944bb74d6d37c8998",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websockets/3.4.0",
+    "dest-filename": "ktor-websockets-3.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/ktor/ktor-websockets/3.4.0/ktor-websockets-3.4.0.pom",
+    "sha512": "abf96a01db520b9db71b7223ce4d0e9f1acc9ea0c5506c7abbb5481e129b6d901de46941e9672de7f14d8dfa64840ce9b0046fafad90f8669204f52bb91e268b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/ktor/ktor-websockets/3.4.0",
+    "dest-filename": "ktor-websockets-3.4.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/opencensus/opencensus-api/0.31.1/opencensus-api-0.31.1.jar",
+    "sha512": "aac98ed2de298609bac9cb5a69ac16df0ca9c9fc82f429720ddcfdd769fdae96b707ed81c8d8c37380de846b302aacaac80156ef75567061aed3f77cc3c3b725",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/opencensus/opencensus-api/0.31.1",
+    "dest-filename": "opencensus-api-0.31.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/opencensus/opencensus-api/0.31.1/opencensus-api-0.31.1.pom",
+    "sha512": "d1a4b97808f714e15aa21dd64292797b8bb02227dd3699d47a3738436c682808658445a602235c0aa964acb4b9461c85b4634171552d0efea683beea61173099",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/opencensus/opencensus-api/0.31.1",
+    "dest-filename": "opencensus-api-0.31.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/opencensus/opencensus-contrib-http-util/0.31.1/opencensus-contrib-http-util-0.31.1.jar",
+    "sha512": "3192532e4989a26d9a69f4246ef994b35058d155e199b500196d14427d1b46b1515f872a36500cb84768524870297388c90272ffa61dc8448f6f7571c4f86b27",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/opencensus/opencensus-contrib-http-util/0.31.1",
+    "dest-filename": "opencensus-contrib-http-util-0.31.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/opencensus/opencensus-contrib-http-util/0.31.1/opencensus-contrib-http-util-0.31.1.pom",
+    "sha512": "1c844455a2555327c106dc16f9bcf0c467473764e20408eae9c1d0493a9cc735d6116d28c90df63f3028b750607d0254e650fbcc4fa359157b7fec56ce79a456",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/opencensus/opencensus-contrib-http-util/0.31.1",
+    "dest-filename": "opencensus-contrib-http-util-0.31.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/swagger/core/v3/swagger-annotations/2.2.31/swagger-annotations-2.2.31.jar",
+    "sha512": "950abb3943cc5207824e167bf6e71205115773b84522d35c5da9e349d6ba107b20fc98e4ae13894567bdbee36e887c5877cc74619399fbcbb127a1e65ed6ec7f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/swagger/core/v3/swagger-annotations/2.2.31",
+    "dest-filename": "swagger-annotations-2.2.31.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/swagger/core/v3/swagger-annotations/2.2.31/swagger-annotations-2.2.31.pom",
+    "sha512": "3170e9c848dd983b03085c0f4563f97a56e95557ad8c1275961267dd481784f077a55f03efc4e1b2c708fe1d95b642680f76098b3cccaec9698da60f4c8b83b1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/swagger/core/v3/swagger-annotations/2.2.31",
+    "dest-filename": "swagger-annotations-2.2.31.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/io/swagger/core/v3/swagger-project/2.2.31/swagger-project-2.2.31.pom",
+    "sha512": "9d900076540bd9bb18758ee4169ad41d43c8311a7511ace95200384f1170db4cf7791c8b3d3d9a40920c23ab6a97883a78e6382aa1b8a66580221010f64a89d0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/io/swagger/core/v3/swagger-project/2.2.31",
+    "dest-filename": "swagger-project-2.2.31.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/jakarta/platform/jakarta.jakartaee-bom/9.1.0/jakarta.jakartaee-bom-9.1.0.pom",
+    "sha512": "7938ebe765028f8f231df08fa1e52550034d0b9278760c3b374b5ca21740fe90e2c8ff889c08a091575fe088d8f516d7510484359ea94c3e9ed23f5586567f5b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/jakarta/platform/jakarta.jakartaee-bom/9.1.0",
+    "dest-filename": "jakarta.jakartaee-bom-9.1.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/jakarta/platform/jakartaee-api-parent/9.1.0/jakartaee-api-parent-9.1.0.pom",
+    "sha512": "358a9b92ae14c9c8b2480a1d90675efacc7a9abb3ebde5fa15f2a114d860b7be9842dd70798721383158d6633e75e3b5c37f9555a58be5b6e4ecdf57838cbd43",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/jakarta/platform/jakartaee-api-parent/9.1.0",
+    "dest-filename": "jakartaee-api-parent-9.1.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar",
+    "sha512": "679cf44c3b9d635b43ed122a555d570292c3f0937c33871c40438a1a53e2058c80578694ec9466eac9e280e19bfb7a95b261594cc4c1161c85dc97df6235e553",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/javax/annotation/javax.annotation-api/1.3.2",
+    "dest-filename": "javax.annotation-api-1.3.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.pom",
+    "sha512": "b97c6fb3b5c6f9ba5c6ec2aa35713816fca94927c1393d2eaa04cac6a6c44c464baeb34d62d9af33268a7eaa817318df1b2116641ff7e8ade84c70b358e60bac",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/javax/annotation/javax.annotation-api/1.3.2",
+    "dest-filename": "javax.annotation-api-1.3.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/junit/junit/4.13.1/junit-4.13.1.pom",
+    "sha512": "919c6fc7a6fab977129181d2b7d06c77fa1efe4c0152204c2fd913cf4a22da0a91bf0ac36051d318cb436d6f9b34defe83ce42c56ddf035abca47a73643c3ea9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/junit/junit/4.13.1",
+    "dest-filename": "junit-4.13.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/net/bytebuddy/byte-buddy-agent/1.14.13/byte-buddy-agent-1.14.13.pom",
+    "sha512": "e97314f002e59a160b12f20dfcaf2d08b20b20b823ca381b6bf5c388ccc87a1de0607ef625ee44871e01038ef7cbfc20776485e39a219565845c18096d33eee3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/net/bytebuddy/byte-buddy-agent/1.14.13",
+    "dest-filename": "byte-buddy-agent-1.14.13.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/net/bytebuddy/byte-buddy/1.14.13/byte-buddy-1.14.13.pom",
+    "sha512": "4010b96f40fe4b8caec63b9011caeb90bb9853e28f3dbe10591cbe2deb003de43fb003802180e2646bb0f1c25ff8db8f3cfba8936cc3a3afd4bc7163c1b830fd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/net/bytebuddy/byte-buddy/1.14.13",
+    "dest-filename": "byte-buddy-1.14.13.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/net/java/jvnet-parent/3/jvnet-parent-3.pom",
+    "sha512": "93b78fac40ca4de12d5a2fb4e339ba9e3c40a25ddcfe58272dc2a8e4b36d2c7cc51075aa2a25f0b3c1d4bd3142551e77847d1bd5599c60f5d50d548b72b74bfa",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/net/java/jvnet-parent/3",
+    "dest-filename": "jvnet-parent-3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/apache/13/apache-13.pom",
+    "sha512": "3b25f9f51a7ee9647fe2e1287e75a67ccdf3f08055bec20c6a60b290876afc691f16b23ab3df7b733695b828411b716a0b3509c22ec6fb0c5dce4f21811ae434",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/apache/13",
+    "dest-filename": "apache-13.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/apache/17/apache-17.pom",
+    "sha512": "1f46cdfd0b29f7faabe6b0c3ec096408d52cf321db81100e69b737443f2b9e71b68a3bfa8f64e318c16859e2de8daafbf40bb0c375c10354a892217cfeee5bec",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/apache/17",
+    "dest-filename": "apache-17.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/apache/21/apache-21.pom",
+    "sha512": "c82bd27c06d76b3f467118b1a8e0976c60fd0e7d7a01dac685c9a91e1822c0e6f5829bf48ad532a9fc000089cdb894a97c5686365fd3c8c8bfa787136a4fa9d2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/apache/21",
+    "dest-filename": "apache-21.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/apache/27/apache-27.pom",
+    "sha512": "35e0254ae70a1b2756e63fde157355a138b0924a7298136135c14092a00e36a7207c46f96c12824f7ce41bf80315594c0c65b832fe9df0a1a4f8b7fd97b59da6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/apache/27",
+    "dest-filename": "apache-27.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/apache/35/apache-35.pom",
+    "sha512": "d599ebf085e96ab2c0fa925fec99fc046f1763743a0445e5a4bf255d8259d44aec7bd175881accf1c6562e13efc26b13a54de01c49b46032464366d41869d7e8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/apache/35",
+    "dest-filename": "apache-35.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-compress/1.28.0/commons-compress-1.28.0.jar",
+    "sha512": "f1f140f4f40ab3cf3265919db9dbb95a631a29aa784e305f291de4e68876bb711d9217d62d7937cddddd393982decdf71a608b4b3ab7f4e6375cf28af2893d7f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-compress/1.28.0",
+    "dest-filename": "commons-compress-1.28.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-compress/1.28.0/commons-compress-1.28.0.pom",
+    "sha512": "8e146052d06e3018b7336a52fbbe979b73e2cd1d318fe9fdb37e22f5ee39e65992351ce5278dc4da34a59256f797882d16b6dee34684742a8a5bfb4f0998d82f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-compress/1.28.0",
+    "dest-filename": "commons-compress-1.28.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar",
+    "sha512": "c2c9d497fc1be411050f4011b2407764b78aa098eb42925af8a197eabdbc25b507f09fb898805e9bed4815f35236a508ee5b096e36f363df4d407232d50fc832",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-lang3/3.18.0",
+    "dest-filename": "commons-lang3-3.18.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.pom",
+    "sha512": "8ea9b9e8605b841f95e856918cd21913e9955e42f5c4c487ba9580252a15163ed910a0aed39720394f2a80813015af99849aa2768254531c1cf75fab22036b00",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-lang3/3.18.0",
+    "dest-filename": "commons-lang3-3.18.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-parent/34/commons-parent-34.pom",
+    "sha512": "364ede203a23157ec601d28ff141c0c69759fc5c483e44e346fa1592403f343f0722f7763243b2ee7a190c7a744b1cce1f40247f5a6c7b3dbfbf487c505a40bf",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-parent/34",
+    "dest-filename": "commons-parent-34.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/commons/commons-parent/85/commons-parent-85.pom",
+    "sha512": "f32482d030a5dbad958d91f7137f9a4cd416a1f60b4701000574222f71e3403363f7863b6c32e19e1d1fc4f752128a6b745888172c188471bc096dc81cd7a337",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/commons/commons-parent/85",
+    "dest-filename": "commons-parent-85.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/groovy/groovy-bom/4.0.27/groovy-bom-4.0.27.pom",
+    "sha512": "50c3d4108e48058c9a0761c6bde742defedc393df49d110f51208f32b156085309420386d83a4474c31460620d2a44f3cfdcb4387311b9d50af62ac75f61f04f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/groovy/groovy-bom/4.0.27",
+    "dest-filename": "groovy-bom-4.0.27.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/client5/httpclient5-parent/5.3.1/httpclient5-parent-5.3.1.pom",
+    "sha512": "4834f80e0a0520ff783411836f2d768d786d1bc7ea51cc236a63cf6d1a1c14cbae51c8d8dd40e65ab9ef73566932a0c5983b22e5a88448763253d65a5128b900",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/client5/httpclient5-parent/5.3.1",
+    "dest-filename": "httpclient5-parent-5.3.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/client5/httpclient5/5.3.1/httpclient5-5.3.1.jar",
+    "sha512": "4c2d75106af8470789f0e08305e64ad86528f2f737da230e561892d33dbca0b6e2dbced2a075f0744cee7801c06ef174481540661b3c9a1bec6d6f93938b05bc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/client5/httpclient5/5.3.1",
+    "dest-filename": "httpclient5-5.3.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/client5/httpclient5/5.3.1/httpclient5-5.3.1.pom",
+    "sha512": "a94286b39d9d4b86572f139642c11af26681af613124839080073e0370677a3a6561725b468fe1e58c2b80070b8935a8ac9b8291b61fd7e2c1348a994ed508ec",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/client5/httpclient5/5.3.1",
+    "dest-filename": "httpclient5-5.3.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/core5/httpcore5-h2/5.2.4/httpcore5-h2-5.2.4.jar",
+    "sha512": "72fbee55f173c43d9ffc0cc5a83d59e60be1002c06ab81de39ba700cc30b04e84fdfed73d3a8985d561a1aa8ac3ca905f9259d01b431e1ff14da6fae622f787d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/core5/httpcore5-h2/5.2.4",
+    "dest-filename": "httpcore5-h2-5.2.4.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/core5/httpcore5-h2/5.2.4/httpcore5-h2-5.2.4.pom",
+    "sha512": "327396bbdc4ca1594a3283c720b9a8596218750fa46d2b320a9e31420c6d62cbe0b81807526b982dd9216b619ba131c7c0e2bd966c93202089574f5ba9471c57",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/core5/httpcore5-h2/5.2.4",
+    "dest-filename": "httpcore5-h2-5.2.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/core5/httpcore5-parent/5.2.4/httpcore5-parent-5.2.4.pom",
+    "sha512": "36ac113db005ef4c3a9b93cfbf290181f05b8bd2b0df45a05306e66cc7f77f0ab4e7af2bda7f9658fffb207163b94739d686fce47ba5b4c3c1b34df54cbc769f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/core5/httpcore5-parent/5.2.4",
+    "dest-filename": "httpcore5-parent-5.2.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/core5/httpcore5/5.2.4/httpcore5-5.2.4.jar",
+    "sha512": "9fb4134d85e665e15410af005b21cd2f9b5e60d75112945d37b879f96f769a70be034557526ea7d05f8b83dda91c56d00f946763c44a183d7aea2857549b4481",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/core5/httpcore5/5.2.4",
+    "dest-filename": "httpcore5-5.2.4.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/core5/httpcore5/5.2.4/httpcore5-5.2.4.pom",
+    "sha512": "81cd2ba8549b791f9d56f3a5c2ba964bcd4423525774106e2a39420a54d77d3da2087f41f94d51b232b0bb1c1fa52268a483b052252a6b1e43921793c83825f6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/core5/httpcore5/5.2.4",
+    "dest-filename": "httpcore5-5.2.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar",
+    "sha512": "a084ef30fb0a2a25397d8fab439fe68f67e294bf53153e2e1355b8df92886d40fe6abe35dc84f014245f7158e92641bcbd98019b4fbbd9e5a0db495b160b4ced",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpclient/4.5.14",
+    "dest-filename": "httpclient-4.5.14.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.pom",
+    "sha512": "46500859b1206c1ec6a69c66d6b6d224ac835c9316a88403a2060c658b4c4e2a7f69ce0b3b5f1900abf479ebda10757c25ab595de9527b53f9e80abdf48383e8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpclient/4.5.14",
+    "dest-filename": "httpclient-4.5.14.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpcomponents-client/4.5.14/httpcomponents-client-4.5.14.pom",
+    "sha512": "7ae6fe0a7865aa7aeb1e4f3f3694856e0b0c5f7d5e452682e3734b45e433d2001352bea46fc32c1694bd10577b16030f77161a0fdca7c369afc2cc5edf4c55e2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpcomponents-client/4.5.14",
+    "dest-filename": "httpcomponents-client-4.5.14.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpcomponents-core/4.4.16/httpcomponents-core-4.4.16.pom",
+    "sha512": "7bc3e413442010aeaaa9fa6fd11e4c32aea9cd50ad19f485869d469a13886ca70f645169c1130ccac864d73570b8dde21562313ef3f8c031ffaf8500b60e14d3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpcomponents-core/4.4.16",
+    "dest-filename": "httpcomponents-core-4.4.16.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpcomponents-parent/11/httpcomponents-parent-11.pom",
+    "sha512": "bc676698caec72d525b9bf408432e9cd9c7b5d2227e0778fd79c303041cb5b07b88f98433d59c0149d6c11c27c3834722ceb283048919e467785efd7f4c399a2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpcomponents-parent/11",
+    "dest-filename": "httpcomponents-parent-11.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpcomponents-parent/13/httpcomponents-parent-13.pom",
+    "sha512": "bd585d7785341389dca9fbf6ef5e054277bdea2a8bb53ed0c2e224e4aded418414959de13e65f8cdc4697d4bc1adfb9930d86a01e329c9f1ff8f0c7ed81e19f0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpcomponents-parent/13",
+    "dest-filename": "httpcomponents-parent-13.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar",
+    "sha512": "168026436a6bcf5e96c0c59606638abbdc30de4b405ae55afde70fdf2895e267a3d48bba6bdadc5a89f38e31da3d9a9dc91e1cab7ea76f5e04322cf1ec63b838",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpcore/4.4.16",
+    "dest-filename": "httpcore-4.4.16.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.pom",
+    "sha512": "8d8809246d6a665e0870dc396da4292c13bee7db7d82fdfffd90049b33141d45d5c1b022d095d0f270fa758472dcd3c6ec742efa045e03eedbe66ceeeca426d4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/httpcomponents/httpcore/4.4.16",
+    "dest-filename": "httpcore-4.4.16.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-api/2.25.3/log4j-api-2.25.3.jar",
+    "sha512": "ce9aaf5beec0fb8cbed8c4ae8a91a58d3f6935c731220b294d70f1569128b5ff367e1bf94d69572dd7ab05bff2a63bde5ff7489eb9743e8c307b644eaeadbc50",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-api/2.25.3",
+    "dest-filename": "log4j-api-2.25.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-api/2.25.3/log4j-api-2.25.3.module",
+    "sha512": "99c9fca00147b10e9dfe429ec71e23d61d48af6f4f6c4bc9f4f742fa4ad98222b88603288588c790e170f5ca6418b9f16cc143bc269504da033b994f4d169b2c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-api/2.25.3",
+    "dest-filename": "log4j-api-2.25.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-api/2.25.3/log4j-api-2.25.3.pom",
+    "sha512": "f5d562192bd39b61888b1294ce30e4a9566a741a21ff3005e2aa71d97ab8947c586df194ee3df48cf9650bdfe16fd9e8c58aa20f70c6abca089528ee730bcfe3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-api/2.25.3",
+    "dest-filename": "log4j-api-2.25.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-bom/2.25.3/log4j-bom-2.25.3.pom",
+    "sha512": "c74685af635596d18404b30c23971b7c300e50d574542f260920495474f36423e752070a3623e58ede6e18e5dac6cf16b69c0d5bfd7da673bea785c55a1e4d19",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-bom/2.25.3",
+    "dest-filename": "log4j-bom-2.25.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-core/2.25.3/log4j-core-2.25.3.jar",
+    "sha512": "64a0776adfd0b082f80e49f4afb8998c15d30c515a3441a074364d37479a2fc059bdd74694c3f609b1fae1d2eca0cb88347e1afd88774ac698a42b8744bf259f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-core/2.25.3",
+    "dest-filename": "log4j-core-2.25.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-core/2.25.3/log4j-core-2.25.3.module",
+    "sha512": "8c27ad55e87bc8484e74f2c03fbddf1015ed7011e26e4c2e2a36c5f5241df1d099d48a7a9253f8185d5d55c990b8773eb25427d642e3d50edbc737cde4585299",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-core/2.25.3",
+    "dest-filename": "log4j-core-2.25.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-core/2.25.3/log4j-core-2.25.3.pom",
+    "sha512": "70d08161e20bf2bd080a9dce25613bbf00a0558c39d25944c27577c800bb1df37e7bc26220bccb5f13a6e8f731b74976a03d988a46963c59735fcb225f6efe9b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-core/2.25.3",
+    "dest-filename": "log4j-core-2.25.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.3/log4j-slf4j2-impl-2.25.3.jar",
+    "sha512": "b10e5a0485e273c93ce54df6e37368e3486c10903b4ee948a116eb48a3bf201521e0abb795130e34911d9e115ddfb5490ed5f761b6e2149bac87ea9932162447",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.3",
+    "dest-filename": "log4j-slf4j2-impl-2.25.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.3/log4j-slf4j2-impl-2.25.3.module",
+    "sha512": "19b422d96455ce7631bd182b162e91937067bb546376c696c02c7751900d3feab36a006181c6294997a483d06959e46a4943efbd019d7d80a6294c2a20d1bbf9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.3",
+    "dest-filename": "log4j-slf4j2-impl-2.25.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.3/log4j-slf4j2-impl-2.25.3.pom",
+    "sha512": "233f84ae615f63c88c997485c19c55bc2d0d15726ac833f461c118d66ac0657e94abfac4811a49aacf88383b91126a2e5508d6e486474fe8c4a9190f06781938",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.3",
+    "dest-filename": "log4j-slf4j2-impl-2.25.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/logging/log4j/log4j/2.25.3/log4j-2.25.3.pom",
+    "sha512": "463edf83a6ed927a5612fc92c5e5f312a7c92f55c834a3a090514baef49e5dbcfdaca2ce43111f9900f12febaec5f6fd7c2c1589d3680ce5db1f4e0ce86cf203",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/apache/logging/log4j/log4j/2.25.3",
+    "dest-filename": "log4j-2.25.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.jar",
+    "sha512": "823ea28e3c822ff48e4e985a421fa0b53ca3419e2c0635c3d4d0a9822399b6491780e26a9161d4733857c97987bff2d725ff4453b2c22ed412eef46ea27f5d84",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/checkerframework/checker-qual/3.43.0",
+    "dest-filename": "checker-qual-3.43.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.module",
+    "sha512": "b5f80edd3661a81288365222b95a85e19096e4bd5485f59b7d72b807553ba8c0dbb1cee300a987f6a0ced3d4114b494cbabe82f52e48f596ae17fab1f1898eba",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/checkerframework/checker-qual/3.43.0",
+    "dest-filename": "checker-qual-3.43.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.pom",
+    "sha512": "b7bdf783e5ea98ee0e11d264f4a0022fd5ae4c228a00e2e8ba2f36c1a3991903ac334ea030bcbf1837e4097599f7cd0a599e0b4c03b35d5dc7550b4d93efda0f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/checkerframework/checker-qual/3.43.0",
+    "dest-filename": "checker-qual-3.43.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/eclipse/ee4j/project/1.0.7/project-1.0.7.pom",
+    "sha512": "b33f5cf3404c4f9f5cbb69a43dcde2d6f06d6cb3d00444dbce879a1bf14f0be4e3093f21be1aa85104cf45ae86ba69374949e35ed567f82f6ede5812140628de",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/eclipse/ee4j/project/1.0.7",
+    "dest-filename": "project-1.0.7.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar",
+    "sha512": "934c6c2bf47c1b88b1f81c25294cd83f5105f90f565e1fce75a09a54e51424fb8335542a6d5c3eb9df19dbc0007e869e9b6aebaf37880eac09759529dc0c5ca7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/freemarker/freemarker/2.3.32",
+    "dest-filename": "freemarker-2.3.32.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/freemarker/freemarker/2.3.32/freemarker-2.3.32.pom",
+    "sha512": "4ac2a905f63f0bb870843564f87f5c71b045bc094cc3226dd87e9273e150abf97b17b83aa99da6727ee93e87b0e71254a0b5ff90ef0cf4aa75b643c95371394b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/freemarker/freemarker/2.3.32",
+    "dest-filename": "freemarker-2.3.32.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.jar",
+    "sha512": "03a21b3e1f63e7f4d35db7eb5de6f5f25d03fa82b4d3bf4ddf78ddc4a665b83c772f3f4519c38aa92bb81551feb3fe04287ee0a7590dffec1f125b06520a0fc4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-websocket/Java-WebSocket/1.6.0",
+    "dest-filename": "Java-WebSocket-1.6.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.pom",
+    "sha512": "3b85107096331d843208010a02c16a512941ee5439023d551031f40e794642efe1eea2152a248d073263687da8cf0e60e7cd3236d676141ff24312fde46b4346",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/java-websocket/Java-WebSocket/1.6.0",
+    "dest-filename": "Java-WebSocket-1.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jcommander/jcommander/1.85/jcommander-1.85.jar",
+    "sha512": "aa1d19723c83de1f54f6f645121ab283403ece5ba78319c9daa4418c421e26c7fbd8bc36d35f6ed4cd9b8ae25d6daa2bc36818a1659cec8c5550441d6fb609d0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jcommander/jcommander/1.85",
+    "dest-filename": "jcommander-1.85.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jcommander/jcommander/1.85/jcommander-1.85.module",
+    "sha512": "eabf09e72953ca83854a08222b637325129aca6e34226a5f8f3de878885b7fd8aa5662f9517ef388c75e74bc21fe72c52d6aceff3858b06684db66d8a1115940",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jcommander/jcommander/1.85",
+    "dest-filename": "jcommander-1.85.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jcommander/jcommander/1.85/jcommander-1.85.pom",
+    "sha512": "ccc4052db8f88869b3582941d2bc42a69b6506c5992fcaddb788833bbc8668a2dac3d25917a7f50160d076b87c2b939d5df242107ccaf41d73c9d34b0764a21d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jcommander/jcommander/1.85",
+    "dest-filename": "jcommander-1.85.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/annotations/13.0/annotations-13.0.jar",
+    "sha512": "5622d0ffe410e7272e2bb9fae1006caedeb86d0c62d2d9f3929a3b3cdcdef1963218fcf0cede82e95ef9f4da3ed4a173fa055ee6e4038886376181e0423e02ff",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/annotations/13.0",
+    "dest-filename": "annotations-13.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/annotations/13.0/annotations-13.0.pom",
+    "sha512": "63ef480f698215d4cd4501b06e86df1a741ac2b86216fd3ff6eee146da746caa390df27351e25598971edb368aeae41055ff1ed77e4bf5d7edb6abc832d150ce",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/annotations/13.0",
+    "dest-filename": "annotations-13.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/annotations/23.0.0/annotations-23.0.0.jar",
+    "sha512": "cb82eb0aaae88e3283b299929173296e30c7b078105e0fc5ecfbcd4eb230026f9a7cc46680832d036e6c1ff036ad99d4c50dc296d4919d223879081ac1616944",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/annotations/23.0.0",
+    "dest-filename": "annotations-23.0.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/annotations/23.0.0/annotations-23.0.0.pom",
+    "sha512": "ae58d75b40e44cb0d8e3bb701c7afefa8cbf96066ae52fc3d57c69b7a7e819fd9b3b01971376da6ea94ee010b9ee59ba05a331b93a65e94c047b095131efd6c0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/annotations/23.0.0",
+    "dest-filename": "annotations-23.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/intellij/deps/coverage-report/1.0.25/coverage-report-1.0.25.jar",
+    "sha512": "a05781dc712a3c84f86c6f0ded369d827fcf0c310c0beff83a38d8825a49b357737e19e3b766bc72c1bad55e3b3d7dc9e043184426dd95cce74a1d71699c7327",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/intellij/deps/coverage-report/1.0.25",
+    "dest-filename": "coverage-report-1.0.25.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/intellij/deps/coverage-report/1.0.25/coverage-report-1.0.25.pom",
+    "sha512": "9cc6c4439df5d48e76b46ca121eebd8c242480c66e0075a1177cf0917b8a9439dbd01be78298ec7c0a246a2f345011161d9e218f0363a083695d6847438342be",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/intellij/deps/coverage-report/1.0.25",
+    "dest-filename": "coverage-report-1.0.25.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/intellij/deps/intellij-coverage-agent/1.0.765/intellij-coverage-agent-1.0.765.jar",
+    "sha512": "ba0a65c262607e07bc5ca194e495279301908ad2882c06f2f7d6ccd1c736508e024a0585a13b513ea29643ca682daca1da25912327e9379461a1229fa48d2f77",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/intellij/deps/intellij-coverage-agent/1.0.765",
+    "dest-filename": "intellij-coverage-agent-1.0.765.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/intellij/deps/intellij-coverage-agent/1.0.765/intellij-coverage-agent-1.0.765.pom",
+    "sha512": "fe163a37c967274eab30db61f38df89bc9f312da95ed01a1f43d727dcf3d9b133ecffd7064657238f5a8924f4ab9cce54d9fa5d682720f443cb95a4d59374193",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/intellij/deps/intellij-coverage-agent/1.0.765",
+    "dest-filename": "intellij-coverage-agent-1.0.765.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/intellij/deps/intellij-coverage-reporter/1.0.765/intellij-coverage-reporter-1.0.765.jar",
+    "sha512": "900e929c5b6873334504fd2115a179ae0c70a6bef5d048df25302a11c7522830fb390965a2b1a8307091d5c0cae6b3411fa7320c8d8db04c56b2f174e407f68a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/intellij/deps/intellij-coverage-reporter/1.0.765",
+    "dest-filename": "intellij-coverage-reporter-1.0.765.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/intellij/deps/intellij-coverage-reporter/1.0.765/intellij-coverage-reporter-1.0.765.pom",
+    "sha512": "0436ee3fad9eb1a4d299706eadfd38d2a509f3fa45bab1965642cf701550f4f1b058a7bb2005ed6b032be3e85c813ee8c6ee539823a121ebca4c8043652d11f8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/intellij/deps/intellij-coverage-reporter/1.0.765",
+    "dest-filename": "intellij-coverage-reporter-1.0.765.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/abi-tools-api/2.3.10/abi-tools-api-2.3.10.jar",
+    "sha512": "201ca364021448c2918df71d30089df589a4e3ebe56c3ad8d09014ed672ab7a16dfe1c5ed3362d8ef885dee1a0cf06e188621d1ae9c932ced974a129f30aa18d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/abi-tools-api/2.3.10",
+    "dest-filename": "abi-tools-api-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/abi-tools-api/2.3.10/abi-tools-api-2.3.10.pom",
+    "sha512": "d5f411fa775ec484f75484cf7baae80f0de0e4d3a03328b468474c908305ba25dd035aadbe24dd7bff024d7283fb041b15689d8ba69bd30dedd70829c500570d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/abi-tools-api/2.3.10",
+    "dest-filename": "abi-tools-api-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/abi-tools/2.3.10/abi-tools-2.3.10.jar",
+    "sha512": "ffd8f0cd4874b6a7933c1f9391461c194dc7105267f8425ee3710fe6b69ca78adf4292aa8228b717d2d02c57c99de19eca8c5a846711dbc192dc1730a915bff0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/abi-tools/2.3.10",
+    "dest-filename": "abi-tools-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/abi-tools/2.3.10/abi-tools-2.3.10.pom",
+    "sha512": "fd69ecc8396fa3f5a6db96804886955a4a197ecea84ef69506bea65cf7a53e3a036690ef5ae5daf04c150b27820293dcb3d7175fa96d71a63f85e9f57b80543c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/abi-tools/2.3.10",
+    "dest-filename": "abi-tools-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/atomicfu/2.3.10/atomicfu-2.3.10.pom",
+    "sha512": "3b8a532071834d576e704368136a40297b3dbcdfc7db025652ed378a2552af5e37539e508f8a42e00d7c2be6f450b2e45d75400a9111680610840c08c66ff45a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/atomicfu/2.3.10",
+    "dest-filename": "atomicfu-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/compose-compiler-gradle-plugin/2.3.10/compose-compiler-gradle-plugin-2.3.10.pom",
+    "sha512": "46ebaf0d0277e1f8f041c2449ff89899376eb660095d7c86539fa20defe512ff6b5dba9ad1cf1b71b6e4a877e8b2900af26c5d95bd08002861fff181c1da23ee",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/compose-compiler-gradle-plugin/2.3.10",
+    "dest-filename": "compose-compiler-gradle-plugin-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.3.10/fus-statistics-gradle-plugin-2.3.10.pom",
+    "sha512": "8eeb13dfb218d9d739186a5ba8152bd2b044a6b23e297d040b73db602b0fc03ec725222464c270b7707945d4e662253859a501a06afa8649ade77a9d877aa9b7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.3.10",
+    "dest-filename": "fus-statistics-gradle-plugin-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-allopen/2.3.10/kotlin-allopen-2.3.10.pom",
+    "sha512": "b10558b0fe55dcd52cd79a3c15cb2c1e36c88e54a5465f14b404f0ffec1c2a1df5cca33fcf642ffafb0483fc037b9e2153f5389cc5f01880fb7f7a8f20819751",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-allopen/2.3.10",
+    "dest-filename": "kotlin-allopen-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-assignment/2.3.10/kotlin-assignment-2.3.10.pom",
+    "sha512": "89de8a58f65a73eab2656395d1a0ce17681402589a0fd9f20eb867de4cda062877dd20e644e37bcddae7c992552fb0242a32431155b223caaa2a817f28c2e4f9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-assignment/2.3.10",
+    "dest-filename": "kotlin-assignment-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-build-tools-api/2.3.10/kotlin-build-tools-api-2.3.10.jar",
+    "sha512": "6b8619c015fc3fc0e1668649358adead2916909f713e2be988a9799183e94a9ccbc5dc46610aef96da66e74eccfe77233719641e068d2f4f90d66d1ed6aae9d1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-build-tools-api/2.3.10",
+    "dest-filename": "kotlin-build-tools-api-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-build-tools-api/2.3.10/kotlin-build-tools-api-2.3.10.pom",
+    "sha512": "b8b09e88d3ac6ec5b79cf8ca65a997b633ceb7065ac80b1a64e19d5016bb00baa674f2879384597cbf758211d4f5aa483136d5ccb6dba5bc2bcf2ddbbbdb79d3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-build-tools-api/2.3.10",
+    "dest-filename": "kotlin-build-tools-api-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-build-tools-compat/2.3.10/kotlin-build-tools-compat-2.3.10.jar",
+    "sha512": "e73f230c29d091ee122a2a78917a639a12e34b79ac368279c195321b5c19b5dbfa3c9ad4c36c4e414f790cc61d16c4aed37e9a7d6e88f86a0e8cf0db1453ebca",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-build-tools-compat/2.3.10",
+    "dest-filename": "kotlin-build-tools-compat-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-build-tools-compat/2.3.10/kotlin-build-tools-compat-2.3.10.pom",
+    "sha512": "0dc4f38e5b8e0522a502a5fc7b4c4232a8231959eb10003e9b8dd3da549399af33da9cca16394d3799f37e403d87acaaaf0511692732fb44dc8afaea27fd9ffa",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-build-tools-compat/2.3.10",
+    "dest-filename": "kotlin-build-tools-compat-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-build-tools-impl/2.3.10/kotlin-build-tools-impl-2.3.10.jar",
+    "sha512": "18a3dafb863e9ba01ee521b28ebd8f425b66d58d0f6e26679725010f0321b7d4eb4345511df8244536ec8c9cc34ae6525bb28f56e896375ce7098f3dd431c2fa",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-build-tools-impl/2.3.10",
+    "dest-filename": "kotlin-build-tools-impl-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-build-tools-impl/2.3.10/kotlin-build-tools-impl-2.3.10.pom",
+    "sha512": "db0afec380882da0520e11a10d39ab4e844d653a5a421b24b653e24292fb74c951a12073d23d76e0198f9fd307f28ffcd2529fd0b38654c060e471f8a6ba184b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-build-tools-impl/2.3.10",
+    "dest-filename": "kotlin-build-tools-impl-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.3.10/kotlin-compiler-embeddable-2.3.10.jar",
+    "sha512": "c1621a6ecdcb45286601378ee0724f462741e8dfc44236d6e52e1f0b2bc6696ad9276dd3835cbdcdc016b38be4b1bb72e83d11495f0f8cc8159e97db8f8181f0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.3.10",
+    "dest-filename": "kotlin-compiler-embeddable-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.3.10/kotlin-compiler-embeddable-2.3.10.pom",
+    "sha512": "baa0252d6f6b59c1712662a5eddf26b82f4746db437a6d8b6f57b46f4a62ff21f897be64f697d7f18ccd351594a0f0d576b0af7e3c84dc34f5b7e2200916457f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.3.10",
+    "dest-filename": "kotlin-compiler-embeddable-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-compiler-runner/2.3.10/kotlin-compiler-runner-2.3.10.jar",
+    "sha512": "55add2f091f67c651cbdd7c912f58466f3e402893c64164aae51094a4f2eb063e020660ef7f9b0770b9bb61ced0829a1906226f4c82d4a54d376b9d56c49e3b3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-compiler-runner/2.3.10",
+    "dest-filename": "kotlin-compiler-runner-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-compiler-runner/2.3.10/kotlin-compiler-runner-2.3.10.pom",
+    "sha512": "8c15301805ef93f0f637be11122fcec101e9927a40805b0534de303bb65f0403136fe458b285a972d042a9b99ad1fe48f8a5d1ae0d21cb4fa19df6829b0e3909",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-compiler-runner/2.3.10",
+    "dest-filename": "kotlin-compiler-runner-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-compiler/2.3.0/kotlin-compiler-2.3.0.jar",
+    "sha512": "5b2555207c0a921c79870a8c6b146e7e80d783133b16945e08a31640d5aff3faca7f6b18e460e67ad499883a74750bbe35e69ab3e4d35adf3f454bef7078b3d5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-compiler/2.3.0",
+    "dest-filename": "kotlin-compiler-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-compiler/2.3.0/kotlin-compiler-2.3.0.pom",
+    "sha512": "db14f475c144f8c2a96de259e6b877314587a5b441968e4128a8ca275ed01ed3b9de52ec5e552ba67468e67150c4eeb7537f5128161aa67a47a7a8e58a73fec4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-compiler/2.3.0",
+    "dest-filename": "kotlin-compiler-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-daemon-client/2.3.10/kotlin-daemon-client-2.3.10.jar",
+    "sha512": "74c66b696eaf9f5fabc6f18914154dbdd21c890294344e95638738a37845afaff2157e9ff72c024a02530a25c9f17ab5c3c8755124ff6ab02ce64eb76cc187fb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-daemon-client/2.3.10",
+    "dest-filename": "kotlin-daemon-client-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-daemon-client/2.3.10/kotlin-daemon-client-2.3.10.pom",
+    "sha512": "b607b22a940465aa9448fbb19fdc2fe25e2033165b433cbdd83277aca4f14bd6089ac8cdeeb4c64993ca1f83957558f71f00d513bfdfdba39943b6b53dd4889c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-daemon-client/2.3.10",
+    "dest-filename": "kotlin-daemon-client-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.3.10/kotlin-daemon-embeddable-2.3.10.jar",
+    "sha512": "3a0c370c48c6ddad990b5c9188776c2c9fde554d6b4e29fa84aba03731e84c79327079d1b12785d4eb8e47b551ce40aed1b27e4280210a3e31434a92adbc4b95",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.3.10",
+    "dest-filename": "kotlin-daemon-embeddable-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.3.10/kotlin-daemon-embeddable-2.3.10.pom",
+    "sha512": "559179b27c0a9717be34b4372db9c033c054e9039b0d2d08e45ba9b7348e09844d8b00b1d689be0872402765991cc69f1bebfe10f888ea04809d4120a73b0270",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.3.10",
+    "dest-filename": "kotlin-daemon-embeddable-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-dataframe/2.3.10/kotlin-dataframe-2.3.10.pom",
+    "sha512": "c5a470578fcd93fa70ed31adfe196c015de0ec3624bde17f115ab5ea43440536cd5e4cabfc751df37dbc3ab3236f9ca5f0b623028b370d3864cce184a7bd03f8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-dataframe/2.3.10",
+    "dest-filename": "kotlin-dataframe-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-gradle-ecosystem-plugin/2.3.10/kotlin-gradle-ecosystem-plugin-2.3.10.pom",
+    "sha512": "40ec3b42077ceaaba0296427c86e248e7cfb545af0baef82b92a31c36ae9d55c33e31de72bf9573b20827c98aa0121c3fbe389d55296d11041ea11d765b32b65",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-gradle-ecosystem-plugin/2.3.10",
+    "dest-filename": "kotlin-gradle-ecosystem-plugin-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/2.3.10/kotlin-gradle-plugin-annotations-2.3.10.jar",
+    "sha512": "3b4a7870824a4db7068492e0242b74301eb6eba2325a37e1688e5ea1e0d0995e1c515c47131816e7d48860bd69775ba793d84bbf42ccd9e48f4bd6295060dfc3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/2.3.10",
+    "dest-filename": "kotlin-gradle-plugin-annotations-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/2.3.10/kotlin-gradle-plugin-annotations-2.3.10.pom",
+    "sha512": "980d4664e142d18e67d9aa10b12dd1aad208a4e37f39b02f87e0a93948d6d668c04021ef57ddfef23432ec65bbefa941f1bef06a6bfce0281a23e5b255c2f212",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/2.3.10",
+    "dest-filename": "kotlin-gradle-plugin-annotations-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.3.10/kotlin-gradle-plugin-api-2.3.10-gradle813.jar",
+    "sha512": "c735e3b15461fec4404c3fd380d5ba2a4c2dadb66d8de2cffbbb4c8977f92cb42d25c9036e5caed83e08f5287b885bfc42de38688851fad4e6dafee8ec73e6f9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.3.10",
+    "dest-filename": "kotlin-gradle-plugin-api-2.3.10-gradle813.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.3.10/kotlin-gradle-plugin-api-2.3.10.module",
+    "sha512": "4c75521b872db0eb92072d0ef01266d7c89543f90b3efbdde64df1c9a776af49d9fe2660e122b338765bda64e162eac9088002c402b7a5c6a17e8315d0ef30d2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.3.10",
+    "dest-filename": "kotlin-gradle-plugin-api-2.3.10.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.3.10/kotlin-gradle-plugin-api-2.3.10.pom",
+    "sha512": "6340032af1caa8d7d3e0244f1298b86cbabeb2e60825c0eccf6b8e54ec05f1d6d8ea60836ecd7753b65e85cca4189e5162d14d1321f1715934eb1ba4bcf58b28",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.3.10",
+    "dest-filename": "kotlin-gradle-plugin-api-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-gradle-plugin/2.3.10/kotlin-gradle-plugin-2.3.10.pom",
+    "sha512": "9394bd57bc878dbb8c427507a47eeeffbb00badec2e87e26ce55020d4c8a17b216350193399a1dd2792458439439c0ce834b54bd5ed874550f9a44e35fb7d542",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin/2.3.10",
+    "dest-filename": "kotlin-gradle-plugin-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.3.10/kotlin-gradle-plugins-bom-2.3.10.module",
+    "sha512": "289f9d6407d8db850439aafb2a5868ee3618bdc4815e6e9a624880a5d7d9a29ed40394e7ffa0a4dddad5270dfd1bf422d07e71706ec045ffc208a49dfa47ade2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.3.10",
+    "dest-filename": "kotlin-gradle-plugins-bom-2.3.10.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.3.10/kotlin-gradle-plugins-bom-2.3.10.pom",
+    "sha512": "d02e66297461c67311016054bcefc533bad158770892dee09ce8d9230813d42b259077693fe71cee30d6e45f1f2bf0cb04dc291e5147f159e1cc8c16c4b15e5f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.3.10",
+    "dest-filename": "kotlin-gradle-plugins-bom-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-klib-abi-reader/2.3.10/kotlin-klib-abi-reader-2.3.10.jar",
+    "sha512": "380e719aa1ee4330b5826393a6ff9f25f260b97561b89d4e58b5bdece6db8ac2f37498ec1bfbd77777e35efa40c6ccd27cfb7948eea12aeeb327f8619a61fec0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-klib-abi-reader/2.3.10",
+    "dest-filename": "kotlin-klib-abi-reader-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-klib-abi-reader/2.3.10/kotlin-klib-abi-reader-2.3.10.pom",
+    "sha512": "d9cfa10b016a18a07add758dca91e0ec4aefe38d4408a929d3d8e6c1ac8869113d12199e19f57e2716c548c835f719c5d47a83291b46c7ee87a1532c913b99a9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-klib-abi-reader/2.3.10",
+    "dest-filename": "kotlin-klib-abi-reader-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-klib-commonizer-embeddable/2.3.10/kotlin-klib-commonizer-embeddable-2.3.10.jar",
+    "sha512": "f2b2ce4f12266d2b922fd6bfebbee63ff1f44a081e71fb3d328f66a59afca32a255108cb0a2b48d41173d86cbc67c43ba0c0d5772b6c501ea58604124993c565",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-klib-commonizer-embeddable/2.3.10",
+    "dest-filename": "kotlin-klib-commonizer-embeddable-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-klib-commonizer-embeddable/2.3.10/kotlin-klib-commonizer-embeddable-2.3.10.pom",
+    "sha512": "cf87f33795dad94dfd1a3031930518add99a057e654fb1ebd3342b2da6430879f907536745013b3dd166e4e77f22b103470a5b51555dd7e541f758cf831d8f48",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-klib-commonizer-embeddable/2.3.10",
+    "dest-filename": "kotlin-klib-commonizer-embeddable-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-lombok/2.3.10/kotlin-lombok-2.3.10.pom",
+    "sha512": "63035a7be9b0329606d03f78a39c03039df637bc75e5cf127272303b1e7c3921129ccb138848a33dc1e106bda7f0de27cdb9e6e602b196c8e67afd57ab579eb1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-lombok/2.3.10",
+    "dest-filename": "kotlin-lombok-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-metadata-jvm/2.3.10/kotlin-metadata-jvm-2.3.10.jar",
+    "sha512": "3788e4cac83a3c3b1ffb3deb3029bebee8552c9c9c9081cbd34073785688502da43f05a65de63d9d2a7d0ee4d3dfd6481930e519d2582194307fba954c3dbaf1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-metadata-jvm/2.3.10",
+    "dest-filename": "kotlin-metadata-jvm-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-metadata-jvm/2.3.10/kotlin-metadata-jvm-2.3.10.pom",
+    "sha512": "4a9df53992b46995c3157f15b5723e383024aabc9820f7692cfdcabac8960f4daf8d1f9cda0131155dd0614f8a4e06921079b0dd654120c568ff45f0cc4d72e6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-metadata-jvm/2.3.10",
+    "dest-filename": "kotlin-metadata-jvm-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-native-utils/2.3.10/kotlin-native-utils-2.3.10.jar",
+    "sha512": "0e55f086d3a82ce4d2c2179768becf2a52a8a08a37d27dc2976ed5f20f9470272adbcc99f6e389cb69d2eafc86f6da3f65be9d336206ad5d2607b1553e00dcb5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-native-utils/2.3.10",
+    "dest-filename": "kotlin-native-utils-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-native-utils/2.3.10/kotlin-native-utils-2.3.10.pom",
+    "sha512": "ae651f77a3296b9f22fa6d3d51c229fea1eb9300a77056ad2a956f5e2114ced6e68e53ed23da48b085b0472f27f413ab47dc74d0836baacdda3f9a271593e8ef",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-native-utils/2.3.10",
+    "dest-filename": "kotlin-native-utils-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-noarg/2.3.10/kotlin-noarg-2.3.10.pom",
+    "sha512": "b06872b0862023d7c6c64df8a6a8920c2867a8453fb91be82f9c84608a8dc00d2617ce7188a23b940097d827ae1f6bdbc24bceb5ea29f1dc408315d4e548221e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-noarg/2.3.10",
+    "dest-filename": "kotlin-noarg-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-power-assert/2.3.10/kotlin-power-assert-2.3.10.pom",
+    "sha512": "f00bfe942d7899c4955c5d13a3d1ef4a14d294bc25c91a8dab3b52b2574303814c3e26bd2782849e1f08eb7ecbfd68aa90939164a9792128f2fe09a80d5cc3f8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-power-assert/2.3.10",
+    "dest-filename": "kotlin-power-assert-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.jar",
+    "sha512": "b28392f114dc049bc4582c5bdbb5b60d74358668efb25579c2ed5ac749debda89dc7426aed1f7f548b5f121f7df227c9d37b4aa49b315a0779afd5847d17872d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/1.6.10",
+    "dest-filename": "kotlin-reflect-1.6.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.pom",
+    "sha512": "3765a8094a88ebdfac50ac898a6cb3e446bc7493fb6f9fad95a4805170f987b9ca0c5c76ed2a22fb53b5171d4564b353a138e4aaad11d42a50ebfe1a11978fe9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/1.6.10",
+    "dest-filename": "kotlin-reflect-1.6.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/1.8.10/kotlin-reflect-1.8.10.jar",
+    "sha512": "43efd3dca21f2de51b3a358c4b297571ac7aa709e9d9036f68e35c1d204afe9e185716b45df412424029ad82de40f87fe3c51895791b469f4be82110cece5a14",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/1.8.10",
+    "dest-filename": "kotlin-reflect-1.8.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/1.8.10/kotlin-reflect-1.8.10.pom",
+    "sha512": "6d82e00c693ccb59a81d03b7ffeb330583eaaf4cf60f4196f7e9a1ff7b0cfcbc43d5fd21211f38e058c09e62e9eaa3d2f3ca287ff9308e461912f06b070736f6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/1.8.10",
+    "dest-filename": "kotlin-reflect-1.8.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/2.3.0/kotlin-reflect-2.3.0.jar",
+    "sha512": "4c015040675028f553d4ebe5edf487a2288d8d20a2b95269a241e141d4087a23a98878d123b31da5a8637bd5f2daf9548a1df9f93a834ffd054e2befd8213de9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/2.3.0",
+    "dest-filename": "kotlin-reflect-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/2.3.0/kotlin-reflect-2.3.0.pom",
+    "sha512": "12e53c164c83b0f51d0f033107449502b7eb20f32ea6d0efd604e0de0af45d7bc48a73cf104be2791909c7975c127027bede64838ab3df9b1a954bebd7161862",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-reflect/2.3.0",
+    "dest-filename": "kotlin-reflect-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-sam-with-receiver/2.3.10/kotlin-sam-with-receiver-2.3.10.pom",
+    "sha512": "c7c9b6f9ec69c2f2342f6a795131dccd8e89419dcd6655785275e3cc4e8f92fe9cd9d81db5179e1993dbe8732a24f77712024a3858981d618d2379a8376ae714",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-sam-with-receiver/2.3.10",
+    "dest-filename": "kotlin-sam-with-receiver-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-script-runtime/2.3.0/kotlin-script-runtime-2.3.0.jar",
+    "sha512": "7755ceb376e7e8df7d96899dd0c38dde88b2ae225f238c203c63ef3b65a2a8cb14297d551448b08a4ab4e5dc08377741344692f41d6617d2ccfdb335a129f3f7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-script-runtime/2.3.0",
+    "dest-filename": "kotlin-script-runtime-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-script-runtime/2.3.0/kotlin-script-runtime-2.3.0.pom",
+    "sha512": "8a5a574b65df5ca7b976ca43e10f7ff5cc610e922138547e9979d10d6a87f3b583d0da3fb439b8d343da1604ddbc6ca9958854a773099bd3c3459acad1c78798",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-script-runtime/2.3.0",
+    "dest-filename": "kotlin-script-runtime-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-script-runtime/2.3.10/kotlin-script-runtime-2.3.10.jar",
+    "sha512": "6485aedee862b55b3c7ffe5b6bc9c186fe173c0fbf3db4b2d09d5d72d9d35080df36738c38f11a59c00d69422133a40df8d0af891d20f0af419af37f4c9017f3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-script-runtime/2.3.10",
+    "dest-filename": "kotlin-script-runtime-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-script-runtime/2.3.10/kotlin-script-runtime-2.3.10.pom",
+    "sha512": "f1f030f118eea20ef31cb91c8e5f6e7029dbdd0fa289778a84d596a02a3d2f9336d356f592a6a81906599f7061162f37e8d68902f84a55c0a1818704b61a5aa5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-script-runtime/2.3.10",
+    "dest-filename": "kotlin-script-runtime-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-common/2.3.10/kotlin-scripting-common-2.3.10.jar",
+    "sha512": "705cbc888414615856c96e8631acb7f4e1bde7590287935fda897553a4ff0d7e3e417983c4d4e922fc33ec264e2cb1984db1c7d9f14173a8d2ef4c4af27c5d64",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-common/2.3.10",
+    "dest-filename": "kotlin-scripting-common-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-common/2.3.10/kotlin-scripting-common-2.3.10.pom",
+    "sha512": "93672a364125052f728b34c946252f589e2885a20c324b63509755765cf1943d33f3ef4ca895f636a93169f9625b8dcc9bfa512a68255b98a3538ad49c6db0c4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-common/2.3.10",
+    "dest-filename": "kotlin-scripting-common-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.3.10/kotlin-scripting-compiler-embeddable-2.3.10.jar",
+    "sha512": "5b0a881bb166b887b755267d4bc99311a6adc7bcabfcc04a580de9cd258194523dbd9f9444b1af15dda6b7bd264d0884229d58a9505c72a7799b7c07e52c32ef",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.3.10",
+    "dest-filename": "kotlin-scripting-compiler-embeddable-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.3.10/kotlin-scripting-compiler-embeddable-2.3.10.pom",
+    "sha512": "4d6ddbd83982997963511bff285b310ee8cbcaa92fe8f55dc6bb2361e8e0b5c16ad5182f37eee077be8abba14c4b8e42d21bef32542eb3767c917933f6caf141",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.3.10",
+    "dest-filename": "kotlin-scripting-compiler-embeddable-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.3.10/kotlin-scripting-compiler-impl-embeddable-2.3.10.jar",
+    "sha512": "0386d858abbc401fdcff38a67da542566dc5baa5ce260808aadeb74ea2eee10c40e58dab7a407c9fd14db2b41f772452601964c13de74b72d10795dc2befac8b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.3.10",
+    "dest-filename": "kotlin-scripting-compiler-impl-embeddable-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.3.10/kotlin-scripting-compiler-impl-embeddable-2.3.10.pom",
+    "sha512": "1e7fb077689afd4abeb174bd1c3aef382e0ff0ac291bb7a226a142464556a36682392bdb5e850b3ff75087ddfd0638fe397460891cf8a4d40f131c3c28a4aa48",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.3.10",
+    "dest-filename": "kotlin-scripting-compiler-impl-embeddable-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.10/kotlin-scripting-jvm-2.3.10.jar",
+    "sha512": "0c48fe52c0dc2892b181a405576a1c40fcb6e72587a39b2d127b9e33ebeb89e4c43265f6a21c1a7ffa03d2736207546f2c603564824430cd75df7f98069c5950",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.10",
+    "dest-filename": "kotlin-scripting-jvm-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.10/kotlin-scripting-jvm-2.3.10.pom",
+    "sha512": "49dd102c42f3dfa46dff8e723e548e10a4be454953414c6f93e8e4a116ff47d16a1ef5a37cf94a2f8ca63d7b3b13999ec27657af74a8ccb1903c519325867735",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.10",
+    "dest-filename": "kotlin-scripting-jvm-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/2.3.10/kotlin-serialization-compiler-plugin-embeddable-2.3.10.jar",
+    "sha512": "7599d3655c211acc1c36c045ba134ccf448ae6759df01d2b5bcfa001fb47b721c3c4162faa867d8570b0ffd118ed95587a4faf4f2a309f26f23c2993520999b6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/2.3.10",
+    "dest-filename": "kotlin-serialization-compiler-plugin-embeddable-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/2.3.10/kotlin-serialization-compiler-plugin-embeddable-2.3.10.pom",
+    "sha512": "51f7dcc622fd8c12b83eebe3a6a8bbd6c7da50cc9370d59906cada2ecb5fada071c9e5dd9f1bfbbe79576132c8f07ad57886960e2c76b8709a61ec6023b887f7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/2.3.10",
+    "dest-filename": "kotlin-serialization-compiler-plugin-embeddable-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-serialization/2.3.10/kotlin-serialization-2.3.10-gradle813.jar",
+    "sha512": "b33beaba9579e1d23e5795fd65e4d322fbf4a1cd84b65763a11ab58894133a75281607844b14fd18e4d6b9963cff5b6d5d784342dda66372a408840a2fef60fa",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-serialization/2.3.10",
+    "dest-filename": "kotlin-serialization-2.3.10-gradle813.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-serialization/2.3.10/kotlin-serialization-2.3.10.module",
+    "sha512": "24e6ac17ae4f3e0a5c7b3d4e70c240a778af5be3ff5b1144482862d86b537f2fe89b6f0adcbfab417e77dd5ca1d2735e9d5e3e296ebfbd71f6e6af4da650f74f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-serialization/2.3.10",
+    "dest-filename": "kotlin-serialization-2.3.10.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-serialization/2.3.10/kotlin-serialization-2.3.10.pom",
+    "sha512": "ce290ee2f27d77f3d722d7df8ea0d3eefbca899a75f11e814c93f1ffdf33b5e8b67e997d6672bfc78964efa515fa7e9e5076be02f78633d78597f2af29e1db86",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-serialization/2.3.10",
+    "dest-filename": "kotlin-serialization-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.2.20/kotlin-stdlib-common-2.2.20.module",
+    "sha512": "0ea5884efbdd01b65ff900a38ce23708343102fcfc76de8e7645c0c119b4431970893bea9de466fb43e391937f35c9891f74c63f8c9ca161b5d64a8f11937a0b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.2.20",
+    "dest-filename": "kotlin-stdlib-common-2.2.20.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.2.20/kotlin-stdlib-common-2.2.20.pom",
+    "sha512": "b8637dfe5425a3cbac46c9e94c47e74772b114f1ffb254667e820ed3ffc6379c553be4b0828a2d26c8d9570e1bc8356a798ef1840ce033059bcb195166ec42e1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.2.20",
+    "dest-filename": "kotlin-stdlib-common-2.2.20.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.0/kotlin-stdlib-common-2.3.0.module",
+    "sha512": "0995682bc3816e4e80ec85d511e6bb982efb88c1113181a5f96137a389ac6408ff9f320c88b81fbcc3ee24026e9162d0003ddb7a4b6083f9a138ad9e2dc04e10",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.0",
+    "dest-filename": "kotlin-stdlib-common-2.3.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.0/kotlin-stdlib-common-2.3.0.pom",
+    "sha512": "706f036e03a2084c9bd790f3d2b462629f23b2fb79039a84f5f548b59b4fdfe3a98206a7c05fb2927e847dade6f43a112ee926f411c1261fee5aa7cadd73a623",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.0",
+    "dest-filename": "kotlin-stdlib-common-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.10/kotlin-stdlib-common-2.3.10.module",
+    "sha512": "72c630752805c438cc2ba7ddc3a1a144903094128cb7116fc57ae94749a228e0b89ef1112849c7054d23e98ac33f3edb141d1db2c77bb2fa037548fabc3b67ed",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.10",
+    "dest-filename": "kotlin-stdlib-common-2.3.10.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.10/kotlin-stdlib-common-2.3.10.pom",
+    "sha512": "c56478096092e3ce3b59d2c0dc91f39c04edcb84199605484618dd0571dc6e04fbddcde52a979852a1194d5a06327f8e603f04acb6cc2b11658ef61061331590",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.10",
+    "dest-filename": "kotlin-stdlib-common-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.8.0/kotlin-stdlib-jdk7-1.8.0.jar",
+    "sha512": "3ed41f0dc53bacac17004e8a205f3ecbe341dfb8ebe200f75b5edf19beea655679958c1e87f5dfd356784fff36a39c0169972f6f3bd32a14d038b17b59e1c4d7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.8.0",
+    "dest-filename": "kotlin-stdlib-jdk7-1.8.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.8.0/kotlin-stdlib-jdk7-1.8.0.pom",
+    "sha512": "f18fd89c03d5abccf2eb2a8306044dc505e29a2bb97e2d8afdd102d7d8c42908494182daa6133e8dceb221c8bcb9a52f62c7a7232c6657abb9c91c77b2a65af7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.8.0",
+    "dest-filename": "kotlin-stdlib-jdk7-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.9.10/kotlin-stdlib-jdk7-1.9.10.jar",
+    "sha512": "f839178f07b9d6bd9a3910d13b181399e975211fa556c3a9ead08eca30ababa74f75c79aee95224ffb7b610b9e56768eeeba18e8fae84826903adb12e122bb67",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.9.10",
+    "dest-filename": "kotlin-stdlib-jdk7-1.9.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.9.10/kotlin-stdlib-jdk7-1.9.10.pom",
+    "sha512": "fdb3c9ce1109cb6f067f0645ffca942982dc7ac66ca92eb5ae22edf9011bc8b5e02ce0e96a5def49945aec45f59f565789dd9c076913f8c8045660dcbcf33a9e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.9.10",
+    "dest-filename": "kotlin-stdlib-jdk7-1.9.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.3.0/kotlin-stdlib-jdk7-2.3.0.jar",
+    "sha512": "133a76883131006185eab1bbc258557037cca3d6ed06739a32b1f709c6c6bfc5ddb32f898a8d50ffbb7cebdbb76bc504f3dbbd9bd811707ed33c9cb258af785b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.3.0",
+    "dest-filename": "kotlin-stdlib-jdk7-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.3.0/kotlin-stdlib-jdk7-2.3.0.pom",
+    "sha512": "3e97f4dd1fc3f6e44451876809f78dd182a1f5c1bb1841ab196d6b16b973df949ab00eb8c1b229acb375e8ca9f18a255093b70e93dc6659d5d11da114bb1bd87",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.3.0",
+    "dest-filename": "kotlin-stdlib-jdk7-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.8.0/kotlin-stdlib-jdk8-1.8.0.jar",
+    "sha512": "a85e81accfeefc7038ae61e003927824e7289557c53e96921e1cecc1c19a63b4aef06ded2fb7439227737e4676bc23a20c9602cf85ccd40619f15b7cfb36603b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.8.0",
+    "dest-filename": "kotlin-stdlib-jdk8-1.8.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.8.0/kotlin-stdlib-jdk8-1.8.0.pom",
+    "sha512": "2c5b573c0e5fcd9137b614586f7e4b5becaff8edcd15431e785bce5014bd23e3c70f22be5fd95ab15ab99326fddc2b27fcdc9726312a59c4d47d34e88940d3f9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.8.0",
+    "dest-filename": "kotlin-stdlib-jdk8-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.9.10/kotlin-stdlib-jdk8-1.9.10.jar",
+    "sha512": "b027fc4a0be8e69f41a86ae775ce350ef0084eb4652e50a0640dbcc600db76c3fc2983e17c96b6071b5698cea636e1b2cb015e84a6c0efe95e6db668036ba3cc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.9.10",
+    "dest-filename": "kotlin-stdlib-jdk8-1.9.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.9.10/kotlin-stdlib-jdk8-1.9.10.pom",
+    "sha512": "8cf0741fc581be275cccb34ab1f37ea6f6adfbeb086ec685258d2ddee1d7fdb03695a4da20c6a97e3043886dbf95f36b29db11699069d71c0c7aff9f4f6c740c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.9.10",
+    "dest-filename": "kotlin-stdlib-jdk8-1.9.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.3.0/kotlin-stdlib-jdk8-2.3.0.jar",
+    "sha512": "522ba4ee4c82627b1b0ab33082d75db0a32a6881622b3712b43da02816ceed31ef5f531536242cce8f97bf7917066a52c1588f7ffd869a431d91821b6dc93cf7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.3.0",
+    "dest-filename": "kotlin-stdlib-jdk8-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.3.0/kotlin-stdlib-jdk8-2.3.0.pom",
+    "sha512": "cd9df8cdd23c2fa0b4cf9044c64cf5bbf8c004bd3cc3e7ca78ca9c63a9b66431870eb5c839d134395088503f0f999e48051cbded83bbda8d4298e212c08bfd89",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.3.0",
+    "dest-filename": "kotlin-stdlib-jdk8-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.jar",
+    "sha512": "22075ba5931e86fcf471249b88593f0651a356a71a2f3152e25effca9a7420a1562579877aca40c98f625bf5a35fa983393a939cb54bbb4c58de13676254d62d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.2.20",
+    "dest-filename": "kotlin-stdlib-2.2.20.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.module",
+    "sha512": "559e5cb85a6b54840acd2b8941abc3653252f8df44e276e3339d6a3a7e9185128eb68900cbad6d65cf5d33acfdfe83a8df83ca2400c6f64e39628ddf97d0735f",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.2.20",
+    "dest-filename": "kotlin-stdlib-2.2.20.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.pom",
+    "sha512": "24e048e39ba8ac1fd249c8276a7024e4ec03fabc10b95c5cc5f8c996ea6e7a29e48457091cae0c1e59985d1f439878b7f12fe77314de14b02824dd986dbdb8ca",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.2.20",
+    "dest-filename": "kotlin-stdlib-2.2.20.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.3.0/kotlin-stdlib-2.3.0.jar",
+    "sha512": "2d19829e49ce79b8587ffc1620f95c4773ec85780f45c609017fa411064c0edbd76fc7c1333775814693258cd9c932d82bc94d18d2c545fc90198fdd3087d6a8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.0",
+    "dest-filename": "kotlin-stdlib-2.3.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.3.0/kotlin-stdlib-2.3.0.module",
+    "sha512": "04bc39c3d5650bc8b212f995fb81e872fe563ce3ecb2ff5355ca33bd1b73b6c44e02fbe9492f2222bfe000a8646bb7e02761d543bd7f4cdb4e49266e01a350d3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.0",
+    "dest-filename": "kotlin-stdlib-2.3.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.3.0/kotlin-stdlib-2.3.0.pom",
+    "sha512": "a19afd768945fd94d9a3167b390a6088cd33fdeba5bbd3817e8bf3946f88b9ba3fb370bbe9441347b4d78e60acd3e0fa3e1a4f0f9ec89dd87e3acd60ef2d0305",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.0",
+    "dest-filename": "kotlin-stdlib-2.3.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.3.10/kotlin-stdlib-2.3.10.jar",
+    "sha512": "8532b9ef9c0ff224aecb521f7fb6251e9ef37537e48a84f8fd09e1466689b96eb5c7b20d0b3f6f3bee36e0e01911fd0d80577725f6f323fa32c856142d4fbebd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.10",
+    "dest-filename": "kotlin-stdlib-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.3.10/kotlin-stdlib-2.3.10.module",
+    "sha512": "5257ab9b466ff2ed1c9708a80c6fddf140bef07deaf115b03244b78ca4827df25de76d56c0c9df97ac8ba713e45e386e3103e18ecd9b0d1e30dbe8ba3ec49fdb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.10",
+    "dest-filename": "kotlin-stdlib-2.3.10.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.3.10/kotlin-stdlib-2.3.10.pom",
+    "sha512": "e0ad7ce36f588d24ee21868d61f6b15f90678485558cf283b88855f0154a6d69a7bc8db02781d62be7099343a41ac311921d944159ccfa7e378a48f9fcd902b5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.10",
+    "dest-filename": "kotlin-stdlib-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-tooling-core/2.3.10/kotlin-tooling-core-2.3.10.jar",
+    "sha512": "831ec9092a896fefa8c4b2bd0c2304307dfe812ad83738e83870ae4de75d3d829cd89c576e9daadcda5c8d54777371bb5611482cfd9d6bab5fe1645dda7132a3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-tooling-core/2.3.10",
+    "dest-filename": "kotlin-tooling-core-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-tooling-core/2.3.10/kotlin-tooling-core-2.3.10.pom",
+    "sha512": "deddb4bb53eea087d5037914a3e41284503617fe6c96d4d953c9d8722ae912901aa5c0cd3371157265221c7822b4980eb899709d7fc1d942ac9572b0f6d75472",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-tooling-core/2.3.10",
+    "dest-filename": "kotlin-tooling-core-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-util-io/2.3.10/kotlin-util-io-2.3.10.jar",
+    "sha512": "16d63d88531855789ba7a6d60ddf4af60f5d2fe89a08cbaa9e457a68ae3e0252d6247abc5a05a57ad0845d0820e4d6892b67d732c33b50a3a6c07f93f6cbff27",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-util-io/2.3.10",
+    "dest-filename": "kotlin-util-io-2.3.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-util-io/2.3.10/kotlin-util-io-2.3.10.pom",
+    "sha512": "930a58a550e65c320123b5ff30fade4788e9869e425b524d56f2b3a154175aa308fb68afc8cae04d2caf4d78cc0e1d2c9710629bb47c686906c4223582b95c66",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/kotlin-util-io/2.3.10",
+    "dest-filename": "kotlin-util-io-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/plugin/serialization/org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.3.10/org.jetbrains.kotlin.plugin.serialization.gradle.plugin-2.3.10.pom",
+    "sha512": "410f93d62dce6ea0a86106b90df34d62a1ced51e06103dfde3f0ee19c936567ee307a63fd4c8df30b73822249c0be3a694832548d6c697a9b6ae1e876272d142",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlin/plugin/serialization/org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.3.10",
+    "dest-filename": "org.jetbrains.kotlin.plugin.serialization.gradle.plugin-2.3.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.10.2/kotlinx-coroutines-android-1.10.2.pom",
+    "sha512": "5c607bf7f1f5da9c7991cb9b8075b0acb8f24065c89b1336f1a433361eb56044b9f2100b707d8e8a1dccdd0b0f0c741728a246d6ecf5b14d2f16916e9360725a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.10.2",
+    "dest-filename": "kotlinx-coroutines-android-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.8.0/kotlinx-coroutines-android-1.8.0.pom",
+    "sha512": "9f10dcfcf35c2c4844f0ef88584e543baf4fea165d73ec387c2bab58e1c64966458358970a699f0b0334e671cf97f0ff6e571df071477ae33c88e00b9271361a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.8.0",
+    "dest-filename": "kotlinx-coroutines-android-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.10.2/kotlinx-coroutines-bom-1.10.2.pom",
+    "sha512": "019fd13ac4ed6829a32489afe003762936937d6894f16ac36f611beb2ef7e9fbb282e56479863da8daa156aa77f834c30420604e431b6e2e56311e3e0240b606",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.10.2",
+    "dest-filename": "kotlinx-coroutines-bom-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.8.0/kotlinx-coroutines-bom-1.8.0.pom",
+    "sha512": "1204d8fbc5b8bf19ea84a008e7b8d4c146ee3fd10bdc603168068b76e30f0e129c7a9ec5467b9de0bdede1b1bd9e65aa028db0769f994baf63effd4af2c6820a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.8.0",
+    "dest-filename": "kotlinx-coroutines-bom-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2/kotlinx-coroutines-core-jvm-1.10.2.jar",
+    "sha512": "238fd451f80e222480c880dd8bcfd76e9203b6833a0306a55483b3f9eb0b25651242a3e7beaf7510d5e39922f1d3d987fca79468d945eb35b0f07156a7887ba0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2/kotlinx-coroutines-core-jvm-1.10.2.module",
+    "sha512": "d105252b959981bf5a1accd86ff176d032eeed22d0e5647eb2d5c811e43019408743ba91a59a21250bcc2bdb0b135c545b57eeba345679ae749d241bec16df7b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2/kotlinx-coroutines-core-jvm-1.10.2.pom",
+    "sha512": "e146303a289ff4ca6e6b93470d37036816a4a77c6d72f7fe8200befe3ba9317dad18e6aa6ee216403a163146b3cc3f55e9a53beec582029fb734d363255f1522",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0/kotlinx-coroutines-core-jvm-1.8.0.jar",
+    "sha512": "081391dcc0b66e4f71401a0684c8f0fe0fa10f195ca5e50208419b4f6110d9b0f90250a43950114d75c79455b9d304afadc069b98c5bc86afa7701ddaed51af1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.8.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0/kotlinx-coroutines-core-jvm-1.8.0.module",
+    "sha512": "44fbb461d2e7d505915d94fd06d48660482aaf75f136862ff7567ec3dc868a84e645785b45710c2045ffe6087f86585b917703e25892d1c68093537dbab5a665",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.8.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0/kotlinx-coroutines-core-jvm-1.8.0.pom",
+    "sha512": "010eb8254d2ff842a039043fe297a3dda0189fbd8ce1a214773724d3fa5e8e8a6a67ed0cd2e72d563d53a061e33041c9745c87c38e2dc7ea98dffab0ee062b03",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2/../../kotlinx-coroutines-core-jvm/1.10.2/kotlinx-coroutines-core-jvm-1.10.2.module",
+    "sha512": "d105252b959981bf5a1accd86ff176d032eeed22d0e5647eb2d5c811e43019408743ba91a59a21250bcc2bdb0b135c545b57eeba345679ae749d241bec16df7b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2/../../kotlinx-coroutines-core-jvm/1.10.2",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2/kotlinx-coroutines-core-1.10.2.module",
+    "sha512": "a88eb8e578850c3ca9e12f9067d761287a3e70c99657f41df959085bd47a9fe7982f835ab37880ca55fe5ebf62e02dbc947794194aee9b03330bc1fb24ed9404",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2",
+    "dest-filename": "kotlinx-coroutines-core-1.10.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2/kotlinx-coroutines-core-1.10.2.pom",
+    "sha512": "63ec46c4f2af79f6c88184a39cd78f3ddd26cf25a89c01a9a2068c7a7d4cf44670def8462703e72505e8a1b0a6530e6b65426486b6d8098ad5a547086025f7ff",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2",
+    "dest-filename": "kotlinx-coroutines-core-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.8.0/kotlinx-coroutines-core-1.8.0.pom",
+    "sha512": "c9b309dcb8aee156210fff58c9fa01b74d186c78e5a6292d8fbbc42776f86cbe6a597e05ea2cd5759c3f93bdd2e4e4453f95dbf61abf994591c114e5cec61b9b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.8.0",
+    "dest-filename": "kotlinx-coroutines-core-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.10.2/kotlinx-coroutines-debug-1.10.2.pom",
+    "sha512": "62e88aa9c8399cb1550d8ffe6830768f00562383b0d8074c733945acd89ea1aed8664186a49a872ea521623a94183da217a2d0aa9a34d322f1cabf2464c20c13",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.10.2",
+    "dest-filename": "kotlinx-coroutines-debug-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.8.0/kotlinx-coroutines-debug-1.8.0.pom",
+    "sha512": "30503a6703bbce1a3909aab1a3456aa08ed7623520ed2992c92a739a2292dd198f238d7cec353ff1a1759d2593a32bfa38dcb6a064417bf78121a15ae2c5283a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.8.0",
+    "dest-filename": "kotlinx-coroutines-debug-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.10.2/kotlinx-coroutines-guava-1.10.2.pom",
+    "sha512": "2f5744e09018bf1fe6358e79d4e72ac0e0c040141e093490e3046402e4bacf8d5e228ab7576270e625753899c2f8e7c0732bd05d95b92c20e30724a67835023b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.10.2",
+    "dest-filename": "kotlinx-coroutines-guava-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.8.0/kotlinx-coroutines-guava-1.8.0.pom",
+    "sha512": "4d08ac866aead40123ef4804c958a06ec52bdc5af64ee2524d81a8c65d3cad6f9605854d79449a6e52e644b4217c6f750b6f474c8311e39a1034d985829b46cf",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.8.0",
+    "dest-filename": "kotlinx-coroutines-guava-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.10.2/kotlinx-coroutines-javafx-1.10.2.pom",
+    "sha512": "38dc16d847a1579c67781b50be82395eccec98ea02eb25b434457819259a3fd98d7a10cf29a40f4b2a49e77f10dea49acccf888c9950ce9dc8ee9dbfb0ce8620",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.10.2",
+    "dest-filename": "kotlinx-coroutines-javafx-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.8.0/kotlinx-coroutines-javafx-1.8.0.pom",
+    "sha512": "24c63b9d60d50352c287760407d91ea23493319a1bf87abf4519fe5a0b22e19148fac49c34da21ce2a4ce703e917c671264a1edae384db9c3ca819b26f653f3d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.8.0",
+    "dest-filename": "kotlinx-coroutines-javafx-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.10.2/kotlinx-coroutines-jdk8-1.10.2.pom",
+    "sha512": "ae0c0e8e79a390d815e5f50787cbc17ee5dffa1dfc99fd3c586b459748e97866176401c408d9d65db2ff0fcd064ed19b31316c03404e29846ced2798247b965a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.10.2",
+    "dest-filename": "kotlinx-coroutines-jdk8-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.8.0/kotlinx-coroutines-jdk8-1.8.0.pom",
+    "sha512": "86a60743fce1550331948226814887846ebd855091a40dae69e272c0c5492fb3218fa6f1f7fa4c47e3099f4edf1de064ee708273c24e971cf1c0e1f1f9d90295",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.8.0",
+    "dest-filename": "kotlinx-coroutines-jdk8-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.10.2/kotlinx-coroutines-jdk9-1.10.2.pom",
+    "sha512": "1d6dd9c33bd42d8170bc2196346ef84445f74ce11b47730b6194a1c5ec1e066fcfcf2ff11c071f24cc53476d917ab04773c7e478c054d26fac159ca4c3ce7230",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.10.2",
+    "dest-filename": "kotlinx-coroutines-jdk9-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.8.0/kotlinx-coroutines-jdk9-1.8.0.pom",
+    "sha512": "80972fd632e469e6e1688f0909ba50a473d1ff7332ac6ec09b5fde3b3fe98bb4684721efa916d8d9230a0c31ed4175c1e73ea878b71268ac053666ca7d707238",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.8.0",
+    "dest-filename": "kotlinx-coroutines-jdk9-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.10.2/kotlinx-coroutines-play-services-1.10.2.pom",
+    "sha512": "1d86a2fb6e27ad9c8f5f2650178151216097628491fdb2d1beaa1c4a8cfaf29ed0f54039ed005aa8923b57db807627cefc5c95f6476139b5d72a0d33184dbfad",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.10.2",
+    "dest-filename": "kotlinx-coroutines-play-services-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.8.0/kotlinx-coroutines-play-services-1.8.0.pom",
+    "sha512": "ff0a43339cc1e7b6359476afc2865a5a071c69564302f7d60497ef1585296c7412bdf4ea5c8d7be2691eddb7d78e577487760f94b6823baf09d661fbd629fef9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.8.0",
+    "dest-filename": "kotlinx-coroutines-play-services-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.10.2/kotlinx-coroutines-reactive-1.10.2.pom",
+    "sha512": "9ba65dfa502929f8916f57894b8ea6205bb52a44eb8aaa5cea0c5630837ce476747e4af8d72ac9df6cabbab8f34398106f825be985600c37fb77e79a9552d17a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.10.2",
+    "dest-filename": "kotlinx-coroutines-reactive-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.8.0/kotlinx-coroutines-reactive-1.8.0.pom",
+    "sha512": "091b384be0eb3d60a9d714276156d67c592fa4700af116a863281127f36656f913fc83e4269ac25daf78416e49ec92519d9706a265e6662fd077228f622237dd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.8.0",
+    "dest-filename": "kotlinx-coroutines-reactive-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.10.2/kotlinx-coroutines-reactor-1.10.2.pom",
+    "sha512": "f4d42f9d92dd3cf83b720df9032e417e661eaa9d52c6e6666f83f5560124675d7a3c82ff56cdaba00b5da64e30fe3fb61960c9de5faf1046bbb4e953fcd4a49c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.10.2",
+    "dest-filename": "kotlinx-coroutines-reactor-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.8.0/kotlinx-coroutines-reactor-1.8.0.pom",
+    "sha512": "72f18d5ca890a927d3e6ea4b0b51c9e8b7db8c74904a1b530743a22cb12a74d42dbe51c8a305f875357c1dc48ac67ecc1df78ffa0359354bfd0b8c0b473ba340",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.8.0",
+    "dest-filename": "kotlinx-coroutines-reactor-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.10.2/kotlinx-coroutines-rx2-1.10.2.pom",
+    "sha512": "19966b5d3355093806434a106588b8d988a23688e602ae9200a0dda5f159e04856049815509f5b7ab9bfeeb1929c700f0a9bc9b8f0848a27fdc19211e5dee711",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.10.2",
+    "dest-filename": "kotlinx-coroutines-rx2-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.8.0/kotlinx-coroutines-rx2-1.8.0.pom",
+    "sha512": "ca6e74249a744670e82908f9891395be3b0a2d4b3f1238f7e919fa833073cc27804e0df96b8d4799b7928f208ccaba6be99c7efdde17f5b67b40eb3e0c1ae68c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.8.0",
+    "dest-filename": "kotlinx-coroutines-rx2-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.10.2/kotlinx-coroutines-rx3-1.10.2.pom",
+    "sha512": "713797767bb99ea92ea9f1bd643a6abbfa957e4f54abaaeff8e2ef851ccece0e582204157b9d3f51887c92fa26190ecc9c2ceab0aa8c2413b954e5e24c182db4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.10.2",
+    "dest-filename": "kotlinx-coroutines-rx3-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.8.0/kotlinx-coroutines-rx3-1.8.0.pom",
+    "sha512": "7c41defe6cfe67e8ed6330be15553e641a75dada600b98c96fb1096cd3f484228d7c3034b523f13d0fa74e31a7bf5bd0dafc30080b176d898da69a93907d66fd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.8.0",
+    "dest-filename": "kotlinx-coroutines-rx3-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2/kotlinx-coroutines-slf4j-1.10.2.jar",
+    "sha512": "e0688d8b0d58774656d147c90438ca3bece9f2052c5ca8c6965817fc29c790e229751f81874a3d06b2291feacea004a7c1b8d7769d2cdd03cd3dc9ddaf5fa183",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2",
+    "dest-filename": "kotlinx-coroutines-slf4j-1.10.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2/kotlinx-coroutines-slf4j-1.10.2.module",
+    "sha512": "956e8b4b2a38dfca46012e1c6f1484d958f860ee57cb8d16767dc2c8c24ec4847c7271b911c30dd4b7e93470bcc3941a9c0d384dd53e41d0dc846394a9e097f4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2",
+    "dest-filename": "kotlinx-coroutines-slf4j-1.10.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2/kotlinx-coroutines-slf4j-1.10.2.pom",
+    "sha512": "e3aeda087f93866da540b152573520706daa7bd3f0cc46a18249f27cf35c17fa74f22203716e1f2ff91c7722fc9617bf7c8a1ce8a72992855ad52940be61bf30",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2",
+    "dest-filename": "kotlinx-coroutines-slf4j-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.8.0/kotlinx-coroutines-slf4j-1.8.0.pom",
+    "sha512": "9444df2629cf6f37bf94ac9daa3ea883f0de58108ad9ac0eb63a822ef78e9c7433e8016300644bbe96f2909e8887981eb32c51f9399a08ce4697221ee5c3f0bf",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.8.0",
+    "dest-filename": "kotlinx-coroutines-slf4j-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.10.2/kotlinx-coroutines-swing-1.10.2.pom",
+    "sha512": "b88bb52e56146233d4703c7a9695049605a9a21d85e3f075f278ededeac80f76e9cf2110f4336cbafb46ee475558da664d8f068f6d2e524b0b18f20483478977",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.10.2",
+    "dest-filename": "kotlinx-coroutines-swing-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.8.0/kotlinx-coroutines-swing-1.8.0.pom",
+    "sha512": "9615b57fcc82c87978371a03626f4d064ded28d2e7575db5f3e78bc31373da23fe86f0512fe9da29229591660e644d50886fe1307a8b684edc26d3790acdc548",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.8.0",
+    "dest-filename": "kotlinx-coroutines-swing-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.10.2/kotlinx-coroutines-test-jvm-1.10.2.pom",
+    "sha512": "646a554dc77ea050467c5cc43518459ce33e7c1b9103673c13a9f0288f5c1cbdbb43913bcf7e0fb1c02f2323b92a0feab17ddc223a1a919b8392431be65fca6d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.10.2",
+    "dest-filename": "kotlinx-coroutines-test-jvm-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.8.0/kotlinx-coroutines-test-jvm-1.8.0.pom",
+    "sha512": "d9c8947372a8d88f3b92d83eedac01013dee9f364d66441ad26daf5961944a868ed99d02b491a9855521b7f2e2baae96c8d195837ce423128c0c596cc2733503",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.8.0",
+    "dest-filename": "kotlinx-coroutines-test-jvm-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.10.2/kotlinx-coroutines-test-1.10.2.pom",
+    "sha512": "4d49f5a32e32558d490f6159be5740a361b2ed615f762a63623b430feca757d499934157e16c52669b07a14cbe5ffe42e192db26b81190b06e3b84963ddaaeed",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.10.2",
+    "dest-filename": "kotlinx-coroutines-test-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.8.0/kotlinx-coroutines-test-1.8.0.pom",
+    "sha512": "e473da72ff8b8362eb934d0a83af4dbfe286e56381402d795e5d530a6b2f587fcb59b0cb84d53e7d7e0dc562a431f7685c24a67248cf44f33dd753e98c7279de",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.8.0",
+    "dest-filename": "kotlinx-coroutines-test-1.8.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.7.1/kotlinx-datetime-jvm-0.7.1.jar",
+    "sha512": "1c7f560ae5ea82f5e874ebd517b44083a66556c821a5fb58216561568a97fc314355e81f5cf1940d6b67dfbb179c3191b59fc4252c11ba9de21ea3433ca27311",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.7.1",
+    "dest-filename": "kotlinx-datetime-jvm-0.7.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.7.1/kotlinx-datetime-jvm-0.7.1.module",
+    "sha512": "10f49a565636051725b4ce8a864b9266f2342496548274fc27c03225b193ffe955050e44180590966c0b8ae201c3c2bff8c853b7ae2bac0e66f948331f5684de",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.7.1",
+    "dest-filename": "kotlinx-datetime-jvm-0.7.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.7.1/kotlinx-datetime-jvm-0.7.1.pom",
+    "sha512": "f4d11a69cd3e825e805273369bfbc9cb4354b7bd9b58046e8387c2a374bd0b4354db87aa13eff755d51b4e16d52dfbfa8529e23efe96088caa0533c15891a515",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.7.1",
+    "dest-filename": "kotlinx-datetime-jvm-0.7.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-datetime/0.7.1/../../kotlinx-datetime-jvm/0.7.1/kotlinx-datetime-jvm-0.7.1.module",
+    "sha512": "10f49a565636051725b4ce8a864b9266f2342496548274fc27c03225b193ffe955050e44180590966c0b8ae201c3c2bff8c853b7ae2bac0e66f948331f5684de",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-datetime/0.7.1/../../kotlinx-datetime-jvm/0.7.1",
+    "dest-filename": "kotlinx-datetime-jvm-0.7.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-datetime/0.7.1/kotlinx-datetime-0.7.1.module",
+    "sha512": "a68209f7dc11f5f4dd0dccb41319b5544aafbe8672b6ecab327b8dc24d103380ccc59d2b40754d2786706b0688a6e886fe9f6cffc7b0dbfc5194e57e05f53c34",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-datetime/0.7.1",
+    "dest-filename": "kotlinx-datetime-0.7.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-datetime/0.7.1/kotlinx-datetime-0.7.1.pom",
+    "sha512": "25d011a5daa059f2d1ec282615dcc472fe38700661b0da2b93fee622dfa6f8b3441de0b126c281e71d2830c8c34c063f058e87dbf1be20c5521cfa4ebc765182",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-datetime/0.7.1",
+    "dest-filename": "kotlinx-datetime-0.7.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0/kotlinx-html-jvm-0.12.0.jar",
+    "sha512": "d54dd43230fe3f05296e44501f613a0242af9ca46900afca5e665287c49527a29e4adee48aac27c614326bbaf9a4d3923536608a2a47a51468360b26ac1b83a0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0",
+    "dest-filename": "kotlinx-html-jvm-0.12.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0/kotlinx-html-jvm-0.12.0.module",
+    "sha512": "f3839adaab991db417f3b26e70f91d1189d1e12070a45e14d8efee280e9519489b1e0e5d968571919400943a7fe70df352a7edbf2f49d4e35295a20a0781671d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0",
+    "dest-filename": "kotlinx-html-jvm-0.12.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0/kotlinx-html-jvm-0.12.0.pom",
+    "sha512": "5a888586314dbdbdf72d22abeedf78aff5300238c50c22afb9845589000f51acba08bceff5af82df7d19075ccd98ee83de64cb9135e6345d9febcfafe83d8f6c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0",
+    "dest-filename": "kotlinx-html-jvm-0.12.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2/kotlinx-io-bytestring-jvm-0.8.2.jar",
+    "sha512": "400f5deae09a285bea68bb00fcc247b9be4c76746584516b6aa5e612719783b6ee79979b497053f28d8878dd7d7514e91aa3611aaa1ce7ce369862f53f3a9c4b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-bytestring-jvm-0.8.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2/kotlinx-io-bytestring-jvm-0.8.2.module",
+    "sha512": "2d1ae5ce7a49681f9f48011301b4fea0bb11639ee4764cb698697576198a28f4e5d0dc446001d785ad882755dc020f1649231a0eb82679fb0610d75a0c133965",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-bytestring-jvm-0.8.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2/kotlinx-io-bytestring-jvm-0.8.2.pom",
+    "sha512": "7fd502441d8a7211df8a6732e321bc6aa5218c2f99ee3c155cf268837fdd70f7b34127c347326e405f9ceaf50959b74677ed704a6991ae5d9157286d7121b7cb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-bytestring-jvm-0.8.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2/../../kotlinx-io-bytestring-jvm/0.8.2/kotlinx-io-bytestring-jvm-0.8.2.module",
+    "sha512": "2d1ae5ce7a49681f9f48011301b4fea0bb11639ee4764cb698697576198a28f4e5d0dc446001d785ad882755dc020f1649231a0eb82679fb0610d75a0c133965",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2/../../kotlinx-io-bytestring-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-bytestring-jvm-0.8.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2/kotlinx-io-bytestring-0.8.2.module",
+    "sha512": "1245511dea7361b90b71211c16af13ba06f3c240abc7d60be367808680b9e291ad3f23bfa21f5421a05b8bae7e7e2db0779d97a7e80d013731013651ad0687f0",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2",
+    "dest-filename": "kotlinx-io-bytestring-0.8.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2/kotlinx-io-bytestring-0.8.2.pom",
+    "sha512": "8d8734e25410a5a4926b0a1aee099c817076ad0a222db54cb4d5e150f7fc7b09a32d02aea05e9a029e9921849ac7899a8c7b777fff7c34f8252a477e481f8378",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2",
+    "dest-filename": "kotlinx-io-bytestring-0.8.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2/kotlinx-io-core-jvm-0.8.2.jar",
+    "sha512": "ccdc618cdead73b4702e1bffcdf503bda7c3e0eae3d4db65430442eff1c7b2fdaeb5838781994fc82e46310de81a806707b9c3c2e72e36bacc154da8a82214bd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-core-jvm-0.8.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2/kotlinx-io-core-jvm-0.8.2.module",
+    "sha512": "481d06019b6fd1c2135fc20ddf30d9fd00a421297af7b12eb783c2afcd0c1c58def59b2d8db61700ccfcc717e2eaabc9070e25eba0779858d996ab3d42841789",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-core-jvm-0.8.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2/kotlinx-io-core-jvm-0.8.2.pom",
+    "sha512": "12f0726310dccc60bb703fc13634e8719d01c80189a512faa7abe9107a51aefabebc04a47116d727473e84db2626c527b1338eead8f66becdb8793b95ea90687",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-core-jvm-0.8.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2/../../kotlinx-io-core-jvm/0.8.2/kotlinx-io-core-jvm-0.8.2.module",
+    "sha512": "481d06019b6fd1c2135fc20ddf30d9fd00a421297af7b12eb783c2afcd0c1c58def59b2d8db61700ccfcc717e2eaabc9070e25eba0779858d996ab3d42841789",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2/../../kotlinx-io-core-jvm/0.8.2",
+    "dest-filename": "kotlinx-io-core-jvm-0.8.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2/kotlinx-io-core-0.8.2.module",
+    "sha512": "d1c88ea8b8aa77bbd213fb63c72b22108223cdddc0109ec6495a63c9305dbb5d5cc4f33140b7c49b8b7ab7b554a0b42f4b4d75e997751d2854f8c5fcd176fac2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2",
+    "dest-filename": "kotlinx-io-core-0.8.2.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2/kotlinx-io-core-0.8.2.pom",
+    "sha512": "f2c5a6d523358da2a0c994f1318c365285c710779f38a794a6cdea76c4a441271be4b5f0a61d0fdd72a0e6e7f2b7a158ddb4a115af5b39858d721e28f5082f1b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2",
+    "dest-filename": "kotlinx-io-core-0.8.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-bom/1.10.0/kotlinx-serialization-bom-1.10.0.pom",
+    "sha512": "fd2506eae3e81484e49f6e175387e12f81c58f00784e00d1f5dc771c7d5e351b737570e4a1b976eb6565ca3a9dedce37eac68513bb46a2f49c8242da4ac73fd8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-bom/1.10.0",
+    "dest-filename": "kotlinx-serialization-bom-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.10.0/kotlinx-serialization-cbor-jvm-1.10.0.pom",
+    "sha512": "d5a98637f0a3f29c7bf7a5b8c515ec34b9835b9ef011af4061d3b0930028698a2180d3cc684b2859983f993f33f2a5b936d6d4be14c60265f2baa9c1b998ea63",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-cbor-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-cbor/1.10.0/kotlinx-serialization-cbor-1.10.0.pom",
+    "sha512": "1fd0c8dfdb847d04adb209f1fb0ba2909d2f76f2a3b06b556a5892e15e25ec50abb55556cebf35954b1b11d8fe2db111c55e127bdf79ec6c7ad02a368023156d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-cbor/1.10.0",
+    "dest-filename": "kotlinx-serialization-cbor-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0/kotlinx-serialization-core-jvm-1.10.0.jar",
+    "sha512": "066f05d77e61a3519f2031f080c6872733f0d3d93b13d77911c302f45b2f975923cb4dfd2d85d6c81c64514181369782dc23aaccae4413b4ef0b7a872ed8896d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.10.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0/kotlinx-serialization-core-jvm-1.10.0.module",
+    "sha512": "19bb80223874dba5cf3899367d6eca4b351c6acf8a1bce54c9c58a53822f9d4b523ad6e6c74771f276529a2169a8d69ff83d9a66e70999ef89daef401193e095",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.10.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0/kotlinx-serialization-core-jvm-1.10.0.pom",
+    "sha512": "7d6d775cadac6dce9e0d66c12b0cea46f1496e1ae4725df93062860f8c268aa68b189872e119bcaa548c0fca2086249c10349f2b9e0300739bb29ddacf5641df",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.jar",
+    "sha512": "26e6fdf3dd6ed31b8d2d6799ce34c07ffaea9a8aed2c003fb6a7c68b23cd49f564d4f2ff1bd55456de6b0805225a644ea3d24eb152858284fd013ff04b18b981",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.4.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.module",
+    "sha512": "7c95b19ad9ddbe0cc594312b930c6c4ca99b7b859586d54e0990829715cb0ff3b85ab953d76859291411e363617834d2e275aae18f976a6ded27e47731259292",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.4.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.pom",
+    "sha512": "4139f92e8d3aec7e8a3df895c16c9fc231ef628502efc40e6a01f4a216d94461ba24b245646d5ba5e00068b3390533251bc0e458107f6ffe16737e540360350c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.4.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0/../../kotlinx-serialization-core-jvm/1.10.0/kotlinx-serialization-core-jvm-1.10.0.module",
+    "sha512": "19bb80223874dba5cf3899367d6eca4b351c6acf8a1bce54c9c58a53822f9d4b523ad6e6c74771f276529a2169a8d69ff83d9a66e70999ef89daef401193e095",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0/../../kotlinx-serialization-core-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.10.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0/kotlinx-serialization-core-1.10.0.module",
+    "sha512": "95f5d0c001cf8000b684c44020c5e4f3fe01ce8e0d9312653757c0b12261a113efb654957471bd337f0a40651039241350314d6dc648018d5cb080d4786a338e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0",
+    "dest-filename": "kotlinx-serialization-core-1.10.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0/kotlinx-serialization-core-1.10.0.pom",
+    "sha512": "823a296b5e341b2904576ba4116fbcfbfcb9ec4d1a885207da29ed7685b982030155da6dc4a67b281df8b832fca792b07a16ba954a0f9e6f3c7cdf147145530b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0",
+    "dest-filename": "kotlinx-serialization-core-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.4.1/../../kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.module",
+    "sha512": "7c95b19ad9ddbe0cc594312b930c6c4ca99b7b859586d54e0990829715cb0ff3b85ab953d76859291411e363617834d2e275aae18f976a6ded27e47731259292",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.4.1/../../kotlinx-serialization-core-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.4.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.4.1/kotlinx-serialization-core-1.4.1.module",
+    "sha512": "1fbe8529bdb84875a0e58b2910d1b9604c5e430a87174c3a124909d2ee6f2330e37d1672708655eb743186e26b43fdc241dd80e2ecc8c4d7e535252dea06b9a1",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.4.1",
+    "dest-filename": "kotlinx-serialization-core-1.4.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.4.1/kotlinx-serialization-core-1.4.1.pom",
+    "sha512": "e73ec15072cd6ff9f83e34478d5602b24c9ebe092fff16876083dc2f99ae39d0079183f9f202c5d93b3c1de76150a86626ec620fd4be6b0dfb1dcc945a66e1d8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.4.1",
+    "dest-filename": "kotlinx-serialization-core-1.4.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-hocon/1.10.0/kotlinx-serialization-hocon-1.10.0.pom",
+    "sha512": "5230c7bd01df301df799355ecdf4aee783d4396a4229d50d7b35d3b96b28c28e4a264a09d0b647b18345f992c65457543647c68f6fa68ddedb7c0282bfe409e7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-hocon/1.10.0",
+    "dest-filename": "kotlinx-serialization-hocon-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.10.0/kotlinx-serialization-json-io-jvm-1.10.0.pom",
+    "sha512": "7d5905efe0ce9e35a2ab9706c564e1443430d68a5a96e1d503ee88a3e2353fca30d3352cf481f6f1214213fa161b2ab6612bce16259904b8e85880a557be726a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-io-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.10.0/kotlinx-serialization-json-io-1.10.0.pom",
+    "sha512": "11788d7796ec404498992e5d8d747962926b40b2f69973784a4fe118f8a1cad1821f2f4085472e297145b190e696e4327bff50a34a33f2261933bf005a1510a8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-io-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0/kotlinx-serialization-json-jvm-1.10.0.jar",
+    "sha512": "e51d563a6195bc0dccff4638039e1e3c34ccc28530c4ad192fc65faddcc8ef47585065d5826bb442814fdac04c9a8269dbceede9cd211c084cd320fbc80e9fdd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.10.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0/kotlinx-serialization-json-jvm-1.10.0.module",
+    "sha512": "ec8a87c1ee2282f06a2e33f33831d8c0602be9af8ecd024b6e0f0fcf916d0e7c837bd7ab39cf239babb2cd3650a7ed748678546eb2a20f8ead443688c51c13b7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.10.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0/kotlinx-serialization-json-jvm-1.10.0.pom",
+    "sha512": "48edd357df91446f0f7229b44d28be1f169ac6caf988d7f890173ff5241056f72ef00b61168dcc32d9933eddc4c2f981ff25381c69889a989317a5e7a92033f4",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.jar",
+    "sha512": "a47c35e4c9a92044b7f54f3fd0cf208ceae08a3513b3d519e17387a0ab05390c8210e5b13853e21c6d0c8797cbc667143777cedee060f16964ff9ec353760f13",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.4.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.module",
+    "sha512": "0e14436ee1184626fcc1c67be0c6476f19f1c97ee2b070b6eefc2c93ee408024bbca3630f5ee078b82649485e15ef74d0ac62ad27fe23dd067615a4210073d70",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.4.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.pom",
+    "sha512": "f2f250578262912600cc0a4ed5c1ed14cedcd5985a4ee6c03404a634bbe81bdeec1be42ce7b8a8a2ad33dd09211dff1b162c76aaae906eb887002e475e66cbb6",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.4.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-okio-jvm/1.10.0/kotlinx-serialization-json-okio-jvm-1.10.0.pom",
+    "sha512": "b834816001eb6709a2edb22d69e12a2351ef348b061007a458062dd52471e8306d59424a68d3a64e2dba181678814f1f858bbdc5f5d6b1bafe7462ce19f59451",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-okio-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-okio-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-okio/1.10.0/kotlinx-serialization-json-okio-1.10.0.pom",
+    "sha512": "acba739a7c00556bfdeefc941640f06f495cd06e3dd3ee50f1422213388d0af7174b35d54666fc6577b0a9823854b51f5ef365341029fd1e6901d32eb52e2236",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-okio/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-okio-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.10.0/../../kotlinx-serialization-json-jvm/1.10.0/kotlinx-serialization-json-jvm-1.10.0.module",
+    "sha512": "ec8a87c1ee2282f06a2e33f33831d8c0602be9af8ecd024b6e0f0fcf916d0e7c837bd7ab39cf239babb2cd3650a7ed748678546eb2a20f8ead443688c51c13b7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.10.0/../../kotlinx-serialization-json-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.10.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.10.0/kotlinx-serialization-json-1.10.0.module",
+    "sha512": "c14ec7e381a23342cf1b96f2d916be132ee6227509a0eeb143a3424b69b505fc94f8a9c264a07b391effee20395b92137e39526f8271bebe7eeea74fef8872fd",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-1.10.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.10.0/kotlinx-serialization-json-1.10.0.pom",
+    "sha512": "0632339f667337e0a02b0b47daedcbf496296b9f56aaf3926a4f0eb2d68eef3a15756f939f534c18628b3fcba8ec3f254408b92652b617ba6bbb11e70fbd944d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.10.0",
+    "dest-filename": "kotlinx-serialization-json-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.4.1/../../kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.module",
+    "sha512": "0e14436ee1184626fcc1c67be0c6476f19f1c97ee2b070b6eefc2c93ee408024bbca3630f5ee078b82649485e15ef74d0ac62ad27fe23dd067615a4210073d70",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.4.1/../../kotlinx-serialization-json-jvm/1.4.1",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.4.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.4.1/kotlinx-serialization-json-1.4.1.module",
+    "sha512": "104c013b5a6ea424d968e7dc27b9b13800e23ca76bb62b656adceba7dde7148dfd55e8e8c5d7d48adccf2bd44d4c43a7ab8b8ebf39c9924ce853222270900d3d",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.4.1",
+    "dest-filename": "kotlinx-serialization-json-1.4.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.4.1/kotlinx-serialization-json-1.4.1.pom",
+    "sha512": "297a3f7a8a8af3155dcf1387a0b3ae6df9ff6a66a13f52d5aa9a0522087037a5dc011f310ff6ab1171d7ebc7d804f3cae15f822ce22d6bfc76900561e16b0989",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.4.1",
+    "dest-filename": "kotlinx-serialization-json-1.4.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-properties-jvm/1.10.0/kotlinx-serialization-properties-jvm-1.10.0.pom",
+    "sha512": "7018d746600988c2d80f8d55820218524810466f4918da4cbf89a9421fbf112cc638a11e4b768a4d8febb23f278ad05200b1353304b42d736924674615233524",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-properties-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-properties-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-properties/1.10.0/kotlinx-serialization-properties-1.10.0.pom",
+    "sha512": "1e92337b6177e70f8a0304cc5a642b0ed01fe57efb837cafb3547209a9db1d13af2234351806ce3b56bc7ba0a88c1812d0fb5a4c66b5b3da59488dc73ef6e3c5",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-properties/1.10.0",
+    "dest-filename": "kotlinx-serialization-properties-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.10.0/kotlinx-serialization-protobuf-jvm-1.10.0.pom",
+    "sha512": "25253b58b0c94329e805f7294912d5da5420a117f011a995b9c0ff2a0b999b38452f02546c6352570147559ca4790983b9b5605950a955a6be520c457d135727",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.10.0",
+    "dest-filename": "kotlinx-serialization-protobuf-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-protobuf/1.10.0/kotlinx-serialization-protobuf-1.10.0.pom",
+    "sha512": "f561276ae918a88e45f6a30ee795ea6b3190da998a9078067f6fee75d6ba68465f8632b9596a47e91ffe685767283ea07b651f3ce43b9452accfb75df8935d85",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-protobuf/1.10.0",
+    "dest-filename": "kotlinx-serialization-protobuf-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kover-features-jvm/0.9.7/kover-features-jvm-0.9.7.jar",
+    "sha512": "2a172b21177d1c9e5019d4ac1e45b9d9a1bcd7a5b94a6945d7edcf08c4c1a77a55a83bf6c3566e7cc3384b03fa139fd85123bb176d458ff0f9be656ff67bc9df",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kover-features-jvm/0.9.7",
+    "dest-filename": "kover-features-jvm-0.9.7.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kover-features-jvm/0.9.7/kover-features-jvm-0.9.7.module",
+    "sha512": "6222eb1b0fc4a6281c9b84ccefb8d86ac8b5da419e9546b29c2d82b1bc9cb84245f468382531ab637c92087508ac2e8dbcbae3275161f2cb3e6429a8ff445262",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kover-features-jvm/0.9.7",
+    "dest-filename": "kover-features-jvm-0.9.7.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kover-features-jvm/0.9.7/kover-features-jvm-0.9.7.pom",
+    "sha512": "b48685c7520c5c7da1b3d3ecf54e42d6ad05a485e1a3ad959ee5a9fc25d2df9b6c81f39aacb4c4809f83d5efb07ff1c576aeb961207cad7677a93cde2e1f3feb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kover-features-jvm/0.9.7",
+    "dest-filename": "kover-features-jvm-0.9.7.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kover-gradle-plugin/0.9.7/kover-gradle-plugin-0.9.7.jar",
+    "sha512": "e24c00dd059d438a02c8b867af0a96304bb8b55b520807ee24302412159ed02f1900f18df15215528337363a4dd1234e62f12f63c5fcad977d7c6841ae852c8c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kover-gradle-plugin/0.9.7",
+    "dest-filename": "kover-gradle-plugin-0.9.7.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kover-gradle-plugin/0.9.7/kover-gradle-plugin-0.9.7.module",
+    "sha512": "8935b8d491860ffa867f016661dbe0d7c704ff82ea517966579c1d33e1600a50d124c0234ef6fad2ef7318f8232f9cfbbb96a81bba3c9f03e9bdef35e6ebacd7",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kover-gradle-plugin/0.9.7",
+    "dest-filename": "kover-gradle-plugin-0.9.7.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kover-gradle-plugin/0.9.7/kover-gradle-plugin-0.9.7.pom",
+    "sha512": "ceddac73ab4fee9fa3775665beba1f80137e4f3a1bcb4041c2d1f500d7cf1d3841ba1e490a4450eec81c25c8bd2b30db2d789589660a53fb500ae8cfb99b290c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kover-gradle-plugin/0.9.7",
+    "dest-filename": "kover-gradle-plugin-0.9.7.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kover-jvm-agent/0.9.7/kover-jvm-agent-0.9.7.jar",
+    "sha512": "570287251ab5c49faccde55c3b7b9198d6a70b787ab5055a353273c94ca85a3e1c75fb8f11ddcf9de3bc39fa17e806e5a369d6f87c3f2d6d8284742f594eb15c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kover-jvm-agent/0.9.7",
+    "dest-filename": "kover-jvm-agent-0.9.7.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kover-jvm-agent/0.9.7/kover-jvm-agent-0.9.7.module",
+    "sha512": "bdb29be9ae62917289f000a039cba03901b408d8a316353fd23d2709f6f94d77be681031c15766b194cab10f785ddbdf7448eb7f2058e3c914e86196e9772307",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kover-jvm-agent/0.9.7",
+    "dest-filename": "kover-jvm-agent-0.9.7.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kover-jvm-agent/0.9.7/kover-jvm-agent-0.9.7.pom",
+    "sha512": "1620cea62c6059936acd140eee6bc184c29b4a5cbc1929e0b0303ef39d1d3cc872b402e68587eaff9664490101659b22724a0588da634d90eb742fd0d0eca93b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kover-jvm-agent/0.9.7",
+    "dest-filename": "kover-jvm-agent-0.9.7.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kover/org.jetbrains.kotlinx.kover.gradle.plugin/0.9.7/org.jetbrains.kotlinx.kover.gradle.plugin-0.9.7.pom",
+    "sha512": "81174d6a77d89905694e6edfba8a213031f00741b4eb3f11d646b159ed0e5b6bdca8d01b1c87544ea2e776e04f7ffbd1e58eb438512389f831cd2ef0ff1298e2",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jetbrains/kotlinx/kover/org.jetbrains.kotlinx.kover.gradle.plugin/0.9.7",
+    "dest-filename": "org.jetbrains.kotlinx.kover.gradle.plugin-0.9.7.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
+    "sha512": "efded31ef5b342f09422935076e599789076431e93a746685c0607e7de5592719ba6aacde0be670b3f064d1e85630d58d5bce6b34aed2a288fdb34f745efb7bc",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jspecify/jspecify/1.0.0",
+    "dest-filename": "jspecify-1.0.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.module",
+    "sha512": "02669b1c62e0c6988dd812b89201acbe6dad796f3573d6e626d2f56d2194896e198bf3998f0618019b722c7b0c93f013528bff1118f835154f2bd61c17e67b77",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jspecify/jspecify/1.0.0",
+    "dest-filename": "jspecify-1.0.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.pom",
+    "sha512": "291d8fb333121ba18ebd427e7ee5e98694be797b8280a228be7c4958af934b2465f341957248dcd396f5ffbe99dd9a65aa61cef70ca772ee37a92c3d20e41f32",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/jspecify/jspecify/1.0.0",
+    "dest-filename": "jspecify-1.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.10.1/junit-bom-5.10.1.pom",
+    "sha512": "1b9c3bcea64f5d98f5e39c88adab6d7a9bfcf0ee4e6639a8c146b4b7cb29a4a280b567c6e42a537c215590c557e86b9446a2c9dcf76191d0ecac1ad9bf16f7c8",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/junit-bom/5.10.1",
+    "dest-filename": "junit-bom-5.10.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom",
+    "sha512": "e1c4acc68f7114cd501754d07e51a9345bc1106623ea9e38cd6d40b1886cea7f8f6fa227da9d71da608b6691ef1f9d75d11253567350fbb4a949770a1cb7023e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/junit-bom/5.13.1",
+    "dest-filename": "junit-bom-5.13.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.13.2/junit-bom-5.13.2.pom",
+    "sha512": "d557142227e27ecee6f3bdc77a7765cec614a2a4b7e88c9343dad30b53648708e8f17e422a9a2cec6aefa9c0c8bc07f573da23ed68211a399ea0a80426011489",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/junit-bom/5.13.2",
+    "dest-filename": "junit-bom-5.13.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
+    "sha512": "ec795b2f32982c1af8dccef57553aa9d959c13ee829aebd6459ba22b4ef434aeb4184aa89f63ad2f0d8c45d59cd020a15cd976ddb4bf20f1044b492a406e029e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/junit-bom/5.13.4",
+    "dest-filename": "junit-bom-5.13.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom",
+    "sha512": "a8f5b64af5387c0eab939f6af8c2d3a7dfe9930ccaf0a33db97a307fa2af2607dfecb520527f9579521d6296d7dc0029310ea410df753e6b3ad7a63ac00f12c9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/junit/junit-bom/5.9.3",
+    "dest-filename": "junit-bom-5.9.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/mockito/mockito-bom/4.11.0/mockito-bom-4.11.0.pom",
+    "sha512": "6bdf2809a5a479f73975ddb87cb102db88dac702904b89e8dcd9b9057dbbce67abb85d9cfbefda79c152d928346122eced122d2af17617772abeae0c383cc16a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/mockito/mockito-bom/4.11.0",
+    "dest-filename": "mockito-bom-4.11.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.annotation.bundle/2.0.0/org.osgi.annotation.bundle-2.0.0.jar",
+    "sha512": "f16b8983240ba3c08d6bc78e2eae92e89eb528f32a705961d90b463def0a5ed1ba08cc3d0be38b5dcfb946c6f759df772e122fb769e58e8c20aa79a489a1fd21",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.annotation.bundle/2.0.0",
+    "dest-filename": "org.osgi.annotation.bundle-2.0.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.annotation.bundle/2.0.0/org.osgi.annotation.bundle-2.0.0.pom",
+    "sha512": "124183dc93b62622a92cbecfda01d728ac7466f7192897fbdf82bdf478f03e11436493884ec7e1dc2a019df995b95804252f1f92cf152477417109feffb37871",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.annotation.bundle/2.0.0",
+    "dest-filename": "org.osgi.annotation.bundle-2.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.annotation.versioning/1.1.2/org.osgi.annotation.versioning-1.1.2.jar",
+    "sha512": "a4c612bec624a168f25f0923d51925bbc914686673eeebd5b2442998b876f05855e2b0a6e6e9aca4a6533ed3156b0d24f94c3e508ee9778e1b2e469be318afa3",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.annotation.versioning/1.1.2",
+    "dest-filename": "org.osgi.annotation.versioning-1.1.2.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.annotation.versioning/1.1.2/org.osgi.annotation.versioning-1.1.2.pom",
+    "sha512": "9ee84aa306441dcb9c02102b5fcaa6fc024f5ce931c9b020bbc6243b7e2bd518e86128986a2e65bf101df311d37a1fe2530d3ad3f67cc6bf96fb22e51f85f83e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.annotation.versioning/1.1.2",
+    "dest-filename": "org.osgi.annotation.versioning-1.1.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.resource/1.0.0/org.osgi.resource-1.0.0.jar",
+    "sha512": "4e798790856f83f50832db80bfab64dfceeff1c509d7dde43e74a9f9192ea7a7d5ea77b9b1e81291fa6ba3dcef5ab8fa791ca8093a72a08d7ca6f6499e13e506",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.resource/1.0.0",
+    "dest-filename": "org.osgi.resource-1.0.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.resource/1.0.0/org.osgi.resource-1.0.0.pom",
+    "sha512": "300a564c775d93966a22d887d8a1fea7d4a2d1db3f1868e13538d0ea0e303b45fe6cb7994d6ac2e3965d2bf82a981cdf4cf6392209f74b1f68170979d65e3dcb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.resource/1.0.0",
+    "dest-filename": "org.osgi.resource-1.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.service.serviceloader/1.0.0/org.osgi.service.serviceloader-1.0.0.jar",
+    "sha512": "a7def4cb7a8ed992645faa80a780e0b30bd39c1587b5bcb65fe170d10842d0d880c2849edd50c64807fe0e4b9cc0051337d1b161d0d390465d9e63a762861c49",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.service.serviceloader/1.0.0",
+    "dest-filename": "org.osgi.service.serviceloader-1.0.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/osgi/org.osgi.service.serviceloader/1.0.0/org.osgi.service.serviceloader-1.0.0.pom",
+    "sha512": "0c971694c707dacbbf0304741ddaed4cc107f7b4c0fdfc0c6cd2a85910df10733185f14e5c3243c0dea545bca2f6a7aeeeb7c048324af5908c96fe0f5484955b",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/osgi/org.osgi.service.serviceloader/1.0.0",
+    "dest-filename": "org.osgi.service.serviceloader-1.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.pom",
+    "sha512": "16bd0ad91a8094fb042f7c4248fcb9737f5827573d97e2c8ce84bd82a234a9247ccd9c1444cf25f5df4c379e8bcd12e732777ad2b1e2a1375bc45b8ff700b767",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/slf4j/slf4j-api/2.0.13",
+    "dest-filename": "slf4j-api-2.0.13.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar",
+    "sha512": "9a3e79db6666a6096a3021bb2e1d918f30f589d8de51d6b600f8ebd92515a510ae2d8f87919cc2dfa8365d64f10194cac8dfa0fb950160eef0e9da06f6caaeb9",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/slf4j/slf4j-api/2.0.17",
+    "dest-filename": "slf4j-api-2.0.17.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.pom",
+    "sha512": "462872ccda241179a77ebc89c3f7be93870fffae344e09d3cccc33d6448336dc77affc9572f420d7da788b3f0eb072b7facc9b7e609b33742ed48f4bb467cb70",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/slf4j/slf4j-api/2.0.17",
+    "dest-filename": "slf4j-api-2.0.17.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/slf4j/slf4j-bom/2.0.17/slf4j-bom-2.0.17.pom",
+    "sha512": "cb2db4597b98b9981959413e3ffcd5882f8e267d3d51f989c396807c36893296065cbe443a173029e8d3a0851eced25f5149dc2dafa0dd2c29fca737180a7029",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/slf4j/slf4j-bom/2.0.17",
+    "dest-filename": "slf4j-bom-2.0.17.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/slf4j/slf4j-parent/2.0.17/slf4j-parent-2.0.17.pom",
+    "sha512": "5b16a209843c18a478a0a16dff83ae1c75eedbdeadc15a958d536a36631d4d39a9998e085c165a79ced8ad187f021e2f3cd4068856ca174db35657ef5a473c5a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/slf4j/slf4j-parent/2.0.17",
+    "dest-filename": "slf4j-parent-2.0.17.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/slf4j/slf4j-simple/2.0.13/slf4j-simple-2.0.13.pom",
+    "sha512": "84257236a096c2ac22fa80cc423624fc46b297bb941693c0bacef6b3ec9bf236100e8ff993f4710d17aad600da98da4378cac79129633946aa06aa9ae12c777e",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/slf4j/slf4j-simple/2.0.13",
+    "dest-filename": "slf4j-simple-2.0.13.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.jar",
+    "sha512": "2e5ab51ee5e170a4ea01c1586e07610fc63fb00e51321a35d04609ca78326d4bf6b7fb3c32b45a9388349cce3c0453a20d77213e33cb9b65b8244c7c54c80e4c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/snakeyaml/snakeyaml-engine/2.10",
+    "dest-filename": "snakeyaml-engine-2.10.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/snakeyaml/snakeyaml-engine/2.10/snakeyaml-engine-2.10.pom",
+    "sha512": "c5677ea77c3b2c98f54de73f1223fa13514a7d6d1bf8f42686e2a9889e40ad2a2b481a87f698cf295025aef6aaf43cbc90e6b6a05fd00c4600b797f93c78c531",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/snakeyaml/snakeyaml-engine/2.10",
+    "dest-filename": "snakeyaml-engine-2.10.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom",
+    "sha512": "63b0951f793ee9d25239ee44760e4d51de3b8503e438e567862306f2d175019d8617eb854bc4ee2374c39f385e0a1094c3c7097f899b2074e4acda14fe6030fb",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/sonatype/oss/oss-parent/7",
+    "dest-filename": "oss-parent-7.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom",
+    "sha512": "1c4f18cacd3a9f99a168bd20845d12d94824e66b5caebe57c164b6ac3dc89803508f60e35c4d1da81d3f3866c89ed407826f0d108f1e624c2d8a258e01e1064a",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/sonatype/oss/oss-parent/9",
+    "dest-filename": "oss-parent-9.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/springframework/spring-framework-bom/5.3.39/spring-framework-bom-5.3.39.pom",
+    "sha512": "3cdfeab209e770d9b555bb759c958f816a4313413f8deb4060954aa72a2170de5f2e90e6b076cd185e853cdc02f5bd7356720084c90a3cbe5847bd6d04e5017c",
+    "dest": "/home/antonio/code/zugaldia/speedofsound/offline-repository/org/springframework/spring-framework-bom/5.3.39",
+    "dest-filename": "spring-framework-bom-5.3.39.pom"
+  }
+]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ buildconfig = "6.0.7"
 clikt = "5.1.0"
 commonsCompress = "1.28.0"
 detekt = "2.0.0-alpha.2"
+flatpakGradleGenerator = "1.6.0"
 googleGenai = "1.37.0"
 javaGi = "0.14.0"
 kotlin = "2.3.10"
@@ -55,6 +56,7 @@ onnxEcosystem = ["onnxRuntime", "onnxRuntimeExtensions"]
 [plugins]
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }
+flatpakGradleGenerator = { id = "io.github.jwharm.flatpak-gradle-generator", version.ref = "flatpakGradleGenerator" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 kotlinPluginSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url = uri("${rootProject.projectDir}/offline-repository") }
+    }
+}
+
 dependencyResolutionManagement {
     // Use Maven Central as the default repository (where Gradle will download dependencies) in all subprojects.
     @Suppress("UnstableApiUsage")
     repositories {
         mavenCentral()
+        maven { url = uri("${rootProject.projectDir}/offline-repository") }
 //        mavenLocal()
 //        maven {
 //            url = uri("https://central.sonatype.com/repository/maven-snapshots/")


### PR DESCRIPTION
## Summary
- Add the [flatpak-gradle-generator](https://github.com/flatpak/flatpak-builder-tools/tree/master/gradle) plugin (v1.6.0) to the `app` and `core` modules for generating Flatpak offline dependency sources
- Configure offline repository in `settings.gradle.kts` for both plugin and dependency resolution
- Add `make flatpak-sources` target to regenerate the sources files

## Notes
- The plugin is not compatible with Gradle's configuration cache, so the Makefile target uses `--no-configuration-cache`
- The CLI module is excluded since it won't be bundled in Flatpak

## Test plan
- [x] `./gradlew build` succeeds
- [x] `make flatpak-sources` generates `app/flatpak-sources.json` and `core/flatpak-sources.json`