### PR TITLE
feat: add Start/Stop buttons to main window

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/AppConstants.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/AppConstants.kt
@@ -15,8 +15,8 @@ const val MIN_ADW_MINOR_VERSION = 5
 const val ADW_MAX_LENGTH_MIN_MAJOR_VERSION = 1
 const val ADW_MAX_LENGTH_MIN_MINOR_VERSION = 6
 
-const val DEFAULT_WINDOW_WIDTH = 425
-const val DEFAULT_WINDOW_HEIGHT = 225
+const val DEFAULT_WINDOW_WIDTH = 450
+const val DEFAULT_WINDOW_HEIGHT = 275
 
 const val DEFAULT_PREFERENCES_DIALOG_WIDTH = 800
 const val DEFAULT_PREFERENCES_DIALOG_HEIGHT = 800
@@ -33,6 +33,8 @@ const val DEFAULT_MARGIN = 10
 const val DEFAULT_BOX_SPACING = 10
 
 const val SETTINGS_SAVE_DEBOUNCE_MS = 500
+
+const val SEPARATOR_CHARACTER = "·"
 
 // Adw CSS style classes
 // https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1-latest/style-classes.html

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/AudioWidget.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/AudioWidget.kt
@@ -2,25 +2,45 @@ package com.zugaldia.speedofsound.app.screens.main
 
 import com.zugaldia.speedofsound.app.DEFAULT_BOX_SPACING
 import com.zugaldia.speedofsound.app.DEFAULT_PROGRESS_BAR_WIDTH
+import com.zugaldia.speedofsound.app.SEPARATOR_CHARACTER
 import com.zugaldia.speedofsound.core.APPLICATION_SHORTCUT_TRIGGER
 import org.gnome.glib.GLib
-import org.slf4j.LoggerFactory
 import org.gnome.gtk.Align
 import org.gnome.gtk.Box
+import org.gnome.gtk.Button
 import org.gnome.gtk.Justification
 import org.gnome.gtk.Label
 import org.gnome.gtk.Orientation
 import org.gnome.gtk.ProgressBar
 
