### PR TITLE
fix: kill app immediately on fatal startup errors

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/plugins/recorder/GStreamerRecorder.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/plugins/recorder/GStreamerRecorder.kt
@@ -1,6 +1,7 @@
 package com.zugaldia.speedofsound.app.plugins.recorder
 
 import com.zugaldia.speedofsound.app.ENV_DISABLE_GSTREAMER
+import com.zugaldia.speedofsound.core.FatalStartupException
 import com.zugaldia.speedofsound.core.audio.AudioInputDevice
 import com.zugaldia.speedofsound.core.audio.AudioManager
 import com.zugaldia.speedofsound.core.plugins.recorder.RecorderEvent
@@ -82,7 +83,7 @@ class GStreamerRecorder(
             val errorMsg = "Failed to initialize GStreamer: ${e.message}. " +
                 "Ensure GStreamer is installed, or set $ENV_DISABLE_GSTREAMER=true to use the fallback recorder."
             log.error(errorMsg, e)
-            throw IllegalStateException(errorMsg, e)
+            throw FatalStartupException(errorMsg)
         }
     }
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -109,7 +109,7 @@ class MainViewModel(
                     false
                 }
             } catch (e: FatalStartupException) {
-                logger.error(e.message)
+                logger.error("A fatal error was encountered during startup.", e)
                 exitProcess(1)
             }
         }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -21,6 +21,7 @@ import com.zugaldia.speedofsound.core.desktop.settings.KEY_TEXT_PROCESSING_ENABL
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_VOICE_MODEL_PROVIDERS
 import com.zugaldia.speedofsound.core.desktop.settings.SettingsClient
 import com.zugaldia.speedofsound.core.languageFromIso2
+import com.zugaldia.speedofsound.core.FatalStartupException
 import com.zugaldia.speedofsound.core.plugins.AppPluginCategory
 import com.zugaldia.speedofsound.core.plugins.AppPluginRegistry
 import com.zugaldia.speedofsound.core.plugins.director.DefaultDirector
@@ -28,6 +29,7 @@ import com.zugaldia.speedofsound.core.plugins.director.DirectorEvent
 import com.zugaldia.speedofsound.core.plugins.director.PipelineStage
 import com.zugaldia.speedofsound.core.plugins.recorder.JvmRecorder
 import com.zugaldia.speedofsound.core.plugins.recorder.RecorderEvent
+import kotlin.system.exitProcess
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -96,14 +98,19 @@ class MainViewModel(
         // Phase 2 (async, IO thread): Enable plugins (heavy: model extraction + ONNX load).
         state.updateStage(AppStage.LOADING)
         viewModelScope.launch(Dispatchers.IO) {
-            registry.setActiveById(AppPluginCategory.RECORDER, recorder.id)
-            asrProviderManager.activateSelectedProvider()
-            llmProviderManager.activateSelectedProvider()
-            registry.setActiveById(AppPluginCategory.DIRECTOR, DefaultDirector.ID)
-            portalsSessionManager.initialize(viewModelScope)
-            GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
-                state.updateStage(AppStage.IDLE)
-                false
+            try {
+                registry.setActiveById(AppPluginCategory.RECORDER, recorder.id)
+                asrProviderManager.activateSelectedProvider()
+                llmProviderManager.activateSelectedProvider()
+                registry.setActiveById(AppPluginCategory.DIRECTOR, DefaultDirector.ID)
+                portalsSessionManager.initialize(viewModelScope)
+                GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
+                    state.updateStage(AppStage.IDLE)
+                    false
+                }
+            } catch (e: FatalStartupException) {
+                logger.error(e.message)
+                exitProcess(1)
             }
         }
     }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/FatalStartupException.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/FatalStartupException.kt
@@ -1,0 +1,7 @@
+package com.zugaldia.speedofsound.core
+
+/**
+ * Thrown when the application encounters an unrecoverable error during startup.
+ * The application should log the message and exit immediately without attempting recovery.
+ */
+open class FatalStartupException(message: String) : Exception(message)

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/models/voice/ModelFileManager.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/models/voice/ModelFileManager.kt
@@ -1,5 +1,6 @@
 package com.zugaldia.speedofsound.core.models.voice
 
