### PR TITLE
build: temporarily disable Snap publish workflow

### DIFF
--- a/.github/workflows/release-dispatcher.yml
+++ b/.github/workflows/release-dispatcher.yml
@@ -57,11 +57,11 @@ jobs:
       version: ${{ needs.check-release.outputs.version }}
       channel: ${{ needs.check-release.outputs.channel }}
 
-  release-snap:
-    needs: check-release
-    if: needs.check-release.outputs.new_release == 'true' && needs.check-release.outputs.channel != 'alpha'
-    secrets: inherit
-    uses: ./.github/workflows/snap-publish.yml
-    with:
-      version: ${{ needs.check-release.outputs.version }}
-      channel: ${{ needs.check-release.outputs.channel }}
+#  release-snap:
+#    needs: check-release
+#    if: needs.check-release.outputs.new_release == 'true' && needs.check-release.outputs.channel != 'alpha'
+#    secrets: inherit
+#    uses: ./.github/workflows/snap-publish.yml
+#    with:
+#      version: ${{ needs.check-release.outputs.version }}
+#      channel: ${{ needs.check-release.outputs.channel }}


### PR DESCRIPTION
## Summary

- Comments out the `release-snap` job in the release dispatcher workflow
- The `snap-publish.yml` workflow remains in place but will not be triggered automatically during releases

## Context

We are temporarily disabling the Snap publishing step while we go through the Snapcraft store approval process. Once the app is approved, this can be re-enabled by uncommenting the `release-snap` job in `release-dispatcher.yml`.