### PR TITLE
feat: prefer digits and symbols over spelled-out words in LLM prompt

### DIFF
--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/director/DirectorOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/director/DirectorOptions.kt
@@ -28,6 +28,7 @@ Your goal is to review the following INPUT transcription to improve its quality 
 - Add proper capitalization.
 - Add any necessary punctuation such as periods and commas.
 - Keep punctuation simple: avoid dashes and semicolons.
+- Use digits and symbols instead of spelling them out (e.g., 2 instead of two, % instead of percent).
 
 ## Context
 $PROMPT_KEY_CONTEXT
@@ -50,6 +51,9 @@ OUTPUT: We'll update to the LTS version of the Linux distribution right away.
 
 INPUT: Open the mail app send an email to John at example dot com and close it
 OUTPUT: Open the mail app, send an email to john@example.com, and close it.
+
+INPUT: there are twenty four items and the discount is fifteen percent
+OUTPUT: There are 24 items and the discount is 15%.
 
 # Transcription
 LANGUAGE: $PROMPT_KEY_LANGUAGE


### PR DESCRIPTION
## Summary

- Adds a new instruction to the polishing prompt to use digits and symbols instead of spelling them out (e.g., 2 instead of two, % instead of percent)
- Adds a matching example demonstrating the rule with numbers and percent

## Test plan

- [ ] Record a dictation with spelled-out numbers (e.g., "twenty four items") and confirm the LLM outputs digits (24)
- [ ] Record a dictation with spelled-out symbols (e.g., "fifteen percent") and confirm the LLM outputs the symbol (15%)