### PR TITLE
fix: correct SVG badge path in getting-started.md for MkDocs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@
 ## 1. Installation
 
 <a href="https://github.com/zugaldia/speedofsound/releases/latest">
-  <img src="assets/appimage/download-appimage-banner.svg" alt="Download as AppImage" height="60">
+  <img src="../assets/appimage/download-appimage-banner.svg" alt="Download as AppImage" height="60">
 </a>
 
 Download the latest AppImage, Deb, or RPM from the [releases page](https://github.com/zugaldia/speedofsound/releases/latest),


### PR DESCRIPTION
## Summary

- Fixes a 404 on the docs site caused by an incorrect relative path in the AppImage download badge
- MkDocs serves `getting-started.md` at `/getting-started/`, so `assets/appimage/...` resolved to `/getting-started/assets/appimage/...` instead of `/assets/appimage/...`
- Changed to `../assets/appimage/...` which resolves correctly on the site and on GitHub