### PR TITLE
Add AppImage build support

### DIFF
--- a/.github/workflows/jpackage-build.yml
+++ b/.github/workflows/jpackage-build.yml
@@ -6,14 +6,12 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'assets/**'
-      - 'scripts/**'
       - '**.md'
       - 'mkdocs.yml'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'assets/**'
-      - 'scripts/**'
       - '**.md'
       - 'mkdocs.yml'
 
@@ -23,8 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install jpackage dependencies
+      - name: Install dependencies
         run: sudo apt-get install -y fakeroot rpm
+      - name: Install appimagetool
+        run: |
+          curl -fsSL -o /usr/local/bin/appimagetool \
+            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$(uname -m).AppImage"
+          chmod +x /usr/local/bin/appimagetool
       - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
@@ -39,9 +42,19 @@ jobs:
         run: |
           ./gradlew :app:jpackage-deb :app:jpackage-rpm --no-configuration-cache \
             -Pspeedofsound.disableGioStore=true
+      - name: Build AppImage
+        env:
+          GRADLE_OPTS: --enable-native-access=ALL-UNNAMED
+        run: |
+          ./gradlew :app:jpackage-app-image --no-configuration-cache \
+            -Pspeedofsound.disableGioStore=true
+          ./scripts/build-appimage.sh
       - name: Upload packages as artifacts
         uses: actions/upload-artifact@v4
         with:
           name: jpackage-packages