+import com.zugaldia.speedofsound.core.FatalStartupException
 import java.io.File
 import java.nio.file.Path
 import org.slf4j.Logger
@@ -86,7 +87,7 @@ class ModelFileManager(private val pathProvider: PathProvider, private val fileS
             }
 
             if (isLfsPointer(outputFile)) {
-                throw IllegalStateException(
+                throw FatalStartupException(
                     "Model file '${component.name}' is a Git LFS pointer, not a real model file. " +
                         "The repository was likely cloned without Git LFS. " +
                         "See CONTRIBUTING.md for setup instructions."

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaWhisperAsr.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaWhisperAsr.kt
@@ -4,6 +4,7 @@ import com.k2fsa.sherpa.onnx.OfflineModelConfig
 import com.k2fsa.sherpa.onnx.OfflineRecognizer
 import com.k2fsa.sherpa.onnx.OfflineRecognizerConfig
 import com.k2fsa.sherpa.onnx.OfflineWhisperModelConfig
+import com.zugaldia.speedofsound.core.FatalStartupException
 import com.zugaldia.speedofsound.core.Language
 import com.zugaldia.speedofsound.core.audio.AudioManager
 import com.zugaldia.speedofsound.core.models.voice.ModelManager
@@ -31,15 +32,18 @@ class SherpaWhisperAsr(
         createRecognizer()
     }
 
-    private fun createRecognizer() {
-        val modelManager = ModelManager()
-
-        // Extract the default model on the first run (NO-OP otherwise)
+    private fun extractDefaultModelIfNeeded(modelManager: ModelManager) {
         if (currentOptions.modelId == DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID) {
             modelManager.extractDefaultModel().onFailure { error ->
+                if (error is FatalStartupException) throw error
                 throw IllegalStateException("Failed to extract default model: ${error.message}", error)
             }
         }
+    }
+
+    private fun createRecognizer() {
+        val modelManager = ModelManager()
+        extractDefaultModelIfNeeded(modelManager)
 
         // Validate model exists in the registry and is downloaded
         val model = SUPPORTED_SHERPA_WHISPER_ASR_MODELS[currentOptions.modelId]

--- a/core/src/test/kotlin/com/zugaldia/speedofsound/core/models/voice/ModelFileManagerTest.kt
+++ b/core/src/test/kotlin/com/zugaldia/speedofsound/core/models/voice/ModelFileManagerTest.kt
@@ -1,5 +1,6 @@
 package com.zugaldia.speedofsound.core.models.voice
 
+import com.zugaldia.speedofsound.core.FatalStartupException
 import com.zugaldia.speedofsound.core.plugins.asr.AsrProvider
 import java.io.InputStream
 import java.nio.file.Path
@@ -77,7 +78,7 @@ class ModelFileManagerTest {
                     lfsPointerPath.toFile().inputStream()
             }
 
-            val exception = assertFailsWith<IllegalStateException> {
+            val exception = assertFailsWith<FatalStartupException> {
                 manager.extractDefaultModelFromResources("test-model", testModel, lfsPointerResourceLoader)
                     .getOrThrow()
             }


### PR DESCRIPTION
## Summary

- Introduces `FatalStartupException` as a typed signal for unrecoverable startup failures
- Phase 2 startup in `MainViewModel` now catches `FatalStartupException`, logs the message, and calls `exitProcess(1)` — preventing a silent coroutine crash that left the app stuck in `LOADING` forever
- Fixes an infinite settings-change loop: when no ASR provider is configured, the fallback path emits a `KEY_SELECTED_VOICE_MODEL_PROVIDER_ID` event which re-triggered `activateSelectedProvider()` indefinitely
- LFS pointer detection in `ModelFileManager` now throws `FatalStartupException` (previously `IllegalStateException`)
- GStreamer init failure in `GStreamerRecorder` now throws `FatalStartupException` (previously `IllegalStateException`)
- `SherpaWhisperAsr` extracts the default-model setup into `extractDefaultModelIfNeeded()` to stay within detekt's `ThrowsCount` limit, and re-throws `FatalStartupException` unwrapped so it reaches the Phase 2 catch