### PR TITLE
Add Help menu item linking to the documentation website

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
@@ -4,6 +4,7 @@ import com.zugaldia.speedofsound.app.BuildConfig
 import com.zugaldia.speedofsound.core.APPLICATION_ID
 import com.zugaldia.speedofsound.core.APPLICATION_NAME
 import com.zugaldia.speedofsound.core.APPLICATION_SHORT
+import com.zugaldia.speedofsound.core.APPLICATION_URL
 import com.zugaldia.speedofsound.core.RuntimeEnvironment
 import com.zugaldia.speedofsound.core.getDataDir
 import com.zugaldia.speedofsound.core.getRuntimeEnvironment
@@ -22,7 +23,7 @@ fun buildAboutDialog(): AboutDialog {
     dialog.applicationName = APPLICATION_NAME
     dialog.developerName = "Antonio Zugaldia"
     dialog.version = "v${BuildConfig.VERSION} (${runtimeEnvironment.label})"
-    dialog.website = "https://www.speedofsound.io"
+    dialog.website = APPLICATION_URL
     dialog.issueUrl = "https://github.com/zugaldia/speedofsound/issues"
     dialog.supportUrl = "https://github.com/zugaldia/speedofsound/issues"
     dialog.licenseType = License.MIT_X11

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -239,6 +239,10 @@ class MainViewModel(
         portalsSessionManager.startSession(viewModelScope, token)
     }
 
+    fun openUri(uri: String) {
+        viewModelScope.launch { portalsClient.openUri(uri) }
+    }
+
     fun onPrimaryLanguageSelected(forceUpdate: Boolean = false) {
         val language = languageFromIso2(settingsClient.getDefaultLanguage()) ?: DEFAULT_LANGUAGE
         if (!forceUpdate && language == state.currentLanguage()) return // Force update on initialization

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
@@ -16,6 +16,7 @@ import com.zugaldia.speedofsound.app.screens.preferences.PreferencesDialog
 import com.zugaldia.speedofsound.app.screens.shortcuts.buildShortcutsWindow
 import com.zugaldia.speedofsound.core.desktop.settings.SettingsClient
 import com.zugaldia.speedofsound.core.APPLICATION_NAME
+import com.zugaldia.speedofsound.core.APPLICATION_URL
 import org.gnome.adw.Banner
 import org.slf4j.LoggerFactory
 import org.gnome.adw.Application
@@ -57,6 +58,7 @@ class MainWindow(
             onSettingsClicked = { onOpenPreferences() },
             onShortcutsClicked = { onOpenShortcuts() },
             onAboutClicked = { onOpenAbout() },
+            onHelpClicked = { onOpenHelp() },
             onQuitClicked = { onQuit() }
         )
 
@@ -157,6 +159,10 @@ class MainWindow(
         shouldHideOnCompletion = false
         viewModel.cancelListening()
         buildAboutDialog().present(this)
+    }
+
+    private fun onOpenHelp() {
+        viewModel.openUri(APPLICATION_URL)
     }
 
     private fun onQuit() {

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/StatusWidget.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/StatusWidget.kt
@@ -17,6 +17,7 @@ class StatusWidget(
     private val onSettingsClicked: () -> Unit,
     private val onShortcutsClicked: () -> Unit,
     private val onAboutClicked: () -> Unit,
+    private val onHelpClicked: () -> Unit,
     private val onQuitClicked: () -> Unit
 ) : Box() {
     private val logger = LoggerFactory.getLogger(StatusWidget::class.java)
@@ -57,6 +58,7 @@ class StatusWidget(
         val mainSection = Menu()
         mainSection.append("Preferences", "status.preferences")
         mainSection.append("Keyboard Shortcuts", "status.shortcuts")
+        mainSection.append("Help", "status.help")
         mainSection.append("About", "status.about")
 
         val quitSection = Menu()
@@ -86,6 +88,10 @@ class StatusWidget(
         val aboutAction = SimpleAction("about", null)
         aboutAction.onActivate { onAboutClicked() }
         actionGroup.addAction(aboutAction)
+
+        val helpAction = SimpleAction("help", null)
+        helpAction.onActivate { onHelpClicked() }
+        actionGroup.addAction(helpAction)
 
         val quitAction = SimpleAction("quit", null)
         quitAction.onActivate { onQuitClicked() }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/Constants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/Constants.kt
@@ -3,6 +3,7 @@ package com.zugaldia.speedofsound.core
 const val APPLICATION_NAME = "Speed of Sound"
 const val APPLICATION_ID = "io.speedofsound.SpeedOfSound"
 const val APPLICATION_SHORT = "speedofsound"
+const val APPLICATION_URL = "https://www.speedofsound.io"
 
 const val ANTHROPIC_ENVIRONMENT_VARIABLE = "ANTHROPIC_API_KEY"
 const val GOOGLE_ENVIRONMENT_VARIABLE = "GOOGLE_API_KEY"

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
@@ -52,6 +52,15 @@ class PortalsClient {
         .onFailure { error -> logger.error("Failed to send notification: ${error.message}") }
 
     /**
+     * Opens a URI in the user's preferred application via the XDG OpenURI portal.
+     *
+     * @param uri The URI to open (e.g. "https://example.com").
+     */
+    suspend fun openUri(uri: String) =
+        portal.openUri.openUri(uri)
+            .onFailure { error -> logger.error("Failed to open URI: ${error.message}") }
+
+    /**
      * Simulates keyboard input by sending each character as a key press/release pair.
      *
      * @param text List of X11 keysym values to type, one per character.


### PR DESCRIPTION
## Summary

- Adds a **Help** entry to the main window's quick menu (positioned before About, following GNOME conventions)
- Opens `https://www.speedofsound.io` via the XDG OpenURI portal, which is reliable in confined environments (Flatpak, Snap)
- Extracts `APPLICATION_URL` as a shared constant in `core/Constants.kt` alongside the other app-level identifiers, replacing the previously hardcoded string in `AppAboutDialog`

## Test plan

- [ ] Open the app and click the gear menu — confirm **Help** appears between Keyboard Shortcuts and About
- [ ] Click Help — confirm the documentation website opens in the default browser
- [ ] Verify the existing About dialog still shows the correct website link
- [ ] Test in a Flatpak build to confirm the OpenURI portal path works in a confined environment