### PR TITLE
feat: add General preferences settings (append space, background recording)

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/App.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/App.kt
@@ -60,7 +60,7 @@ class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Appl
 
         onActivate {
             logger.info("Application activated.")
-            if (mainWindow == null) { mainWindow = MainWindow(this, mainViewModel, settingsClient) }
+            ensureMainWindow()
             mainWindow?.present()
         }
 
@@ -86,13 +86,20 @@ class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Appl
         }
     }
 
+    private fun ensureMainWindow() {
+        if (mainWindow == null) {
+            mainWindow = MainWindow(this, mainViewModel, settingsClient)
+        }
+    }
+
     /**
      * Registers the trigger action to handle D-Bus calls from scripts/trigger.sh
      */
     private fun registerTriggerAction() {
         val triggerAction = SimpleAction(TRIGGER_ACTION, null)
         triggerAction.onActivate {
-            activate() // Make sure the MainWindow is ready
+            ensureMainWindow()
+            if (!settingsClient.getBackgroundRecording()) mainWindow?.present()
             mainWindow?.let { mainViewModel.onTriggerAction() }
         }
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/AppConstants.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/AppConstants.kt
@@ -65,6 +65,9 @@ const val MAX_PROVIDER_CONFIG_NAME_LENGTH = 100
 const val DEFAULT_ADD_PROVIDER_DIALOG_WIDTH = 600
 const val DEFAULT_ADD_PROVIDER_DIALOG_HEIGHT = 500
 
+// Transcription output
+const val APPEND_SPACE_TEXT = " "
+
 const val TRIGGER_ACTION = "trigger"
 
 const val SIGNAL_STAGE_CHANGED = "stage-changed"

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -1,5 +1,6 @@
 package com.zugaldia.speedofsound.app.screens.main
 
+import com.zugaldia.speedofsound.app.APPEND_SPACE_TEXT
 import com.zugaldia.speedofsound.app.isGStreamerDisabled
 import com.zugaldia.speedofsound.app.plugins.recorder.GStreamerRecorder
 import com.zugaldia.speedofsound.app.portals.PortalsSessionManager
@@ -276,7 +277,8 @@ class MainViewModel(
             // Wait for the main window to go away before typing
             val postHideDelayMs = settingsClient.getPostHideDelayMs()
             if (postHideDelayMs > 0) delay(postHideDelayMs.toLong())
-            val finalText = event.finalResult.trim() + " " // Separate multiple results with a space
+            val suffix = if (settingsClient.getAppendSpace()) APPEND_SPACE_TEXT else ""
+            val finalText = event.finalResult.trim() + suffix
             TextUtils.textToKeySym(finalText)
                 .onSuccess { keySyms -> portalsClient.typeText(keySyms, settingsClient.getTypingDelayMs().toLong()) }
                 .onFailure { error -> logger.error("Error converting text to key symbols: ${error.message}") }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
@@ -126,11 +126,16 @@ class MainWindow(
     }
 
     private fun goAway() {
-        // We use visible = false (not minimize/iconify) to hide the window. This allows the window
-        // to be restored on the current workspace when the user relaunches the app. If we used
-        // `minimize` instead, GNOME would remember the original workspace and restore the window there,
-        // which doesn't work to type into arbitrary apps in arbitrary workspaces.
-        visible = false
+        if (settingsClient.getBackgroundRecording()) {
+            // In background recording mode we minimize instead of hiding, so that the window
+            // remains accessible from the dock (e.g. to access preferences, or quit the app).
+            minimize()
+        } else {
+            // We use `visible = false` (not `minimize()`) to hide the window. This allows the window
+            // to be restored on the current workspace (where the target app is), rather than on the workspace
+            // the window was originally in (preventing us from typing on the target app).
+            visible = false
+        }
     }
 
     private fun onOpenPreferences() {

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
@@ -31,6 +31,9 @@ class PreferencesViewModel(private val settingsClient: SettingsClient) {
     fun getSecondaryLanguage(): String = settingsClient.getSecondaryLanguage()
     fun setSecondaryLanguage(value: String): Boolean = settingsClient.setSecondaryLanguage(value)
 
+    fun getAppendSpace(): Boolean = settingsClient.getAppendSpace()
+    fun setAppendSpace(value: Boolean): Boolean = settingsClient.setAppendSpace(value)
+
     /*
      * Cloud Credentials page
      */

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
@@ -25,6 +25,9 @@ class PreferencesViewModel(private val settingsClient: SettingsClient) {
      * General page
      */
 
+    fun getBackgroundRecording(): Boolean = settingsClient.getBackgroundRecording()
+    fun setBackgroundRecording(value: Boolean): Boolean = settingsClient.setBackgroundRecording(value)
+
     fun getDefaultLanguage(): String = settingsClient.getDefaultLanguage()
     fun setDefaultLanguage(value: String): Boolean = settingsClient.setDefaultLanguage(value)
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
@@ -6,6 +6,7 @@ import org.gnome.adw.PreferencesPage
 import org.gnome.adw.SwitchRow
 
 class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage() {
+    private val backgroundRecordingRow: SwitchRow
     private val primaryComboRow: LanguageComboRow
     private val secondaryComboRow: LanguageComboRow
     private val appendSpaceRow: SwitchRow
@@ -13,6 +14,17 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
     init {
         title = "General"
         iconName = "preferences-system-symbolic"
+
+        backgroundRecordingRow = SwitchRow().apply {
+            title = "Record in background"
+            subtitle = "Keep the main window hidden while listening."
+            active = viewModel.getBackgroundRecording()
+        }
+
+        val behaviorGroup = PreferencesGroup().apply {
+            title = "App Behavior"
+            add(backgroundRecordingRow)
+        }
 
         primaryComboRow = LanguageComboRow(
             rowTitle = "Primary Language",
@@ -47,16 +59,19 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
             add(appendSpaceRow)
         }
 
+        add(behaviorGroup)
         add(languageGroup)
         add(outputGroup)
 
         // Set up notifications after all widgets are initialized
+        backgroundRecordingRow.onNotify("active") { viewModel.setBackgroundRecording(backgroundRecordingRow.active) }
         primaryComboRow.setupNotifications()
         secondaryComboRow.setupNotifications()
         appendSpaceRow.onNotify("active") { viewModel.setAppendSpace(appendSpaceRow.active) }
     }
 
     fun refresh() {
+        backgroundRecordingRow.active = viewModel.getBackgroundRecording()
         primaryComboRow.refresh()
         secondaryComboRow.refresh()
         appendSpaceRow.active = viewModel.getAppendSpace()

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
@@ -3,10 +3,12 @@ package com.zugaldia.speedofsound.app.screens.preferences.general
 import com.zugaldia.speedofsound.app.screens.preferences.PreferencesViewModel
 import org.gnome.adw.PreferencesGroup
 import org.gnome.adw.PreferencesPage
+import org.gnome.adw.SwitchRow
 
 class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage() {
     private val primaryComboRow: LanguageComboRow
     private val secondaryComboRow: LanguageComboRow
+    private val appendSpaceRow: SwitchRow
 
     init {
         title = "General"
@@ -26,7 +28,7 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
             setLanguage = { viewModel.setSecondaryLanguage(it) }
         )
 
-        val group = PreferencesGroup().apply {
+        val languageGroup = PreferencesGroup().apply {
             title = "Language"
             description = "The primary language is used by default. Optionally, set a secondary language " +
                 "to switch between the two using left Shift (primary) and right Shift (secondary)."
@@ -34,15 +36,29 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
             add(secondaryComboRow)
         }
 
-        add(group)
+        appendSpaceRow = SwitchRow().apply {
+            title = "Append space after transcription"
+            subtitle = "Useful when dictating consecutive sentences independently."
+            active = viewModel.getAppendSpace()
+        }
+
+        val outputGroup = PreferencesGroup().apply {
+            title = "Output"
+            add(appendSpaceRow)
+        }
+
+        add(languageGroup)
+        add(outputGroup)
 
         // Set up notifications after all widgets are initialized
         primaryComboRow.setupNotifications()
         secondaryComboRow.setupNotifications()
+        appendSpaceRow.onNotify("active") { viewModel.setAppendSpace(appendSpaceRow.active) }
     }
 
     fun refresh() {
         primaryComboRow.refresh()
         secondaryComboRow.refresh()
+        appendSpaceRow.active = viewModel.getAppendSpace()
     }
 }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
@@ -117,6 +117,14 @@ class SettingsClient(val settingsStore: SettingsStore) {
             if (success) _settingsChanged.tryEmit(KEY_SECONDARY_LANGUAGE)
         }
 
+    fun getBackgroundRecording(): Boolean =
+        settingsStore.getBoolean(KEY_BACKGROUND_RECORDING, DEFAULT_BACKGROUND_RECORDING)
+
+    fun setBackgroundRecording(value: Boolean): Boolean =
+        settingsStore.setBoolean(KEY_BACKGROUND_RECORDING, value).also { success ->
+            if (success) _settingsChanged.tryEmit(KEY_BACKGROUND_RECORDING)
+        }
+
     fun getAppendSpace(): Boolean =
         settingsStore.getBoolean(KEY_APPEND_SPACE, DEFAULT_APPEND_SPACE)
 

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
@@ -117,6 +117,14 @@ class SettingsClient(val settingsStore: SettingsStore) {
             if (success) _settingsChanged.tryEmit(KEY_SECONDARY_LANGUAGE)
         }
 
+    fun getAppendSpace(): Boolean =
+        settingsStore.getBoolean(KEY_APPEND_SPACE, DEFAULT_APPEND_SPACE)
+
+    fun setAppendSpace(value: Boolean): Boolean =
+        settingsStore.setBoolean(KEY_APPEND_SPACE, value).also { success ->
+            if (success) _settingsChanged.tryEmit(KEY_APPEND_SPACE)
+        }
+
     /*
      * Cloud Credentials page
      */

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
@@ -18,6 +18,9 @@ val DEFAULT_LANGUAGE = Language.ENGLISH
 const val KEY_SECONDARY_LANGUAGE = "secondary-language"
 val DEFAULT_SECONDARY_LANGUAGE = Language.SPANISH
 
+const val KEY_BACKGROUND_RECORDING = "background-recording"
+const val DEFAULT_BACKGROUND_RECORDING = false
+
 const val KEY_APPEND_SPACE = "append-space"
 const val DEFAULT_APPEND_SPACE = false
 

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
@@ -18,6 +18,9 @@ val DEFAULT_LANGUAGE = Language.ENGLISH
 const val KEY_SECONDARY_LANGUAGE = "secondary-language"
 val DEFAULT_SECONDARY_LANGUAGE = Language.SPANISH
 
+const val KEY_APPEND_SPACE = "append-space"
+const val DEFAULT_APPEND_SPACE = false
+
 // Cloud Credentials page
 
 const val KEY_CREDENTIALS = "credentials"

--- a/data/io.speedofsound.SpeedOfSound.gschema.xml
+++ b/data/io.speedofsound.SpeedOfSound.gschema.xml
@@ -10,6 +10,11 @@
 
     <!-- General page -->
 
+    <key name="background-recording" type="b">
+      <default>false</default>
+      <summary>Record in background</summary>
+      <description>When enabled, the main window stays hidden during recordings. The pipeline runs entirely in the background, and the window remains accessible from the dock.</description>
+    </key>
     <key name="default-language" type="s">
       <default>'en'</default>
       <summary>Default language</summary>

--- a/data/io.speedofsound.SpeedOfSound.gschema.xml
+++ b/data/io.speedofsound.SpeedOfSound.gschema.xml
@@ -20,6 +20,11 @@
       <summary>Secondary language</summary>
       <description>ISO 639-1 code for the secondary language. Use left Shift for primary and right Shift for secondary language.</description>
     </key>
+    <key name="append-space" type="b">
+      <default>false</default>
+      <summary>Append space after transcription</summary>
+      <description>When enabled, a space character is appended after each transcription output.</description>
+    </key>
 
     <!-- Cloud Credentials page -->
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,9 +42,12 @@ configuration to personalization and backup.
 ![Preferences](assets/screenshots/preferences-light.png#only-light)
 ![Preferences](assets/screenshots/preferences-dark.png#only-dark)
 
-**General** — Set the primary language used for speech recognition. You can optionally configure a secondary language
-and switch between the two using the Left Shift and Right Shift keys while the main window is focused.
-The **Output** section lets you configure how transcription results are delivered. Here you can enable
+**General** — The **App Behavior** section lets you configure how shortcut-triggered sessions behave. Enable
+**Record in background** to keep the main window hidden during recordings. In this case, the pipeline runs
+entirely in the background. You can still access the window at any time from the dock.
+Set the primary language used for speech recognition in the **Language** section. You can optionally configure
+a secondary language and switch between the two using the `Left Shift` and `Right Shift` keys while the main window
+is focused. The **Output** section lets you configure how transcription results are delivered. Here you can enable
 **Append space after transcription** to automatically insert a trailing space after each result, which is useful
 when dictating consecutive sentences independently.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -44,6 +44,9 @@ configuration to personalization and backup.
 
 **General** — Set the primary language used for speech recognition. You can optionally configure a secondary language
 and switch between the two using the Left Shift and Right Shift keys while the main window is focused.
+The **Output** section lets you configure how transcription results are delivered. Here you can enable
+**Append space after transcription** to automatically insert a trailing space after each result, which is useful
+when dictating consecutive sentences independently.
 
 **Model Library** — Browse and manage the locally available voice models. You can download new models or remove
 ones you no longer need. Keep this window open while a download is in progress.


### PR DESCRIPTION
## Summary

- `feat: add append-space setting to core settings and GSettings schema` — Introduces the `append-space` boolean key to `SettingsConstants`, `SettingsClient`, and the GSettings schema, with a default of `false`.
- `feat: expose append-space toggle in General preferences UI` — Adds an **Output** group to the General preferences page with a `SwitchRow` for controlling the append-space behavior.
- `feat: add background recording mode to General preferences` — Adds a **Record in background** toggle under a new **App Behavior** group. When enabled, shortcut-triggered recordings run without presenting the main window; the window minimizes after each session so it remains accessible from the dock. Includes GSettings schema key, settings layer, preferences UI, and user guide update.

## Test plan

- [ ] Toggle **Append space after transcription** on/off and verify a trailing space is/isn't appended after each result
- [ ] Toggle **Record in background** on and trigger a recording via shortcut — verify the main window does not appear and typing lands on the target app
- [ ] With **Record in background** on, verify the window is accessible from the dock after recording completes
- [ ] With **Record in background** off, verify the existing hide-on-completion behavior is unchanged
- [ ] Open and close Preferences — verify both toggles reflect saved state correctly