### PR TITLE
replace getTmpDataDir with getCacheDir following XDG spec

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
@@ -7,7 +7,7 @@ import com.zugaldia.speedofsound.core.APPLICATION_SHORT
 import com.zugaldia.speedofsound.core.RuntimeEnvironment
 import com.zugaldia.speedofsound.core.getDataDir
 import com.zugaldia.speedofsound.core.getRuntimeEnvironment
-import com.zugaldia.speedofsound.core.getTmpDataDir
+import com.zugaldia.speedofsound.core.getCacheDir
 import org.gnome.adw.AboutDialog
 import org.gnome.gtk.License
 
@@ -47,7 +47,7 @@ private fun buildDebugInfo(): String = buildString {
     appendLine()
     appendLine("Runtime: ${getRuntimeEnvironment().label}")
     appendLine("Data directory: ${getDataDir()}")
-    appendLine("Temporary directory: ${getTmpDataDir()}")
+    appendLine("Cache directory: ${getCacheDir()}")
     appendLine()
     appendLine("OS: ${System.getProperty("os.name")} ${System.getProperty("os.version")}")
     appendLine("Architecture: ${System.getProperty("os.arch")}")

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/Utils.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/Utils.kt
@@ -35,58 +35,57 @@ fun languageFromIso2(iso2: String): Language? =
     Language.all.firstOrNull { it.iso2 == iso2 }
 
 /**
- * Get the data directory path depending on the environment.
- * Returns $SNAP_USER_COMMON or $XDG_DATA_HOME (if set), falling back to $HOME/.local/share/speedofsound
+ * Resolves and ensures an application directory exists, adapting to the runtime environment.
+ *
+ * @param xdgEnvVar the XDG environment variable to check (e.g. XDG_DATA_HOME, XDG_CACHE_HOME)
+ * @param fallbackPath path segments under $HOME to use when no XDG variable is set (APPLICATION_SHORT is appended)
+ * @param snapSubDir optional subdirectory to append under SNAP_USER_COMMON (e.g. "cache")
  */
-fun getDataDir(): Path {
+private fun resolveAppDir(xdgEnvVar: String, fallbackPath: List<String>, snapSubDir: String? = null): Path {
     val snapUserCommon = System.getenv("SNAP_USER_COMMON") // In a Snap
-    val xdgDataHome = System.getenv("XDG_DATA_HOME") // Typically, in a Flatpak
-    val appDataDir = if (!snapUserCommon.isNullOrEmpty()) {
-        Paths.get(snapUserCommon) // Already includes the Snap name
-    } else if (!xdgDataHome.isNullOrEmpty()) {
-        if (APPLICATION_ID in xdgDataHome) {
-            Paths.get(xdgDataHome) // APPLICATION_ID already included in Flatpak sandboxes
+    val xdgDir = System.getenv(xdgEnvVar) // Typically, in a Flatpak
+    val appDir = if (!snapUserCommon.isNullOrEmpty()) {
+        if (snapSubDir != null) Paths.get(snapUserCommon, snapSubDir) else Paths.get(snapUserCommon)
+    } else if (!xdgDir.isNullOrEmpty()) {
+        if (APPLICATION_ID in xdgDir) {
+            Paths.get(xdgDir) // APPLICATION_ID already included in Flatpak sandboxes
         } else {
-            Paths.get(xdgDataHome, APPLICATION_SHORT)
+            Paths.get(xdgDir, APPLICATION_SHORT)
         }
     } else {
         val home = System.getProperty("user.home")
-        Paths.get(home, ".local", "share", APPLICATION_SHORT)
+        Paths.get(home, *fallbackPath.toTypedArray(), APPLICATION_SHORT)
     }
 
     // Ensure it exists
-    val dir = appDataDir.toFile()
+    val dir = appDir.toFile()
     if (!dir.exists()) {
         dir.mkdirs()
     }
 
-    return appDataDir
+    return appDir
 }
 
 /**
- * Get the temporary data directory path.
- * Returns {dataDir}/tmp, creating it if it doesn't exist.
- * This ensures temporary files work in sandboxed environments like Flatpak and Snap.
+ * Get the data directory path depending on the environment.
+ * Returns $SNAP_USER_COMMON or $XDG_DATA_HOME (if set), falling back to $HOME/.local/share/speedofsound
  */
-fun getTmpDataDir(): Path {
-    val dataDir = getDataDir()
-    val tmpDir = dataDir.resolve("tmp")
-    val dir = tmpDir.toFile()
-    if (!dir.exists()) {
-        dir.mkdirs()
-    }
+fun getDataDir(): Path = resolveAppDir("XDG_DATA_HOME", listOf(".local", "share"))
 
-    return tmpDir
-}
+/**
+ * Get the cache directory path depending on the environment.
+ * Returns $SNAP_USER_COMMON/cache or $XDG_CACHE_HOME (if set), falling back to $HOME/.cache/speedofsound
+ */
+fun getCacheDir(): Path = resolveAppDir("XDG_CACHE_HOME", listOf(".cache"), snapSubDir = "cache")
 
 /**
  * Generate a temporary WAV file path with a timestamp.
- * Format: {tmpDataDir}/speedofsound-{timestamp}.wav
+ * Format: {cacheDir}/speedofsound-{timestamp}.wav
  */
 fun generateTmpWavFilePath(): Path {
-    val dataDir = getTmpDataDir()
+    val cacheDir = getCacheDir()
     val timestamp = generateTimestamp()
-    return dataDir.resolve("$APPLICATION_SHORT-$timestamp.wav")
+    return cacheDir.resolve("$APPLICATION_SHORT-$timestamp.wav")
 }
 
 /**

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/models/voice/ModelManager.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/models/voice/ModelManager.kt
@@ -100,7 +100,7 @@ class ModelManager(
     }
 
     private fun createTempDirectory(): Path {
-        val tempDir = pathProvider.getTmpDataDir().resolve(idGenerator.generateUniqueId())
+        val tempDir = pathProvider.getCacheDir().resolve(idGenerator.generateUniqueId())
         fileSystem.mkdirs(tempDir)
         return tempDir
     }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/models/voice/PathProvider.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/models/voice/PathProvider.kt
@@ -1,15 +1,15 @@
 package com.zugaldia.speedofsound.core.models.voice
 
 import com.zugaldia.speedofsound.core.getDataDir as getCoreDataDir
-import com.zugaldia.speedofsound.core.getTmpDataDir as getCoreTmpDataDir
+import com.zugaldia.speedofsound.core.getCacheDir as getCoreCacheDir
 import java.nio.file.Path
 
 /**
- * Provides paths for data and temporary directories.
+ * Provides paths for data and cache directories.
  */
 interface PathProvider {
     fun getDataDir(): Path
-    fun getTmpDataDir(): Path
+    fun getCacheDir(): Path
 }
 
 /**
@@ -17,5 +17,5 @@ interface PathProvider {
  */
 class DefaultPathProvider : PathProvider {
     override fun getDataDir(): Path = getCoreDataDir()
-    override fun getTmpDataDir(): Path = getCoreTmpDataDir()
+    override fun getCacheDir(): Path = getCoreCacheDir()
 }

--- a/core/src/test/kotlin/com/zugaldia/speedofsound/core/UtilsTest.kt
+++ b/core/src/test/kotlin/com/zugaldia/speedofsound/core/UtilsTest.kt
@@ -64,16 +64,16 @@ class UtilsTest {
     }
 
     @Test
-    fun `getTmpDataDir returns non-null path`() {
-        val tmpDir = getTmpDataDir()
-        assertNotNull(tmpDir)
+    fun `getCacheDir returns non-null path`() {
+        val cacheDir = getCacheDir()
+        assertNotNull(cacheDir)
     }
 
     @Test
-    fun `getTmpDataDir creates directory that exists`() {
-        val tmpDir = getTmpDataDir()
-        assertTrue(tmpDir.toFile().exists())
-        assertTrue(tmpDir.toFile().isDirectory)
+    fun `getCacheDir creates directory that exists`() {
+        val cacheDir = getCacheDir()
+        assertTrue(cacheDir.toFile().exists())
+        assertTrue(cacheDir.toFile().isDirectory)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Replaces `getTmpDataDir()` (which stored files in `{dataDir}/tmp/`) with `getCacheDir()` that correctly uses `XDG_CACHE_HOME` (`~/.cache/speedofsound`)
- Introduces a private `resolveAppDir()` helper in `Utils.kt` to de-duplicate the Snap/Flatpak/fallback path detection logic shared by `getDataDir` and `getCacheDir`
- Updates all call sites: WAV recording paths, model download staging (`ModelManager`), `PathProvider` interface + `DefaultPathProvider`, and the about dialog debug info

## Test plan

- [ ] Run `make check` to verify detekt and tests pass
- [ ] Run the app and confirm WAV files land in `~/.cache/speedofsound/` (not `~/.local/share/speedofsound/tmp/`)
- [ ] Download a model via the UI and confirm temp staging files use the cache dir
- [ ] Check the About dialog debug info shows "Cache directory" with the correct path