### PR TITLE
feat: add Advanced preferences page for typing delay settings

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/AppConstants.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/AppConstants.kt
@@ -29,7 +29,6 @@ const val DEFAULT_TEXT_VIEW_HEIGHT = 200
 const val DEFAULT_MARGIN = 10
 const val DEFAULT_BOX_SPACING = 10
 
-const val POST_HIDE_DELAY_MS = 100L
 const val SETTINGS_SAVE_DEBOUNCE_MS = 500
 
 // Adw CSS style classes

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -1,7 +1,6 @@
 package com.zugaldia.speedofsound.app.screens.main
 
 import com.zugaldia.speedofsound.app.isGStreamerDisabled
-import com.zugaldia.speedofsound.app.POST_HIDE_DELAY_MS
 import com.zugaldia.speedofsound.app.plugins.recorder.GStreamerRecorder
 import com.zugaldia.speedofsound.app.portals.PortalsSessionManager
 import com.zugaldia.speedofsound.app.portals.TextUtils
@@ -274,10 +273,11 @@ class MainViewModel(
         hideAndReset()
         if (event.finalResult.isBlank()) return
         viewModelScope.launch {
-            delay(POST_HIDE_DELAY_MS) // Wait for the main window to fully go away before typing
+            val postHideDelayMs = settingsClient.getPostHideDelayMs()
+            if (postHideDelayMs > 0) delay(postHideDelayMs.toLong())
             val finalText = event.finalResult.trim() + " " // Separate multiple results with a space
             TextUtils.textToKeySym(finalText)
-                .onSuccess { keySyms -> portalsClient.typeText(keySyms) }
+                .onSuccess { keySyms -> portalsClient.typeText(keySyms, settingsClient.getTypingDelayMs().toLong()) }
                 .onFailure { error -> logger.error("Error converting text to key symbols: ${error.message}") }
         }
     }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -273,6 +273,7 @@ class MainViewModel(
         hideAndReset()
         if (event.finalResult.isBlank()) return
         viewModelScope.launch {
+            // Wait for the main window to go away before typing
             val postHideDelayMs = settingsClient.getPostHideDelayMs()
             if (postHideDelayMs > 0) delay(postHideDelayMs.toLong())
             val finalText = event.finalResult.trim() + " " // Separate multiple results with a space

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesDialog.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesDialog.kt
@@ -21,21 +21,22 @@ import org.gnome.gtk.Stack
 import org.gnome.gtk.StackSidebar
 import org.slf4j.LoggerFactory
 
-class PreferencesDialog(private val settingsClient: SettingsClient) : Dialog() {
+class PreferencesDialog(settingsClient: SettingsClient) : Dialog() {
     private val logger = LoggerFactory.getLogger(PreferencesDialog::class.java)
     private val viewModel = PreferencesViewModel(settingsClient)
 
     private val operationsBanner: Banner
     private val stack: Stack
     private val sidebar: StackSidebar
+
     private val generalPage: GeneralPage
+    private val modelLibraryPage: ModelLibraryPage
     private val cloudCredentialsPage: CloudCredentialsPage
     private val voiceModelsPage: VoiceModelsPage
     private val textModelsPage: TextModelsPage
-    private val modelLibraryPage: ModelLibraryPage
     private val personalizationPage: PersonalizationPage
-    private val importExportPage: ImportExportPage
     private val advancedPage: AdvancedPage
+    private val importExportPage: ImportExportPage
 
     init {
         title = "Preferences"
@@ -47,13 +48,13 @@ class PreferencesDialog(private val settingsClient: SettingsClient) : Dialog() {
         }
 
         generalPage = GeneralPage(viewModel)
+        modelLibraryPage = ModelLibraryPage(viewModel) { hasOperations -> operationsBanner.revealed = hasOperations }
         cloudCredentialsPage = CloudCredentialsPage(viewModel)
         voiceModelsPage = VoiceModelsPage(viewModel)
         textModelsPage = TextModelsPage(viewModel)
-        modelLibraryPage = ModelLibraryPage(viewModel) { hasOperations -> operationsBanner.revealed = hasOperations }
         personalizationPage = PersonalizationPage(viewModel)
-        importExportPage = ImportExportPage(viewModel) { refreshAllPages() }
         advancedPage = AdvancedPage(viewModel)
+        importExportPage = ImportExportPage(viewModel) { refreshAllPages() }
 
         stack = Stack().apply {
             hexpand = true
@@ -106,8 +107,8 @@ class PreferencesDialog(private val settingsClient: SettingsClient) : Dialog() {
         }
 
         onClosed {
-            personalizationPage.forceSaveInstructions()
             modelLibraryPage.shutdown()
+            personalizationPage.forceSaveInstructions()
             importExportPage.shutdown()
         }
     }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesDialog.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesDialog.kt
@@ -2,6 +2,7 @@ package com.zugaldia.speedofsound.app.screens.preferences
 
 import com.zugaldia.speedofsound.app.DEFAULT_PREFERENCES_DIALOG_HEIGHT
 import com.zugaldia.speedofsound.app.DEFAULT_PREFERENCES_DIALOG_WIDTH
+import com.zugaldia.speedofsound.app.screens.preferences.advanced.AdvancedPage
 import com.zugaldia.speedofsound.app.screens.preferences.credentials.CloudCredentialsPage
 import com.zugaldia.speedofsound.app.screens.preferences.general.GeneralPage
 import com.zugaldia.speedofsound.app.screens.preferences.importexport.ImportExportPage
@@ -34,6 +35,7 @@ class PreferencesDialog(private val settingsClient: SettingsClient) : Dialog() {
     private val modelLibraryPage: ModelLibraryPage
     private val personalizationPage: PersonalizationPage
     private val importExportPage: ImportExportPage
+    private val advancedPage: AdvancedPage
 
     init {
         title = "Preferences"
@@ -51,6 +53,7 @@ class PreferencesDialog(private val settingsClient: SettingsClient) : Dialog() {
         modelLibraryPage = ModelLibraryPage(viewModel) { hasOperations -> operationsBanner.revealed = hasOperations }
         personalizationPage = PersonalizationPage(viewModel)
         importExportPage = ImportExportPage(viewModel) { refreshAllPages() }
+        advancedPage = AdvancedPage(viewModel)
 
         stack = Stack().apply {
             hexpand = true
@@ -61,6 +64,7 @@ class PreferencesDialog(private val settingsClient: SettingsClient) : Dialog() {
             addTitled(voiceModelsPage, "voice_models", "Voice Models")
             addTitled(textModelsPage, "text_models", "Text Models")
             addTitled(personalizationPage, "personalization", "Personalization")
+            addTitled(advancedPage, "advanced", "Advanced")
             addTitled(importExportPage, "import_export", "Import / Export")
 
             // This is to make sure the voice models page includes any models the user just downloaded

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
@@ -79,4 +79,14 @@ class PreferencesViewModel(private val settingsClient: SettingsClient) {
 
     fun getCustomVocabulary(): List<String> = settingsClient.getCustomVocabulary()
     fun setCustomVocabulary(value: List<String>): Boolean = settingsClient.setCustomVocabulary(value)
+
+    /*
+     * Advanced page
+     */
+
+    fun getPostHideDelayMs(): Int = settingsClient.getPostHideDelayMs()
+    fun setPostHideDelayMs(value: Int): Boolean = settingsClient.setPostHideDelayMs(value)
+
+    fun getTypingDelayMs(): Int = settingsClient.getTypingDelayMs()
+    fun setTypingDelayMs(value: Int): Boolean = settingsClient.setTypingDelayMs(value)
 }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/advanced/AdvancedPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/advanced/AdvancedPage.kt
@@ -1,0 +1,57 @@
+package com.zugaldia.speedofsound.app.screens.preferences.advanced
+
+import com.zugaldia.speedofsound.app.screens.preferences.PreferencesViewModel
+import org.gnome.adw.PreferencesGroup
+import org.gnome.adw.PreferencesPage
+import org.gnome.adw.SpinRow
+
+class AdvancedPage(private val viewModel: PreferencesViewModel) : PreferencesPage() {
+    private val postHideDelayRow: SpinRow
+    private val typingDelayRow: SpinRow
+
+    init {
+        title = "Advanced"
+        iconName = "preferences-other-symbolic"
+
+        postHideDelayRow = SpinRow.withRange(POST_HIDE_DELAY_MIN, POST_HIDE_DELAY_MAX, STEP).apply {
+            title = "Post-Hide Delay (ms)"
+            subtitle = "Time to wait after hiding the window before typing. Set to 0 to disable. " +
+                    "Increase this if the beginning of the typed text is missing."
+            digits = 0
+            value = viewModel.getPostHideDelayMs().toDouble()
+            onNotify("value") {
+                viewModel.setPostHideDelayMs(value.toInt())
+            }
+        }
+
+        typingDelayRow = SpinRow.withRange(TYPING_DELAY_MIN, TYPING_DELAY_MAX, STEP).apply {
+            title = "Typing Delay (ms)"
+            subtitle = "Delay between each virtual keystroke. Set to 0 to disable. " +
+                    "Increase this if characters are dropped or out of order " +
+                    "(or you like a slower typing effect)."
+            digits = 0
+            value = viewModel.getTypingDelayMs().toDouble()
+            onNotify("value") {
+                viewModel.setTypingDelayMs(value.toInt())
+            }
+        }
+
+        val group = PreferencesGroup().apply {
+            title = "Typing"
+            description = "Settings on this page control low-level typing behavior. " +
+                    "The defaults are safe for most desktop environments and generally do not need to be changed."
+            add(postHideDelayRow)
+            add(typingDelayRow)
+        }
+
+        add(group)
+    }
+
+    companion object {
+        private const val STEP = 1.0
+        private const val POST_HIDE_DELAY_MIN = 0.0
+        private const val POST_HIDE_DELAY_MAX = 1000.0
+        private const val TYPING_DELAY_MIN = 0.0
+        private const val TYPING_DELAY_MAX = 100.0
+    }
+}

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/advanced/AdvancedPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/advanced/AdvancedPage.kt
@@ -26,9 +26,9 @@ class AdvancedPage(private val viewModel: PreferencesViewModel) : PreferencesPag
 
         typingDelayRow = SpinRow.withRange(TYPING_DELAY_MIN, TYPING_DELAY_MAX, STEP).apply {
             title = "Typing Delay (ms)"
-            subtitle = "Delay between each virtual keystroke. Set to 0 to disable. " +
-                    "Increase this if characters are dropped or out of order " +
-                    "(or you like a slower typing effect)."
+            subtitle = "Delay between each keystroke. Set to 0 to disable. " +
+                    "Increase this if characters are dropped, out of order, " +
+                    "or like a slower typing effect."
             digits = 0
             value = viewModel.getTypingDelayMs().toDouble()
             onNotify("value") {
@@ -38,7 +38,7 @@ class AdvancedPage(private val viewModel: PreferencesViewModel) : PreferencesPag
 
         val group = PreferencesGroup().apply {
             title = "Typing"
-            description = "Settings on this page control low-level typing behavior. " +
+            description = "Settings on this section control low-level typing behavior. " +
                     "The defaults are safe for most desktop environments and generally do not need to be changed."
             add(postHideDelayRow)
             add(typingDelayRow)

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/settings/GioStore.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/settings/GioStore.kt
@@ -90,4 +90,20 @@ class GioStore(val schemaId: String = APPLICATION_ID): SettingsStore {
         logger.error("Error setting boolean value ($key -> $value): ${e.message}")
         false
     }
+
+    override fun getInt(key: String, defaultValue: Int): Int = try {
+        ensureKeyExists(key)
+        settings?.getInt(key) ?: defaultValue
+    } catch (e: IllegalArgumentException) {
+        logger.error("Error getting int setting ($key), using default ($defaultValue): ${e.message}")
+        defaultValue
+    }
+
+    override fun setInt(key: String, value: Int): Boolean = try {
+        ensureKeyExists(key)
+        settings?.setInt(key, value) ?: false
+    } catch (e: IllegalArgumentException) {
+        logger.error("Error setting int value ($key -> $value): ${e.message}")
+        false
+    }
 }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
@@ -17,6 +17,12 @@ class PortalsClient {
     val sessionClosedEvents: Flow<SessionClosedEvent>
         get() = portal.remoteDesktop.observeSessionClosed()
 
+    /**
+     * Starts a remote desktop session with keyboard input support.
+     *
+     * @param restoreToken Optional token from a previous session. When provided, the portal will
+     * attempt to restore the session without prompting the user for authorization again.
+     */
     suspend fun startRemoteDesktopSession(restoreToken: String?): Result<StartResponse> =
         portal.remoteDesktop.startSession(
             types = setOf(DeviceType.KEYBOARD),
@@ -24,6 +30,13 @@ class PortalsClient {
             persistMode = PersistMode.UNTIL_REVOKED
         )
 
+    /**
+     * Simulates keyboard input by sending each character as a key press/release pair.
+     *
+     * @param text List of X11 keysym values to type, one per character.
+     * @param delayMs Delay in milliseconds between consecutive keystrokes. Set to 0 to disable.
+     * Increase this if characters are dropped or appear out of order (or like a slower typing effect).
+     */
     suspend fun typeText(text: List<Int>, delayMs: Long) {
         logger.info("Typing ${text.size} characters.")
         for (key in text) {

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
@@ -24,12 +24,12 @@ class PortalsClient {
             persistMode = PersistMode.UNTIL_REVOKED
         )
 
-    suspend fun typeText(text: List<Int>, delayMs: Long = 10L) {
+    suspend fun typeText(text: List<Int>, delayMs: Long) {
         logger.info("Typing ${text.size} characters.")
         for (key in text) {
             portal.remoteDesktop.notifyKeyboardKeySym(key, InputState.PRESSED)
             portal.remoteDesktop.notifyKeyboardKeySym(key, InputState.RELEASED)
-            delay(delayMs)
+            if (delayMs > 0) delay(delayMs)
         }
     }
 }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/PropertiesStore.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/PropertiesStore.kt
@@ -71,6 +71,14 @@ class PropertiesStore(filename: String = DEFAULT_PROPERTIES_FILENAME) : Settings
         return save()
     }
 
+    override fun getInt(key: String, defaultValue: Int): Int =
+        properties.getProperty(key)?.toIntOrNull() ?: defaultValue
+
+    override fun setInt(key: String, value: Int): Boolean {
+        properties.setProperty(key, value.toString())
+        return save()
+    }
+
     companion object {
         private const val ARRAY_DELIMITER = "|||"
     }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
@@ -255,4 +255,24 @@ class SettingsClient(val settingsStore: SettingsStore) {
         settingsStore.setStringArray(KEY_CUSTOM_VOCABULARY, value).also { success ->
             if (success) _settingsChanged.tryEmit(KEY_CUSTOM_VOCABULARY)
         }
+
+    /*
+     * Advanced page
+     */
+
+    fun getPostHideDelayMs(): Int =
+        settingsStore.getInt(KEY_POST_HIDE_DELAY_MS, DEFAULT_POST_HIDE_DELAY_MS)
+
+    fun setPostHideDelayMs(value: Int): Boolean =
+        settingsStore.setInt(KEY_POST_HIDE_DELAY_MS, value).also { success ->
+            if (success) _settingsChanged.tryEmit(KEY_POST_HIDE_DELAY_MS)
+        }
+
+    fun getTypingDelayMs(): Int =
+        settingsStore.getInt(KEY_TYPING_DELAY_MS, DEFAULT_TYPING_DELAY_MS)
+
+    fun setTypingDelayMs(value: Int): Boolean =
+        settingsStore.setInt(KEY_TYPING_DELAY_MS, value).also { success ->
+            if (success) _settingsChanged.tryEmit(KEY_TYPING_DELAY_MS)
+        }
 }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
@@ -46,6 +46,14 @@ const val DEFAULT_TEXT_MODEL_PROVIDERS = "[]"
 const val KEY_SELECTED_TEXT_MODEL_PROVIDER_ID = "selected-text-model-provider-id"
 const val DEFAULT_SELECTED_TEXT_MODEL_PROVIDER_ID = ""
 
+// Advanced page
+
+const val KEY_POST_HIDE_DELAY_MS = "post-hide-delay-ms"
+const val DEFAULT_POST_HIDE_DELAY_MS = 100
+
+const val KEY_TYPING_DELAY_MS = "typing-delay-ms"
+const val DEFAULT_TYPING_DELAY_MS = 10
+
 // Personalization page
 
 const val KEY_CUSTOM_CONTEXT = "custom-context"

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsStore.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsStore.kt
@@ -8,4 +8,6 @@ interface SettingsStore {
     fun setStringArray(key: String, value: List<String>): Boolean
     fun getBoolean(key: String, defaultValue: Boolean): Boolean
     fun setBoolean(key: String, value: Boolean): Boolean
+    fun getInt(key: String, defaultValue: Int): Int
+    fun setInt(key: String, value: Int): Boolean
 }

--- a/data/io.speedofsound.SpeedOfSound.gschema.xml
+++ b/data/io.speedofsound.SpeedOfSound.gschema.xml
@@ -60,6 +60,19 @@
       <description>The ID of the currently selected text model provider for text processing.</description>
     </key>
 
+    <!-- Personalization page -->
+
+    <key name="custom-context" type="s">
+      <default>''</default>
+      <summary>Custom LLM context</summary>
+      <description>Optionally share details like job, location, or writing style to help improve transcriptions.</description>
+    </key>
+    <key name="custom-vocabulary" type="as">
+      <default>[]</default>
+      <summary>Custom vocabulary entries</summary>
+      <description>Optionally add words, names, technical terms, or acronyms the model should recognize.</description>
+    </key>
+
     <!-- Advanced page -->
 
     <key name="post-hide-delay-ms" type="i">
@@ -72,20 +85,7 @@
       <range min="0" max="100"/>
       <default>10</default>
       <summary>Typing delay (ms)</summary>
-      <description>Delay in milliseconds between each virtual keyboard keystroke. Set to 0 to disable. Increase this if characters are dropped or appear out of order.</description>
-    </key>
-
-    <!-- Personalization page -->
-
-    <key name="custom-context" type="s">
-      <default>''</default>
-      <summary>Custom LLM context</summary>
-      <description>Optionally share details like job, location, or writing style to help improve transcriptions.</description>
-    </key>
-    <key name="custom-vocabulary" type="as">
-      <default>[]</default>
-      <summary>Custom vocabulary entries</summary>
-      <description>Optionally add words, names, technical terms, or acronyms the model should recognize.</description>
+      <description>Delay in milliseconds between each virtual keyboard keystroke. Set to 0 to disable. Increase this if characters are dropped or appear out of order or like a slower typing effect.</description>
     </key>
 
   </schema>

--- a/data/io.speedofsound.SpeedOfSound.gschema.xml
+++ b/data/io.speedofsound.SpeedOfSound.gschema.xml
@@ -60,6 +60,21 @@
       <description>The ID of the currently selected text model provider for text processing.</description>
     </key>
 
+    <!-- Advanced page -->
+
+    <key name="post-hide-delay-ms" type="i">
+      <range min="0" max="1000"/>
+      <default>100</default>
+      <summary>Post-hide delay (ms)</summary>
+      <description>Time in milliseconds to wait after hiding the main window before issuing typing commands, to give the desktop environment time to physically hide the window.</description>
+    </key>
+    <key name="typing-delay-ms" type="i">
+      <range min="0" max="100"/>
+      <default>10</default>
+      <summary>Typing delay (ms)</summary>
+      <description>Delay in milliseconds between each virtual keyboard keystroke. Set to 0 to disable. Increase this if characters are dropped or appear out of order.</description>
+    </key>
+
     <!-- Personalization page -->
 
     <key name="custom-context" type="s">

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -69,4 +69,6 @@ and formatting. You can add one or more providers and choose which one is active
 information about your writing style and add custom vocabulary entries such as names, technical terms, or
 acronyms that the model should recognize.
 
+**Advanced** — Fine-tune low-level typing behavior. You can adjust the delay between hiding the main window and issuing keystrokes, as well as the delay between individual keystrokes. The defaults work well for most desktop environments and do not normally need to be changed.
+
 **Import / Export** — Back up your preferences to a file, useful to set up Speed of Sound on a different machine.


### PR DESCRIPTION
## Summary

- Promotes two previously hardcoded timing constants into user-configurable GSettings-backed preferences: post-hide delay (default 100ms) and per-keystroke typing delay (default 10ms)
- Adds `getInt`/`setInt` to the `SettingsStore` interface with implementations in `GioStore` and `PropertiesStore`
- Adds a new **Advanced** preferences page (between Personalization and Import/Export) exposing both settings via `SpinRow` controls

Closes #53

## Test plan

- [ ] Open Preferences → Advanced and verify both spin rows load with correct default values (100ms and 10ms)
- [ ] Change post-hide delay to 0 and confirm typing still works (no delay path)
- [ ] Change typing delay to 0 and confirm typing still works (no per-keystroke delay)
- [ ] Change typing delay to a high value (e.g. 50ms) and confirm the slower typing effect is noticeable
- [ ] Verify settings persist across app restarts
- [ ] Verify dev mode (`SOS_DISABLE_GIO_STORE=true`) works correctly via `PropertiesStore`