-          path: app/build/jpackage/
+          path: |
+            app/build/jpackage/*.deb
+            app/build/jpackage/*.rpm
+            app/build/jpackage/*.AppImage
           retention-days: 7

--- a/.github/workflows/release-dispatcher.yml
+++ b/.github/workflows/release-dispatcher.yml
@@ -57,6 +57,15 @@ jobs:
       version: ${{ needs.check-release.outputs.version }}
       channel: ${{ needs.check-release.outputs.channel }}
 
+  release-jpackage:
+    needs: [check-release, release-github]
+    if: needs.check-release.outputs.new_release == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-jpackage.yml
+    with:
+      version: ${{ needs.check-release.outputs.version }}
+
 #  release-snap:
 #    needs: check-release
 #    if: needs.check-release.outputs.new_release == 'true' && needs.check-release.outputs.channel != 'alpha'

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -56,15 +56,6 @@ jobs:
           ./gradlew shadowJar \
             -PreleaseVersion=${{ inputs.version }} \
             -Pspeedofsound.disableGioStore=true
-      - name: Install jpackage dependencies
-        run: sudo apt-get install -y fakeroot rpm
-      - name: Build DEB and RPM packages
-        env:
-          GRADLE_OPTS: --enable-native-access=ALL-UNNAMED
-        run: |
-          ./gradlew :app:jpackage-deb :app:jpackage-rpm --no-configuration-cache \
-            -PreleaseVersion=${{ inputs.version }} \
-            -Pspeedofsound.disableGioStore=true
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -75,8 +66,6 @@ jobs:
           fi
           gh release create "v${{ inputs.version }}" \
             app/build/libs/speedofsound.jar \
-            app/build/jpackage/*.deb \
-            app/build/jpackage/*.rpm \
             scripts/trigger.sh \
             --title "Release v${{ inputs.version }}" \
             --generate-notes \

--- a/.github/workflows/release-jpackage.yml
+++ b/.github/workflows/release-jpackage.yml
@@ -31,8 +31,13 @@ jobs:
           cache: 'gradle'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
-      - name: Install jpackage dependencies
+      - name: Install dependencies
         run: sudo apt-get install -y fakeroot rpm
+      - name: Install appimagetool
+        run: |
+          curl -fsSL -o /usr/local/bin/appimagetool \
+            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$(uname -m).AppImage"
+          chmod +x /usr/local/bin/appimagetool
       - name: Build DEB and RPM packages
         env:
           GRADLE_OPTS: --enable-native-access=ALL-UNNAMED
@@ -40,10 +45,19 @@ jobs:
           ./gradlew :app:jpackage-deb :app:jpackage-rpm --no-configuration-cache \
             -PreleaseVersion=${{ inputs.version }} \
             -Pspeedofsound.disableGioStore=true
+      - name: Build AppImage
+        env:
+          GRADLE_OPTS: --enable-native-access=ALL-UNNAMED
+        run: |
+          ./gradlew :app:jpackage-app-image --no-configuration-cache \
+            -PreleaseVersion=${{ inputs.version }} \
+            -Pspeedofsound.disableGioStore=true
+          ./scripts/build-appimage.sh
       - name: Upload packages to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "v${{ inputs.version }}" \
             app/build/jpackage/*.deb \
-            app/build/jpackage/*.rpm
+            app/build/jpackage/*.rpm \
+            app/build/jpackage/*.AppImage

--- a/.github/workflows/release-jpackage.yml
+++ b/.github/workflows/release-jpackage.yml
@@ -1,0 +1,49 @@
+name: Release jpackage
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 0.8.0 or 0.8.0-alpha.1)'
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }}
+          lfs: true
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+      - name: Install jpackage dependencies
+        run: sudo apt-get install -y fakeroot rpm
+      - name: Build DEB and RPM packages
+        env:
+          GRADLE_OPTS: --enable-native-access=ALL-UNNAMED
+        run: |
+          ./gradlew :app:jpackage-deb :app:jpackage-rpm --no-configuration-cache \
+            -PreleaseVersion=${{ inputs.version }} \
+            -Pspeedofsound.disableGioStore=true
+      - name: Upload packages to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "v${{ inputs.version }}" \
+            app/build/jpackage/*.deb \
+            app/build/jpackage/*.rpm

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export GRADLE_OPTS = --enable-native-access=ALL-UNNAMED
 	meson-clean meson-setup meson-build meson-install uninstall install \
 	flatpak-sources flatpak-linter flatpak-build flatpak-bundle flatpak-run desktop-validate \
 	snapcraft-clean snapcraft-pack snapcraft-lint snap-install snap-remove \
-	jpackage-deb jpackage-rpm jpackage-app-image \
+	jpackage-deb jpackage-rpm jpackage-app-image appimage \
 	docs-serve docs-build
 
 clean:
@@ -116,6 +116,9 @@ jpackage-rpm:
 jpackage-app-image:
 	rm -rf app/build/jpackage
 	./gradlew :app:jpackage-app-image --no-configuration-cache
+
+appimage: jpackage-app-image
+	./scripts/build-appimage.sh
 
 
 #

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export GRADLE_OPTS = --enable-native-access=ALL-UNNAMED
 	meson-clean meson-setup meson-build meson-install uninstall install \
 	flatpak-sources flatpak-linter flatpak-build flatpak-bundle flatpak-run desktop-validate \
 	snapcraft-clean snapcraft-pack snapcraft-lint snap-install snap-remove \
-	jpackage-deb jpackage-rpm \
+	jpackage-deb jpackage-rpm jpackage-app-image \
 	docs-serve docs-build
 
 clean:
@@ -112,6 +112,10 @@ jpackage-deb:
 jpackage-rpm:
 	rm -rf app/build/jpackage
 	./gradlew :app:jpackage-rpm --no-configuration-cache
+
+jpackage-app-image:
+	rm -rf app/build/jpackage
+	./gradlew :app:jpackage-app-image --no-configuration-cache
 
 
 #

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,7 @@ tasks.flatpakGradleGenerator {
 }
 
 //
-// We use the built-in `jpackage` for DEB and RPM generation (straightforward but bundles the JRE).
+// We use the built-in `jpackage` for DEB, RPM, and app-image generation (straightforward but bundles the JRE).
 // Potential alternative (from Netflix?): https://github.com/nebula-plugins/gradle-ospackage-plugin
 //
 
@@ -71,16 +71,20 @@ val jpackageCommonArgs = listOf(
     "--description", "Voice typing for the Linux desktop",
     "--app-version", appVersion.substringBefore("-"),
     "--vendor", "Speed of Sound",
-    "--about-url", "https://www.speedofsound.io",
     "--copyright", "Copyright 2026 Antonio Zugaldia",
-    "--license-file", rootProject.file("LICENSE").absolutePath,
     "--icon", rootProject.file("assets/logo/logo-square-512.png").absolutePath,
+)
+
+// These flags are only valid for installer package types (deb, rpm), not app-image
+val jpackageLinuxInstallerArgs = listOf(
+    "--license-file", rootProject.file("LICENSE").absolutePath,
+    "--about-url", "https://www.speedofsound.io",
     "--linux-app-category", "Utility",
     "--linux-menu-group", "Utility",
     "--linux-shortcut",
 )
 
-listOf("deb", "rpm").forEach { packageType ->
+listOf("deb", "rpm", "app-image").forEach { packageType ->
     tasks.register<Exec>("jpackage-$packageType") {
         group = "distribution"
         description = "Package the app as a $packageType using jpackage"
@@ -89,6 +93,9 @@ listOf("deb", "rpm").forEach { packageType ->
         commandLine(buildList {
             add("jpackage")
             addAll(jpackageCommonArgs)
+            if (packageType != "app-image") {
+                addAll(jpackageLinuxInstallerArgs)
+            }
             if (packageType == "deb") {
                 add("--linux-deb-maintainer"); add("antonio@zugaldia.com")
             }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
@@ -15,7 +15,10 @@ fun buildAboutDialog(): AboutDialog {
     val runtimeEnvironment = getRuntimeEnvironment()
 
     val dialog = AboutDialog()
-    if (runtimeEnvironment != RuntimeEnvironment.JVM) { dialog.applicationIcon = APPLICATION_ID }
+    if (runtimeEnvironment == RuntimeEnvironment.FLATPAK || runtimeEnvironment == RuntimeEnvironment.SNAP) {
+        dialog.applicationIcon = APPLICATION_ID
+    }
+
     dialog.applicationName = APPLICATION_NAME
     dialog.developerName = "Antonio Zugaldia"
     dialog.version = "v${BuildConfig.VERSION} (${runtimeEnvironment.label})"

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/Utils.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/Utils.kt
@@ -95,11 +95,12 @@ fun generateTmpWavFilePath(): Path {
 enum class RuntimeEnvironment(val label: String) {
     FLATPAK("Flatpak"),
     SNAP("Snap"),
+    APPIMAGE("AppImage"),
     JVM("JVM"),
 }
 
 /**
- * Detects the runtime environment (Flatpak, Snap, or regular JVM Linux).
+ * Detects the runtime environment (Flatpak, Snap, AppImage, or regular JVM Linux).
  */
 fun getRuntimeEnvironment(): RuntimeEnvironment {
     // https://snapcraft.io/docs/reference/development/environment-variables/
@@ -108,9 +109,13 @@ fun getRuntimeEnvironment(): RuntimeEnvironment {
     // https://docs.flatpak.org/en/latest/flatpak-command-reference.html
     val isFlatpak = !System.getenv("FLATPAK_ID").isNullOrEmpty()
 
+    // https://docs.appimage.org/packaging-guide/environment-variables.html
+    val isAppImage = !System.getenv("APPIMAGE").isNullOrEmpty()
+
     return when {
         isSnap -> RuntimeEnvironment.SNAP
         isFlatpak -> RuntimeEnvironment.FLATPAK
+        isAppImage -> RuntimeEnvironment.APPIMAGE
         else -> RuntimeEnvironment.JVM
     }
 }

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Build a valid AppImage from the jpackage app-image output.
+# Build an AppImage from the jpackage app-image output (which is NOT a valid AppImage, but it's close).
 # The version is always read from the VERSION file.
 # Requires appimagetool to be available in PATH.
 
@@ -43,6 +43,9 @@ ln -sf usr/share/applications/io.speedofsound.SpeedOfSound.desktop \
 
 # Icon at root (appimagetool requires it here, matching Icon= above)
 ln -sf lib/speedofsound.png "$APP_DIR/speedofsound.png"
+
+# .DirIcon: required by AppDir spec for thumbnailers and file managers
+ln -sf lib/speedofsound.png "$APP_DIR/.DirIcon"
 
 # AppStream metadata
 mkdir -p "$APP_DIR/usr/share/metainfo"

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Build a valid AppImage from the jpackage app-image output.
+# The version is always read from the VERSION file.
+# Requires appimagetool to be available in PATH.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+APP_DIR="$ROOT_DIR/app/build/jpackage/speedofsound"
+OUTPUT_DIR="$ROOT_DIR/app/build/jpackage"
+VERSION="$(tr -d '[:space:]' < "$ROOT_DIR/VERSION")"
+ARCH="$(uname -m)"
+
+if [ ! -d "$APP_DIR" ]; then
+    echo "Error: jpackage app-image directory not found at $APP_DIR"
+    echo "Run 'make jpackage-app-image' first."
+    exit 1
+fi
+
+# AppRun: symlink to the jpackage native launcher
+ln -sf bin/speedofsound "$APP_DIR/AppRun"
+
+# Desktop file under usr/share/applications (for appstreamcli and FHS convention),
+# symlinked to the AppDir root (required by the AppImage spec)
+mkdir -p "$APP_DIR/usr/share/applications"
+cat > "$APP_DIR/usr/share/applications/io.speedofsound.SpeedOfSound.desktop" << 'DESKTOP'
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Speed of Sound
+Comment=Voice typing for the Linux desktop
+Categories=Utility;Accessibility;
+Keywords=voice;typing;dictation;transcription;speech;microphone;whisper;
+Icon=speedofsound
+Exec=speedofsound
+Terminal=false
+StartupNotify=true
+DESKTOP
+ln -sf usr/share/applications/io.speedofsound.SpeedOfSound.desktop \
+    "$APP_DIR/io.speedofsound.SpeedOfSound.desktop"
+
+# Icon at root (appimagetool requires it here, matching Icon= above)
+ln -sf lib/speedofsound.png "$APP_DIR/speedofsound.png"
+
+# AppStream metadata
+mkdir -p "$APP_DIR/usr/share/metainfo"
+cp "$ROOT_DIR/data/io.speedofsound.SpeedOfSound.metainfo.xml.in" \
+    "$APP_DIR/usr/share/metainfo/io.speedofsound.SpeedOfSound.appdata.xml"
+
+# Build the AppImage, APPIMAGE_EXTRACT_AND_RUN=1 avoids a FUSE dependency
+OUTPUT="$OUTPUT_DIR/speedofsound-${VERSION}-${ARCH}.AppImage"
+APPIMAGE_EXTRACT_AND_RUN=1 appimagetool "$APP_DIR" "$OUTPUT"
+echo "AppImage created: $OUTPUT"


### PR DESCRIPTION
## Summary

- Adds `scripts/build-appimage.sh` to assemble a portable AppImage from the `jpackage` app-image output using `appimagetool`
- Updates CI build and release workflows to install `appimagetool`, run the AppImage build step, and publish the `.AppImage` alongside `.deb` and `.rpm`
- Adds `make appimage` convenience target for local builds

## Test plan

- [ ] CI `JPackage Build` workflow completes successfully
- [ ] All three artifacts (`.deb`, `.rpm`, `.AppImage`) are uploaded to the workflow run
- [ ] AppImage launches correctly on a fresh Ubuntu system