-class AudioWidget : Box(Orientation.VERTICAL, DEFAULT_BOX_SPACING) {
-    private val logger = LoggerFactory.getLogger(AudioWidget::class.java)
-
+class AudioWidget(
+    private val onToggle: () -> Unit,
+) : Box(Orientation.VERTICAL, DEFAULT_BOX_SPACING) {
     private val progressBar = ProgressBar().apply {
         setSizeRequest(DEFAULT_PROGRESS_BAR_WIDTH, -1)
         fraction = 0.0
     }
 
     private var isPulsating: Boolean = false
+    private var hasGrabbedFocus: Boolean = false
+    private var isPortalsReady: Boolean = false
+    private var currentStage: AppStage = AppStage.LOADING
+
+    private val startButton = Button.withLabel("Start").apply {
+        tooltipText = "Window will minimize automatically after transcription"
+        onClicked { onToggle() }
+    }
+
+    private val stopButton = Button.withLabel("Stop").apply {
+        sensitive = false
+        onClicked { onToggle() }
+    }
+
+    private val controlsBox = Box(Orientation.HORIZONTAL, DEFAULT_BOX_SPACING).apply {
+        halign = Align.CENTER
+        append(startButton)
+        append(stopButton)
+    }
 
     private val statusLabel = Label(INITIAL_LOADING_MESSAGE).apply {
         cssClasses = arrayOf("dim-label")
@@ -35,16 +55,31 @@ class AudioWidget : Box(Orientation.VERTICAL, DEFAULT_BOX_SPACING) {
         valign = Align.CENTER
         spacing = 2 * DEFAULT_BOX_SPACING
         append(progressBar)
+        append(controlsBox)
         append(statusLabel)
     }
 
     fun setStage(stage: AppStage) {
+        currentStage = stage
+        startButton.label = when (stage) {
+            AppStage.LOADING, AppStage.IDLE -> "Start"
+            AppStage.LISTENING -> "Listening..."
+            AppStage.TRANSCRIBING -> "Transcribing..."
+            AppStage.POLISHING -> "${polishingMessages.random()}..."
+        }
+
         statusLabel.label = when (stage) {
             AppStage.LOADING -> INITIAL_LOADING_MESSAGE
-            AppStage.IDLE -> "Tap <tt>$APPLICATION_SHORTCUT_TRIGGER</tt> to start/stop listening"
-            AppStage.LISTENING -> "Listening...\n<tt>Esc</tt> to cancel"
-            AppStage.TRANSCRIBING -> "Transcribing...\n<tt>Esc</tt> to cancel"
-            AppStage.POLISHING -> "${polishingMessages.random()}...\n<tt>Esc</tt> to cancel"
+            AppStage.IDLE -> "Or use <tt>$APPLICATION_SHORTCUT_TRIGGER</tt> to start and stop"
+            else -> "<tt>Esc</tt> to cancel $SEPARATOR_CHARACTER the window minimizes when done"
+        }
+
+        startButton.sensitive = stage == AppStage.IDLE && isPortalsReady
+        stopButton.sensitive = stage == AppStage.LISTENING
+
+        if (stage == AppStage.IDLE && !hasGrabbedFocus) {
+            hasGrabbedFocus = true
+            startButton.grabFocus()
         }
 
         val shouldPulsate = stage in listOf(AppStage.LOADING, AppStage.TRANSCRIBING, AppStage.POLISHING)
@@ -69,6 +104,11 @@ class AudioWidget : Box(Orientation.VERTICAL, DEFAULT_BOX_SPACING) {
 
     fun setRecordingLevel(level: Double) {
         progressBar.fraction = level.coerceIn(0.0, 1.0)
+    }
+
+    fun setPortalsReady(ready: Boolean) {
+        isPortalsReady = ready
+        startButton.sensitive = currentStage == AppStage.IDLE && isPortalsReady
     }
 
     companion object {

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/BannerWidget.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/BannerWidget.kt
@@ -1,11 +1,10 @@
 package com.zugaldia.speedofsound.app.screens.main
 
-import com.zugaldia.speedofsound.core.APPLICATION_NAME
 import org.gnome.adw.Banner
 
-fun buildBannerWidget(onStart: () -> Unit): Banner =
-    Banner("Allow $APPLICATION_NAME to type for you.").apply {
-        setButtonLabel("Start")
-        onButtonClicked { onStart() }
+fun buildBannerWidget(onAllow: () -> Unit): Banner =
+    Banner("Permission required to enable typing").apply {
+        buttonLabel = "Allow"
+        onButtonClicked { onAllow() }
         revealed = false
     }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
@@ -60,7 +60,7 @@ class MainWindow(
         })
 
         portalsBanner = buildBannerWidget { viewModel.startPortalsSession() }
-        audioWidget = AudioWidget()
+        audioWidget = AudioWidget(onToggle = { viewModel.toggleListening() })
         statusWidget = StatusWidget()
 
         val contentBox = Box.builder()
@@ -131,6 +131,7 @@ class MainWindow(
             SIGNAL_PORTALS_RESTORE_TOKEN_MISSING,
             MainState.PortalsRestoreTokenMissingChanged { missing: Boolean ->
                 portalsBanner.revealed = missing
+                audioWidget.setPortalsReady(!missing)
             }
         )
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/StatusWidget.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/StatusWidget.kt
@@ -2,6 +2,7 @@ package com.zugaldia.speedofsound.app.screens.main
 
 import com.zugaldia.speedofsound.app.DEFAULT_BOX_SPACING
 import com.zugaldia.speedofsound.app.DEFAULT_MARGIN
+import com.zugaldia.speedofsound.app.SEPARATOR_CHARACTER
 import org.gnome.gtk.Align
 import org.gnome.gtk.Box
 import org.gnome.gtk.Label
@@ -15,7 +16,6 @@ class StatusWidget : Box() {
     private val languageLabel: Label
 
     companion object {
-        private const val SEPARATOR_CHARACTER = "·"
         private const val MAX_MODEL_LABEL_LENGTH = 15
     }
 


### PR DESCRIPTION
## Summary

- Add **Start** and **Stop** buttons to the main window between the progress bar and status label
- Start button label reflects the active stage (Listening..., Transcribing..., polishing message)
- Button sensitivity is stage-driven: Start enabled only in IDLE, Stop only in LISTENING; both disabled otherwise
- Start button is also gated on the portal session being ready (fixes silent pipeline failure when permissions not yet granted)
- Both buttons call `toggleListening()`, matching the Super+Z keyboard shortcut behavior
- Start button grabs focus on first transition to IDLE (after the widget is realized)
- Status label simplified to a single line; shortcut hint updated to "Or use ⌘Z to start and stop"
- Tooltip on Start button warns that the window minimizes after transcription
- Banner updated: message → "Permission required to enable typing", button → "Allow" (avoids two "Start" buttons)
- `SEPARATOR_CHARACTER` promoted from `StatusWidget` companion to `AppConstants`
- Window size bumped from 425×225 to 450×275