### PR TITLE
fix: grant contents:write permission to release-github reusable workflow call

### DIFF
--- a/.github/workflows/release-dispatcher.yml
+++ b/.github/workflows/release-dispatcher.yml
@@ -50,6 +50,8 @@ jobs:
   release-github:
     needs: check-release
     if: needs.check-release.outputs.new_release == 'true'
+    permissions:
+      contents: write
     uses: ./.github/workflows/release-github.yml
     with:
       version: ${{ needs.check-release.outputs.version }}


### PR DESCRIPTION
## Summary

- Fixes GitHub Actions error: `Error calling workflow ... The nested job 'release' is requesting 'contents: write', but is only allowed 'contents: read'`
- When calling a reusable workflow via `uses:`, GitHub restricts permissions to `contents: read` by default — the `contents: write` on the `check-release` job does not carry over
- Added explicit `permissions: contents: write` to the `release-github` job in `release-dispatcher.yml`

## Test plan

- [ ] Merge a `release/v*` PR into `main` and verify the release-dispatcher workflow completes without the permissions error