### PR TITLE
Update website URL to speedofsound.io

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
@@ -10,9 +10,6 @@ import com.zugaldia.speedofsound.core.getRuntimeEnvironment
 import com.zugaldia.speedofsound.core.getTmpDataDir
 import org.gnome.adw.AboutDialog
 import org.gnome.gtk.License
-import org.slf4j.LoggerFactory
-
-private val logger = LoggerFactory.getLogger("AppAboutDialog")
 
 fun buildAboutDialog(): AboutDialog {
     val runtimeEnvironment = getRuntimeEnvironment()
@@ -38,9 +35,6 @@ fun buildAboutDialog(): AboutDialog {
             "The dbus-java team https://github.com/hypfvieh/dbus-java",
         )
     )
-
-    dialog.onMap { logger.info("AboutDialog opened") }
-    dialog.onUnmap { logger.info("AboutDialog closed") }
 
     return dialog
 }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
@@ -10,6 +10,9 @@ import com.zugaldia.speedofsound.core.getRuntimeEnvironment
 import com.zugaldia.speedofsound.core.getTmpDataDir
 import org.gnome.adw.AboutDialog
 import org.gnome.gtk.License
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger("AppAboutDialog")
 
 fun buildAboutDialog(): AboutDialog {
     val runtimeEnvironment = getRuntimeEnvironment()
@@ -19,7 +22,7 @@ fun buildAboutDialog(): AboutDialog {
     dialog.applicationName = APPLICATION_NAME
     dialog.developerName = "Antonio Zugaldia"
     dialog.version = "v${BuildConfig.VERSION} (${runtimeEnvironment.label})"
-    dialog.website = "https://github.com/zugaldia/speedofsound"
+    dialog.website = "https://www.speedofsound.io"
     dialog.issueUrl = "https://github.com/zugaldia/speedofsound/issues"
     dialog.supportUrl = "https://github.com/zugaldia/speedofsound/issues"
     dialog.licenseType = License.MIT_X11
@@ -35,6 +38,9 @@ fun buildAboutDialog(): AboutDialog {
             "The dbus-java team https://github.com/hypfvieh/dbus-java",
         )
     )
+
+    dialog.onMap { logger.info("AboutDialog opened") }
+    dialog.onUnmap { logger.info("AboutDialog closed") }
 
     return dialog
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ title: Speed of Sound
 contact: https://github.com/zugaldia/speedofsound
 donation: https://github.com/zugaldia/speedofsound
 source-code: https://github.com/zugaldia/speedofsound
-website: https://github.com/zugaldia/speedofsound
+website: https://www.speedofsound.io
 issues: https://github.com/zugaldia/speedofsound/issues
 license: MIT
 


### PR DESCRIPTION
## Summary
- Update `dialog.website` in the about dialog to point to `https://www.speedofsound.io`
- Update `website` field in `snap/snapcraft.yaml` to `https://www.speedofsound.io`

## Test plan
- [ ] Open the About dialog and verify the website link points to speedofsound.io
- [ ] Verify snap metadata reflects the new URL