### PR TITLE
fix: require Ctrl modifier for S and M keyboard shortcuts

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
@@ -117,8 +117,8 @@ class MainWindow(
         return when {
             key == "Shift_L" -> { viewModel.onPrimaryLanguageSelected(); true }
             key == "Shift_R" -> { viewModel.onSecondaryLanguageSelected(); true }
-            key == "s" || key == "S" -> { viewModel.toggleListening(); true }
-            key == "m" || key == "M" -> { goAway(); true }
+            (key == "s" || key == "S") && ctrlPressed -> { viewModel.toggleListening(); true }
+            (key == "m" || key == "M") && ctrlPressed -> { goAway(); true }
             key == "Escape" -> { viewModel.cancelListening(); true }
             (key == "q" || key == "Q") && ctrlPressed -> { onQuit(); true }
             else -> false

--- a/app/src/main/resources/shortcuts.xml
+++ b/app/src/main/resources/shortcuts.xml
@@ -10,7 +10,7 @@
                         <child>
                             <object class="GtkShortcutsShortcut">
                                 <property name="title">Start or Stop Listening</property>
-                                <property name="accelerator">s</property>
+                                <property name="accelerator">&lt;Control&gt;s</property>
                             </object>
                         </child>
                         <child>
@@ -22,7 +22,7 @@
                         <child>
                             <object class="GtkShortcutsShortcut">
                                 <property name="title">Minimize Window</property>
-                                <property name="accelerator">m</property>
+                                <property name="accelerator">&lt;Control&gt;m</property>
                             </object>
                         </child>
                         <child>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -21,9 +21,9 @@ dictation from any application.
 | Shortcut      | Action                                                                                |
 |---------------|---------------------------------------------------------------------------------------|
 | `Super+Z`     | Start or stop dictation (global, configured in [Getting Started](getting-started.md)) |
-| `S`           | Start or stop listening (while the app window is focused)                             |
+| `Ctrl+S`      | Start or stop listening (while the app window is focused)                             |
 | `Escape`      | Cancel listening                                                                      |
-| `M`           | Minimize window                                                                       |
+| `Ctrl+M`      | Minimize window                                                                       |
 | `Left Shift`  | Select primary language                                                               |
 | `Right Shift` | Select secondary language                                                             |
 | `Ctrl+Q`      | Quit                                                                                  |


### PR DESCRIPTION
## Summary

- Changes `S` → `Ctrl+S` and `M` → `Ctrl+M` in the `EventControllerKey` handler in `MainWindow`
- Updates `shortcuts.xml` accelerators to match
- Updates the keyboard shortcuts table in `docs/user-guide.md`

## Root cause

Bare `S` and `M` keys were triggering `toggleListening()` and `goAway()` via the window's `EventControllerKey` handler. When the pipeline completed and typed text was injected through the Remote Desktop Portal, the SOS window sometimes still had focus (the 100ms `POST_HIDE_DELAY_MS` is not always enough for focus to transfer). Any `s` character in the transcribed text (e.g. "This is the test…") would fire `toggleListening()`, starting a spurious new recording cycle.

## Test plan

- [ ] Verify `Ctrl+S` starts and stops listening while the main window is focused
- [ ] Verify `Ctrl+M` hides the window
- [ ] Verify bare `s` and `m` keys no longer trigger those actions
- [ ] Verify the Keyboard Shortcuts dialog shows the updated accelerators
- [ ] Run a dictation session and confirm no spurious recording starts after the pipeline completes