### PR TITLE
Target GNOME 50 for Flatpak

### DIFF
--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -20,7 +20,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-49
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
       options: --privileged
     steps:
       - uses: actions/checkout@v4

--- a/io.speedofsound.SpeedOfSound.yml
+++ b/io.speedofsound.SpeedOfSound.yml
@@ -1,6 +1,6 @@
 id: io.speedofsound.SpeedOfSound
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 
 sdk: org.gnome.Sdk
 sdk-extensions:


### PR DESCRIPTION
## Summary

- Update Flatpak runtime version from GNOME 49 to GNOME 50 (`io.speedofsound.SpeedOfSound.yml`)
- Update Flatpak CI container image from `gnome-49` to `gnome-50` (`.github/workflows/flatpak-build.yml`)
- No Snapcraft changes needed — the GNOME SDK snap is tied to the Ubuntu LTS base (`core24` → `gnome-46-2404-sdk`), not the desktop GNOME version

## Test plan

- [ ] Verify Flatpak CI build passes with the `gnome-50` container image
- [ ] Verify the app builds and runs correctly against `org.gnome.Platform` 50