### PR TITLE
add desktop notifications for pipeline errors and typing failures

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -25,6 +25,7 @@ import com.zugaldia.speedofsound.core.plugins.AppPluginCategory
 import com.zugaldia.speedofsound.core.plugins.AppPluginRegistry
 import com.zugaldia.speedofsound.core.plugins.director.DefaultDirector
 import com.zugaldia.speedofsound.core.plugins.director.DirectorEvent
+import com.zugaldia.speedofsound.core.plugins.director.PipelineStage
 import com.zugaldia.speedofsound.core.plugins.recorder.JvmRecorder
 import com.zugaldia.speedofsound.core.plugins.recorder.RecorderEvent
 import kotlinx.coroutines.CoroutineScope
@@ -281,7 +282,10 @@ class MainViewModel(
             val finalText = event.finalResult.trim() + suffix
             TextUtils.textToKeySym(finalText)
                 .onSuccess { keySyms -> portalsClient.typeText(keySyms, settingsClient.getTypingDelayMs().toLong()) }
-                .onFailure { error -> logger.error("Error converting text to key symbols: ${error.message}") }
+                .onFailure { error ->
+                    logger.error("Error converting text to key symbols: ${error.message}")
+                    portalsClient.showNotification(body = "Failed to type text: ${error.message ?: "Unknown error"}")
+                }
         }
     }
 
@@ -291,6 +295,12 @@ class MainViewModel(
 
     private fun onPipelineError(event: DirectorEvent.PipelineError) {
         logger.error("Pipeline error at ${event.stage}: ${event.error.message}")
+        val body = when (event.stage) {
+            PipelineStage.RECORDING -> "Recording failed: ${event.error.message ?: "Unknown error"}"
+            PipelineStage.TRANSCRIPTION -> "Transcription failed: ${event.error.message ?: "Unknown error"}"
+            PipelineStage.POLISHING -> "Text processing failed: ${event.error.message ?: "Unknown error"}"
+        }
+        portalsClient.showNotification(body = body)
         hideAndReset()
     }
 

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
@@ -1,6 +1,9 @@
 package com.zugaldia.speedofsound.core.desktop.portals
 
+import com.zugaldia.speedofsound.core.APPLICATION_NAME
+import com.zugaldia.speedofsound.core.generateUniqueId
 import com.zugaldia.stargate.sdk.DesktopPortal
+import com.zugaldia.stargate.sdk.notification.NotificationPriority
 import com.zugaldia.stargate.sdk.remotedesktop.DeviceType
 import com.zugaldia.stargate.sdk.remotedesktop.InputState
 import com.zugaldia.stargate.sdk.remotedesktop.PersistMode
@@ -29,6 +32,24 @@ class PortalsClient {
             restoreToken = restoreToken,
             persistMode = PersistMode.UNTIL_REVOKED
         )
+
+    /**
+     * Sends a desktop notification via the XDG Notification portal.
+     *
+     * @param body The main notification message shown to the user.
+     * @param id Unique identifier for the notification. Defaults to a generated ID. Sending a new
+     * notification with the same ID replaces any existing notification with that ID.
+     * @param title The notification title. Defaults to the application name.
+     * @param priority The notification priority level. Defaults to [NotificationPriority.NORMAL],
+     * which is appropriate for most informational messages and errors.
+     */
+    fun showNotification(
+        body: String,
+        id: String = generateUniqueId(),
+        title: String = APPLICATION_NAME,
+        priority: NotificationPriority = NotificationPriority.NORMAL
+    ) = runCatching { portal.notification.addNotification(id = id, title = title, body = body, priority = priority) }
+        .onFailure { error -> logger.error("Failed to send notification: ${error.message}") }
 
     /**
      * Simulates keyboard input by sending each character as a key press/release pair.


### PR DESCRIPTION
## Summary

- Adds `PortalsClient.showNotification()` wrapping the XDG Desktop Notification portal via Stargate SDK
- Notifies the user when a pipeline stage fails (recording, transcription, or text processing) with a stage-specific message
- Notifies the user when text-to-keysym conversion fails, so typing errors are no longer silent

## Test plan

- [ ] Trigger a pipeline error (e.g. disable the ASR model) and verify a desktop notification appears with the correct stage label
- [ ] Verify the notification title defaults to "Speed of Sound"
- [ ] Verify normal successful runs produce no notifications