### PR TITLE
feat: add DEB and RPM packages via jpackage

### DIFF
--- a/.github/workflows/jpackage-build.yml
+++ b/.github/workflows/jpackage-build.yml
@@ -1,0 +1,47 @@
+name: JPackage Build
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'assets/**'
+      - 'scripts/**'
+      - '**.md'
+      - 'mkdocs.yml'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'assets/**'
+      - 'scripts/**'
+      - '**.md'
+      - 'mkdocs.yml'
+
+jobs:
+  jpackage:
+    name: "JPackage"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install jpackage dependencies
+        run: sudo apt-get install -y fakeroot rpm
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+      - name: Build DEB and RPM packages
+        env:
+          GRADLE_OPTS: --enable-native-access=ALL-UNNAMED
+        run: |
+          ./gradlew :app:jpackage-deb :app:jpackage-rpm --no-configuration-cache \
+            -Pspeedofsound.disableGioStore=true
+      - name: Upload packages as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: jpackage-packages
+          path: app/build/jpackage/
+          retention-days: 7

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -56,6 +56,15 @@ jobs:
           ./gradlew shadowJar \
             -PreleaseVersion=${{ inputs.version }} \
             -Pspeedofsound.disableGioStore=true
+      - name: Install jpackage dependencies
+        run: sudo apt-get install -y fakeroot rpm
+      - name: Build DEB and RPM packages
+        env:
+          GRADLE_OPTS: --enable-native-access=ALL-UNNAMED
+        run: |
+          ./gradlew :app:jpackage-deb :app:jpackage-rpm --no-configuration-cache \
+            -PreleaseVersion=${{ inputs.version }} \
+            -Pspeedofsound.disableGioStore=true
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -66,6 +75,8 @@ jobs:
           fi
           gh release create "v${{ inputs.version }}" \
             app/build/libs/speedofsound.jar \
+            app/build/jpackage/*.deb \
+            app/build/jpackage/*.rpm \
             scripts/trigger.sh \
             --title "Release v${{ inputs.version }}" \
             --generate-notes \

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ export GRADLE_OPTS = --enable-native-access=ALL-UNNAMED
 	meson-clean meson-setup meson-build meson-install uninstall install \
 	flatpak-sources flatpak-linter flatpak-build flatpak-bundle flatpak-run desktop-validate \
 	snapcraft-clean snapcraft-pack snapcraft-lint snap-install snap-remove \
+	jpackage-deb jpackage-rpm \
 	docs-serve docs-build
 
 clean:
@@ -99,6 +100,19 @@ snap-install:
 
 snap-remove:
 	snap remove speedofsound
+
+#
+# jpackage
+#
+
+jpackage-deb:
+	rm -rf app/build/jpackage
+	./gradlew :app:jpackage-deb --no-configuration-cache
+
+jpackage-rpm:
+	rm -rf app/build/jpackage
+	./gradlew :app:jpackage-rpm --no-configuration-cache
+
 
 #
 # Docs

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,3 +53,46 @@ tasks.flatpakGradleGenerator {
     downloadDirectory = "offline-repository"
     excludeConfigurations = listOf("testCompileClasspath", "testRuntimeClasspath")
 }
+
+//
+// We use the built-in `jpackage` for DEB and RPM generation (straightforward but bundles the JRE).
+// Potential alternative (from Netflix?): https://github.com/nebula-plugins/gradle-ospackage-plugin
+//
+
+val jpackageInputDir = layout.buildDirectory.dir("libs")
+val jpackageOutputDir = layout.buildDirectory.dir("jpackage")
+val jpackageCommonArgs = listOf(
+    "--input", jpackageInputDir.get().asFile.absolutePath,
+    "--dest", jpackageOutputDir.get().asFile.absolutePath,
+    "--main-class", "com.zugaldia.speedofsound.app.AppKt",
+    "--main-jar", "speedofsound.jar",
+    "--java-options", "--enable-native-access=ALL-UNNAMED",
+    "--name", "speedofsound",
+    "--description", "Voice typing for the Linux desktop",
+    "--app-version", appVersion.substringBefore("-"),
+    "--vendor", "Speed of Sound",
+    "--about-url", "https://www.speedofsound.io",
+    "--copyright", "Copyright 2026 Antonio Zugaldia",
+    "--license-file", rootProject.file("LICENSE").absolutePath,
+    "--icon", rootProject.file("assets/logo/logo-square-512.png").absolutePath,
+    "--linux-app-category", "Utility",
+    "--linux-menu-group", "Utility",
+    "--linux-shortcut",
+)
+
+listOf("deb", "rpm").forEach { packageType ->
+    tasks.register<Exec>("jpackage-$packageType") {
+        group = "distribution"
+        description = "Package the app as a $packageType using jpackage"
+        dependsOn(tasks.shadowJar)
+        doFirst { jpackageOutputDir.get().asFile.mkdirs() }
+        commandLine(buildList {
+            add("jpackage")
+            addAll(jpackageCommonArgs)
+            if (packageType == "deb") {
+                add("--linux-deb-maintainer"); add("antonio@zugaldia.com")
+            }
+            add("--type"); add(packageType)
+        })
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `jpackage-deb` and `jpackage-rpm` Gradle tasks that build native Linux packages from the shadow JAR using the JDK-bundled `jpackage` tool
- Each package bundles the JRE, desktop shortcut, icon, license, and full app metadata (vendor, description, homepage, copyright)
- Adds `make jpackage-deb` and `make jpackage-rpm` Makefile targets for local builds
- Adds a `jpackage-build.yml` CI workflow that validates DEB and RPM packaging on every PR and push to `main`, uploading packages as 7-day build artifacts
- Extends `release-github.yml` to build and attach the `.deb` and `.rpm` files to GitHub Releases going forward

Note: documentation will be updated in a follow-up once packages have been validated on target distributions.

## Test plan

- [ ] CI passes for `jpackage-build.yml` (both DEB and RPM build successfully)
- [ ] Download and inspect the build artifacts from this PR's CI run
- [ ] Verify `.deb` installs on a Debian/Ubuntu system
- [ ] Verify `.rpm` installs on a Fedora/RHEL system