### PR TITLE
Upgrade Stargate to 0.3.0 and add XDG Registry registration

### DIFF
--- a/app/flatpak-sources.json
+++ b/app/flatpak-sources.json
@@ -890,24 +890,24 @@
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.2.0/stargate-0.2.0.jar",
-    "sha512": "ff0ebcbe2decb1929d77b7a85f57bb7dc8be204f7ced0dd396a5fcca1d79cb41d42089b66dce481ac54d0cb7018199e10d084438f8270f32f46dab09f1b6ade1",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.2.0",
-    "dest-filename": "stargate-0.2.0.jar"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.3.0/stargate-0.3.0.jar",
+    "sha512": "87339f91066c3ce530c26c876ae15b21762a01f299a917b291e277662412e3ceee14aeffd1dcd5158d968b4d68e76f5c4394d103eee9018b1ff0b463670a17d7",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.3.0",
+    "dest-filename": "stargate-0.3.0.jar"
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.2.0/stargate-0.2.0.module",
-    "sha512": "d188766709b98d31d21aa9ee4ee7a48ce15cf2b1d18e5fd7928aec044e6be789ff8064b373650fe9f1f9f59cc516ab38c793538ec3f59416fe8086fd0d82c223",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.2.0",
-    "dest-filename": "stargate-0.2.0.module"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.3.0/stargate-0.3.0.module",
+    "sha512": "04357e051e9c84faab44901505c068a05e5b5a6f2b49caea7a5febd2dadf8d2afc19cf06bc7838a6eb508138e288dadf6f50b28e01bdd43ec9d102e5a5b4e356",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.3.0",
+    "dest-filename": "stargate-0.3.0.module"
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.2.0/stargate-0.2.0.pom",
-    "sha512": "317fda5693e83b57d09ce36a1502fdd933572f62a10da00a65e93a42e04b8e4667f190d70655bef9c7a3d771d51189af24fecd4f9e05640fd86409a232ced80a",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.2.0",
-    "dest-filename": "stargate-0.2.0.pom"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.3.0/stargate-0.3.0.pom",
+    "sha512": "7420b9c32a9404cec86e8bf58c4154ede4d155742eda44d9dfa0792fa141567c92d830fff952a8dbccc3fd64908562c86843273971f7d84a317ec507ee49ac7f",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.3.0",
+    "dest-filename": "stargate-0.3.0.pom"
   },
   {
     "type": "file",

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/portals/PortalsSessionManager.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/portals/PortalsSessionManager.kt
@@ -2,6 +2,7 @@ package com.zugaldia.speedofsound.app.portals
 
 import com.zugaldia.speedofsound.core.desktop.portals.PortalsClient
 import com.zugaldia.speedofsound.core.desktop.settings.SettingsClient
+import com.zugaldia.stargate.sdk.isSandboxed
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,11 +28,18 @@ class PortalsSessionManager(
     val isRestoreTokenMissing: StateFlow<Boolean> = _isRestoreTokenMissing.asStateFlow()
 
     fun initialize(scope: CoroutineScope) {
-        val token = settingsClient.getPortalsRestoreToken()
-        if (token.isNotBlank()) {
-            startSession(scope, token)
-        } else {
-            logger.info("No previous session found.")
+        scope.launch {
+            // Registration must happen before any other portal call, otherwise registration will result in an error.
+            if (!isSandboxed()) { portalsClient.registerApplication() }
+
+            // We can still use portals even if registration above fails (some portals might not work, e.g. Global
+            // Shortcuts, or have degraded experience).
+            val token = settingsClient.getPortalsRestoreToken()
+            if (token.isNotBlank()) {
+                startSession(scope, token)
+            } else {
+                logger.info("No previous session found.")
+            }
         }
     }
 

--- a/core/flatpak-sources.json
+++ b/core/flatpak-sources.json
@@ -841,24 +841,24 @@
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.2.0/stargate-0.2.0.jar",
-    "sha512": "ff0ebcbe2decb1929d77b7a85f57bb7dc8be204f7ced0dd396a5fcca1d79cb41d42089b66dce481ac54d0cb7018199e10d084438f8270f32f46dab09f1b6ade1",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.2.0",
-    "dest-filename": "stargate-0.2.0.jar"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.3.0/stargate-0.3.0.jar",
+    "sha512": "87339f91066c3ce530c26c876ae15b21762a01f299a917b291e277662412e3ceee14aeffd1dcd5158d968b4d68e76f5c4394d103eee9018b1ff0b463670a17d7",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.3.0",
+    "dest-filename": "stargate-0.3.0.jar"
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.2.0/stargate-0.2.0.module",
-    "sha512": "d188766709b98d31d21aa9ee4ee7a48ce15cf2b1d18e5fd7928aec044e6be789ff8064b373650fe9f1f9f59cc516ab38c793538ec3f59416fe8086fd0d82c223",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.2.0",
-    "dest-filename": "stargate-0.2.0.module"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.3.0/stargate-0.3.0.module",
+    "sha512": "04357e051e9c84faab44901505c068a05e5b5a6f2b49caea7a5febd2dadf8d2afc19cf06bc7838a6eb508138e288dadf6f50b28e01bdd43ec9d102e5a5b4e356",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.3.0",
+    "dest-filename": "stargate-0.3.0.module"
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.2.0/stargate-0.2.0.pom",
-    "sha512": "317fda5693e83b57d09ce36a1502fdd933572f62a10da00a65e93a42e04b8e4667f190d70655bef9c7a3d771d51189af24fecd4f9e05640fd86409a232ced80a",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.2.0",
-    "dest-filename": "stargate-0.2.0.pom"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.3.0/stargate-0.3.0.pom",
+    "sha512": "7420b9c32a9404cec86e8bf58c4154ede4d155742eda44d9dfa0792fa141567c92d830fff952a8dbccc3fd64908562c86843273971f7d84a317ec507ee49ac7f",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.3.0",
+    "dest-filename": "stargate-0.3.0.pom"
   },
   {
     "type": "file",

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/Utils.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/Utils.kt
@@ -1,5 +1,7 @@
 package com.zugaldia.speedofsound.core
 
+import com.zugaldia.stargate.sdk.isFlatpak
+import com.zugaldia.stargate.sdk.isSnap
 import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -102,18 +104,11 @@ enum class RuntimeEnvironment(val label: String) {
  * Detects the runtime environment (Flatpak, Snap, AppImage, or regular JVM Linux).
  */
 fun getRuntimeEnvironment(): RuntimeEnvironment {
-    // https://snapcraft.io/docs/reference/development/environment-variables/
-    val isSnap = !System.getenv("SNAP_NAME").isNullOrEmpty()
-
-    // https://docs.flatpak.org/en/latest/flatpak-command-reference.html
-    val isFlatpak = !System.getenv("FLATPAK_ID").isNullOrEmpty()
-
     // https://docs.appimage.org/packaging-guide/environment-variables.html
     val isAppImage = !System.getenv("APPIMAGE").isNullOrEmpty()
-
     return when {
-        isSnap -> RuntimeEnvironment.SNAP
-        isFlatpak -> RuntimeEnvironment.FLATPAK
+        isSnap() -> RuntimeEnvironment.SNAP
+        isFlatpak() -> RuntimeEnvironment.FLATPAK
         isAppImage -> RuntimeEnvironment.APPIMAGE
         else -> RuntimeEnvironment.JVM
     }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
@@ -1,5 +1,6 @@
 package com.zugaldia.speedofsound.core.desktop.portals
 
+import com.zugaldia.speedofsound.core.APPLICATION_ID
 import com.zugaldia.speedofsound.core.APPLICATION_NAME
 import com.zugaldia.speedofsound.core.generateUniqueId
 import com.zugaldia.stargate.sdk.DesktopPortal
@@ -19,6 +20,16 @@ class PortalsClient {
 
     val sessionClosedEvents: Flow<SessionClosedEvent>
         get() = portal.remoteDesktop.observeSessionClosed()
+
+    /**
+     * Registers the application with the XDG Registry portal.
+     * This should only be called when not running in a sandboxed environment (Flatpak/Snap),
+     * as sandboxed apps are registered automatically.
+     */
+    suspend fun registerApplication() =
+        portal.registry.register(APPLICATION_ID)
+            .onSuccess { logger.info("Registered application ID: {}", APPLICATION_ID) }
+            .onFailure { logger.warn("Failed to register application ID: {} ({})", APPLICATION_ID, it.message) }
 
     /**
      * Starts a remote desktop session with keyboard input support.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ onnx = "1.24.3"
 onnxExtensions = "0.13.0"
 openai = "4.29.0"
 shadow = "9.3.2"
-stargate = "0.2.0"
+stargate = "0.3.0"
 versionsPlugin = "0.53.0"
 
 [libraries]


### PR DESCRIPTION
## Summary

- Bumps Stargate dependency from 0.2.0 to 0.3.0 and updates Flatpak offline sources (SHA512s + paths) in both `app` and `core`
- Replaces manual `SNAP_NAME`/`FLATPAK_ID` env-var checks in `Utils.kt` with `isSnap()`/`isFlatpak()` SDK helpers from Stargate
- Adds `PortalsClient.registerApplication()` using the new `portal.registry` API; non-sandboxed apps must register before making any portal calls
- `PortalsSessionManager.initialize()` is now async and calls `registerApplication()` before starting the session when not running in a Flatpak/Snap sandbox

## Test plan

- [ ] Run app outside a sandbox (JVM mode) and confirm registration succeeds in logs before session start
- [ ] Run app inside Flatpak and confirm `registerApplication()` is skipped (`isSandboxed()` returns true)
- [ ] Verify remote desktop session connects and typing works end-to-end in both environments
- [ ] Confirm `make check` (detekt) passes with no new warnings