### PR TITLE
feat: async plugin initialization for faster window startup

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/AudioWidget.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/AudioWidget.kt
@@ -43,7 +43,7 @@ class AudioWidget : Box(Orientation.VERTICAL, DEFAULT_BOX_SPACING) {
             AppStage.POLISHING -> "${polishingMessages.random()}..."
         }
 
-        val shouldPulsate = stage in listOf(AppStage.TRANSCRIBING, AppStage.POLISHING)
+        val shouldPulsate = stage in listOf(AppStage.LOADING, AppStage.TRANSCRIBING, AppStage.POLISHING)
         setPulsating(shouldPulsate)
         if (!shouldPulsate) setRecordingLevel(0.0)
     }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -73,28 +73,35 @@ class MainViewModel(
     private var currentPipelineJob: Job? = null
 
     fun start() {
-        // Register and initialize all plugins
+        // Phase 1 (sync, main thread): Register plugins and set up event collection.
+        // This is lightweight so the window can render immediately with "Loading..." state.
         registry.register(AppPluginCategory.RECORDER, recorder)
         asrProviderManager.registerAsrPlugins()
         llmProviderManager.registerLlmPlugins()
         registry.register(AppPluginCategory.DIRECTOR, director)
 
-        // Set active plugins
-        registry.setActiveById(AppPluginCategory.RECORDER, recorder.id)
-        asrProviderManager.activateSelectedProvider()
-        llmProviderManager.activateSelectedProvider()
-        registry.setActiveById(AppPluginCategory.DIRECTOR, DefaultDirector.ID)
-
         collectDirectorEvents()
         collectRecorderEvents()
         collectSettingsChanges()
         collectPortalsSessionState()
-        portalsSessionManager.initialize(viewModelScope)
-        state.updateStage(AppStage.IDLE)
 
         // Initialize status UI labels
         onPrimaryLanguageSelected(forceUpdate = true)
         updateModelLabels()
+
+        // Phase 2 (async, IO thread): Enable plugins (heavy: model extraction + ONNX load).
+        state.updateStage(AppStage.LOADING)
+        viewModelScope.launch(Dispatchers.IO) {
+            registry.setActiveById(AppPluginCategory.RECORDER, recorder.id)
+            asrProviderManager.activateSelectedProvider()
+            llmProviderManager.activateSelectedProvider()
+            registry.setActiveById(AppPluginCategory.DIRECTOR, DefaultDirector.ID)
+            portalsSessionManager.initialize(viewModelScope)
+            GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
+                state.updateStage(AppStage.IDLE)
+                false
+            }
+        }
     }
 
     fun onTriggerAction() {

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/AppPluginRegistry.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/AppPluginRegistry.kt
@@ -24,6 +24,7 @@ class AppPluginRegistry {
      * Sets a specific plugin as active for a given category by its ID.
      * Disables the currently active plugin (if any) and enables the new one.
      */
+    @Synchronized
     fun setActiveById(category: AppPluginCategory, pluginId: String) {
         if (activePlugins[category] == pluginId) {
             log.info("Plugin $pluginId is already active for category $category, skipping")
@@ -59,6 +60,7 @@ class AppPluginRegistry {
      * Gets the currently active plugin for a given category.
      * Returns null if no plugin is active for this category.
      */
+    @Synchronized
     fun getActive(category: AppPluginCategory): AppPlugin<*>? {
         val activeId = activePlugins[category] ?: return null
         return getPluginById(category, activeId)

--- a/docs/manual-installation.md
+++ b/docs/manual-installation.md
@@ -42,7 +42,8 @@ by [Java GI](https://java-gi.org/usage/#linux).)
 On the first launch, two things will happen:
 
 1. **Model setup**: The built-in Whisper Tiny model is unpacked into your user data folder.
-   This is automatic and the app will start faster in the future.
+   The app window will open and show a **Loading…** state while this happens in the background.
+   Subsequent launches will be faster.
 2. **Permissions prompt**: The app will ask you to grant permission to type on your behalf.
    To support both X11 and Wayland desktops without requiring root access, Speed of Sound uses XDG Desktop Portals
    for keyboard input. You must approve this prompt for dictation to work.


### PR DESCRIPTION
## Summary

- Splits `MainViewModel.start()` into two phases: a lightweight sync phase (plugin registration + event collection) that returns immediately, and a heavy async IO phase (model extraction, ONNX load, portal session init) that runs in the background
- Shows `AppStage.LOADING` with pulsation animation while the background initialization completes, then transitions to `AppStage.IDLE`
- Adds `@Synchronized` to `AppPluginRegistry.setActiveById` and `getActive` for thread safety when called from the IO coroutine

Closes #28.

## Test plan

- [ ] Launch the app and verify the main window appears immediately with a "Loading..." pulsating state
- [ ] Confirm the app transitions to idle (ready to record) once initialization completes
- [ ] Verify recording and transcription still work normally after the async init
- [ ] Confirm no race conditions when switching providers after startup