### PR TITLE
chore: release v0.6.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 
 # Project version
-speedofsound.version=0.6.0-dev
+speedofsound.version=0.7.0-dev
 
 # - disableGioStore: When true, uses Java Properties for settings instead of GSettings.
 #   Helpful when running the shadow JAR standalone outside an installed environment

--- a/io.speedofsound.App.metainfo.xml
+++ b/io.speedofsound.App.metainfo.xml
@@ -54,6 +54,16 @@
     </screenshots>
 
     <releases>
+        <release version="0.6.0" date="2026-03-04">
+            <description>
+                <p>
+                    Added Gemini 3.1 Pro and Gemini Flash Lite as available cloud text models,
+                    replacing Gemini 3 Pro. Also improved LLM text polishing quality with
+                    few-shot prompt examples for better handling of commonly spoken language patterns.
+                    Fixed icon visibility for model removal on light mode.
+                </p>
+            </description>
+        </release>
         <release version="0.5.0" date="2026-02-24">
             <description>
                 <p>


### PR DESCRIPTION
Bumps version to 0.7.0-dev and adds v0.6.0 release notes to metainfo.xml.