### PR TITLE
feat: improve model library UI clarity

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/library/ModelLibraryPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/library/ModelLibraryPage.kt
@@ -68,11 +68,13 @@ class ModelLibraryPage(
                 val isDeleting = deletingModels.contains(model.id)
                 val isDownloading = downloadingModels.contains(model.id)
                 val isOperationInProgress = isDeleting || isDownloading
+                val isBundled = model.id == DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
                 val row = ActionRow().apply {
                     title = model.name
                     subtitle = when {
                         isDeleting -> "Deleting..."
                         isDownloading -> "Downloading..."
+                        isBundled -> "Bundled — always available"
                         else -> "${model.dataSizeMegabytes} MB"
                     }
 
@@ -135,6 +137,7 @@ class ModelLibraryPage(
         val isOperationInProgress = isDownloading || isDeleting
         val downloadButton = Button.fromIconName("folder-download-symbolic").apply {
             tooltipText = when {
+                isDefaultModel -> "Bundled with the application"
                 isDownloading -> "Downloading..."
                 isOperationInProgress -> "Operation in progress"
                 isDownloaded -> "Already downloaded"
@@ -149,7 +152,7 @@ class ModelLibraryPage(
         val isDefaultModel = modelId == DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
         val removeButton = Button.fromIconName("user-trash-symbolic").apply {
             tooltipText = when {
-                isDefaultModel -> "Cannot delete default model"
+                isDefaultModel -> "Bundled with the application, cannot be removed"
                 isDeleting -> "Deleting..."
                 isOperationInProgress -> "Operation in progress"
                 else -> "Remove model"

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/library/ModelLibraryPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/library/ModelLibraryPage.kt
@@ -1,7 +1,6 @@
 package com.zugaldia.speedofsound.app.screens.preferences.library
 
 import com.zugaldia.speedofsound.app.STYLE_CLASS_BOXED_LIST
-import com.zugaldia.speedofsound.app.STYLE_CLASS_DIM_LABEL
 import com.zugaldia.speedofsound.app.STYLE_CLASS_FLAT
 import com.zugaldia.speedofsound.app.screens.preferences.PreferencesViewModel
 import com.zugaldia.speedofsound.core.desktop.settings.SUPPORTED_LOCAL_ASR_MODELS
@@ -75,12 +74,8 @@ class ModelLibraryPage(
                         isDeleting -> "Deleting..."
                         isDownloading -> "Downloading..."
                         isBundled -> "Bundled — always available"
+                        isDownloaded -> "${model.dataSizeMegabytes} MB — downloaded"
                         else -> "${model.dataSizeMegabytes} MB"
-                    }
-
-                    // Gray out models that haven't been downloaded
-                    if (!isDownloaded && !isOperationInProgress) {
-                        addCssClass(STYLE_CLASS_DIM_LABEL)
                     }
 
                     // Add spinner as the first suffix - create a new one for each row
@@ -135,6 +130,7 @@ class ModelLibraryPage(
         val isDownloading = downloadingModels.contains(modelId)
         val isDeleting = deletingModels.contains(modelId)
         val isOperationInProgress = isDownloading || isDeleting
+        val isDefaultModel = modelId == DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
         val downloadButton = Button.fromIconName("folder-download-symbolic").apply {
             tooltipText = when {
                 isDefaultModel -> "Bundled with the application"
@@ -149,7 +145,6 @@ class ModelLibraryPage(
             onClicked { handleDownloadModel(modelId) }
         }
 
-        val isDefaultModel = modelId == DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
         val removeButton = Button.fromIconName("user-trash-symbolic").apply {
             tooltipText = when {
                 isDefaultModel -> "Bundled with the application, cannot be removed"


### PR DESCRIPTION
## Summary

- Adds a "Bundled — always available" subtitle for the default Whisper Tiny model so its special status is immediately visible
- Replaces the dim-label CSS approach for undownloaded models with an explicit "MB — downloaded" subtitle, making download state clearer without relying on visual graying

## Test plan

- [ ] Open the Model Library preferences page
- [ ] Verify the bundled Whisper Tiny model shows "Bundled — always available" as subtitle
- [ ] Verify downloaded models show `"X MB — downloaded"` as subtitle
- [ ] Verify undownloaded models show only `"X MB"` (no dimming)
- [ ] Download a model and confirm the subtitle updates correctly on completion