### PR TITLE
fix: add lfs: true to all build workflow checkouts

### DIFF
--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -24,6 +24,8 @@ jobs:
       options: --privileged
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Lint AppStream metadata and manifests
         run: |
           flatpak-builder-lint appstream data/io.speedofsound.SpeedOfSound.metainfo.xml.in

--- a/.github/workflows/jpackage-build.yml
+++ b/.github/workflows/jpackage-build.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Install dependencies
         run: sudo apt-get install -y fakeroot rpm
       - name: Install appimagetool

--- a/.github/workflows/snap-build.yml
+++ b/.github/workflows/snap-build.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: snapcore/action-build@v1
         id: build
       - name: Lint snap

--- a/.github/workflows/snap-publish.yml
+++ b/.github/workflows/snap-publish.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: v${{ inputs.version }}
+          lfs: true
       - uses: snapcore/action-build@v1
         id: build
       - name: Lint snap


### PR DESCRIPTION
## Summary

- `snap-build`, `snap-publish`, `flatpak-build`, and `jpackage-build` workflows were checking out the repo without Git LFS, causing `.onnx` model files to be checked out as LFS pointers
- These pointer files got bundled into the JAR, making the Tiny model unavailable at runtime (`ModelFileManager` correctly detects and rejects LFS pointers)
- Added `lfs: true` to `actions/checkout` in all four affected workflows