### PR TITLE
fix: explicitly declare audio-playback plug alongside audio-record

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,8 +73,9 @@ apps:
       - speedofsound
     plugs:
       - network       # Enables network access
-      - audio-record  # Allows audio recording
-      - alsa          # Java (javax.sound) uses ALSA
+      - audio-record   # Allows audio recording (microphone)
+      - audio-playback # Required alongside audio-record by Snap Store policy
+      - alsa           # Java (javax.sound) uses ALSA
       - gsettings     # GSettings access for GioStore
     environment:
       JAVA_HOME: $SNAP/usr/lib/jvm/java-25-openjdk-amd64


### PR DESCRIPTION
## Summary

- Adds `audio-playback` explicitly to the snap app's `plugs` list in `snapcraft.yaml`
- The `gnome` extension already injects `audio-playback` automatically, but the Snap Store policy requires it to be co-declared alongside `audio-record` in the app's own plugs section

## Context

The `v0.8.0-beta.1` snap publish failed with:
```
- audio-playback must be specified with audio-record
- human review required due to 'deny-connection' constraint (interface attributes)
```

This PR fixes the first error. The second error (human review for `audio-record`) requires a Store Declaration request on the Snapcraft forum.

## Test plan

- [ ] Snap build succeeds in CI
- [ ] Snap Store publish no longer errors on `audio-playback must be specified with audio-record`