### PR TITLE
ci: promote stable snap releases to beta channel

### DIFF
--- a/.github/workflows/release-dispatcher.yml
+++ b/.github/workflows/release-dispatcher.yml
@@ -23,7 +23,7 @@ jobs:
         id: detect
         run: |
           # Determine channel from version string
-          VERSION=$(cat VERSION | tr -d '[:space:]')
+          VERSION=$(tr -d '[:space:]' < VERSION)
           if [[ "$VERSION" == *"alpha"* ]]; then
             CHANNEL="alpha"
           elif [[ "$VERSION" == *"beta"* ]]; then
@@ -32,19 +32,19 @@ jobs:
             CHANNEL="stable"
           fi
 
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
 
           # Check if tag already exists
           TAG="v${VERSION}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists, skipping release."
-            echo "new_release=false" >> $GITHUB_OUTPUT
+            echo "new_release=false" >> "$GITHUB_OUTPUT"
           else
             echo "Tag $TAG does not exist, creating it."
             git tag "$TAG"
             git push origin "$TAG"
-            echo "new_release=true" >> $GITHUB_OUTPUT
+            echo "new_release=true" >> "$GITHUB_OUTPUT"
           fi
 
   release-github:

--- a/.github/workflows/snap-publish.yml
+++ b/.github/workflows/snap-publish.yml
@@ -35,9 +35,18 @@ jobs:
         id: build
       - name: Lint snap
         run: sg lxd -c "snapcraft lint ${{ steps.build.outputs.snap }}"
+      - name: Determine release channels
+        id: channels
+        run: |
+          # When publishing to stable, also update beta so beta users are never behind
+          if [[ "${{ inputs.channel }}" == "stable" ]]; then
+            echo "release=stable,beta" >> "$GITHUB_OUTPUT"
+          else
+            echo "release=${{ inputs.channel }}" >> "$GITHUB_OUTPUT"
+          fi
       - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_LOGIN }}
         with:
           snap: ${{ steps.build.outputs.snap }}
-          release: ${{ inputs.channel }}
+          release: ${{ steps.channels.outputs.release }}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ export GRADLE_OPTS = --enable-native-access=ALL-UNNAMED
 	flatpak-sources flatpak-linter flatpak-build flatpak-bundle flatpak-run flatpak-remove desktop-validate \
 	snapcraft-clean snapcraft-pack snapcraft-lint snap-install snap-remove \
 	jpackage-deb jpackage-rpm jpackage-app-image appimage \
+	actionlint \
 	docs-serve docs-build
 
 clean:
@@ -106,6 +107,13 @@ snap-install:
 
 snap-remove:
 	snap remove speedofsound
+
+#
+# GitHub Actions
+#
+
+actionlint:
+	actionlint -verbose
 
 #
 # jpackage


### PR DESCRIPTION
## Summary
- When publishing a stable release to the Snap Store, also publish to the beta channel so beta users are never behind stable. Uses the `snapcore/action-publish` action's comma-separated channel support (`stable,beta`).
- Fix shellcheck warnings in `release-dispatcher.yml` (useless cat, unquoted `$GITHUB_OUTPUT`).
- Fix shellcheck warnings in `snap-publish.yml` (unquoted `$GITHUB_OUTPUT`).
- Add `make actionlint` target for validating GitHub Actions workflows locally.

## Test plan
- [ ] Verify `make actionlint` passes with 0 errors
- [ ] Trigger a manual `workflow_dispatch` of `snap-publish.yml` with channel=stable and confirm it publishes to both stable and beta
- [ ] Trigger with channel=beta and confirm it only publishes to beta