### PR TITLE
Fix ComboRow search by setting a PropertyExpression on the model

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/LanguageComboRow.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/LanguageComboRow.kt
@@ -3,7 +3,9 @@ package com.zugaldia.speedofsound.app.screens.preferences.general
 import com.zugaldia.speedofsound.core.Language
 import com.zugaldia.speedofsound.core.languageFromIso2
 import org.gnome.adw.ComboRow
+import org.gnome.gtk.PropertyExpression
 import org.gnome.gtk.StringList
+import org.gnome.gtk.StringObject
 import org.slf4j.LoggerFactory
 
 class LanguageComboRow(
@@ -25,6 +27,7 @@ class LanguageComboRow(
         model = stringList
         useSubtitle = false
         enableSearch = true
+        expression = PropertyExpression(StringObject.getType(), null, "string")
         refresh()
     }
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/shared/ModelComboRow.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/shared/ModelComboRow.kt
@@ -3,7 +3,9 @@ package com.zugaldia.speedofsound.app.screens.preferences.shared
 import com.zugaldia.speedofsound.core.models.SelectableModel
 import org.gnome.adw.ComboRow
 import org.gnome.adw.EntryRow
+import org.gnome.gtk.PropertyExpression
 import org.gnome.gtk.StringList
+import org.gnome.gtk.StringObject
 import org.slf4j.LoggerFactory
 
 /**
@@ -37,6 +39,7 @@ class ModelComboRow<T : SelectableModel>(
             subtitle = rowSubtitle
             useSubtitle = false // Do not use the _current value_ as the subtitle
             enableSearch = true // Some providers list *many* models, so allow searching
+            expression = PropertyExpression(StringObject.getType(), null, "string")
         }
         refreshComboRows()
     }


### PR DESCRIPTION
## Summary

- Fixes search in `LanguageComboRow` and `ModelComboRow`, which was broken despite `enableSearch = true` being set
- Root cause: GTK requires `GtkDropDown:expression` to be set for search to work — without it the search field appears but does not filter
- Adds `PropertyExpression(StringObject.getType(), null, "string")` to both rows, targeting the `string` property of the `StringObject` items in the `StringList` model

## Test plan

- [ ] Open Preferences → General — confirm the language dropdown search field now filters the language list as you type
- [ ] Open Preferences → Voice/Text models — confirm the model dropdown search field filters models as you type