### PR TITLE
docs: update Flathub metainfo screenshots and captions

### DIFF
--- a/data/io.speedofsound.SpeedOfSound.metainfo.xml.in
+++ b/data/io.speedofsound.SpeedOfSound.metainfo.xml.in
@@ -42,16 +42,16 @@
 
     <screenshots>
         <screenshot type="default">
-            <caption>The main window</caption>
-            <image>https://www.speedofsound.io/assets/screenshots/main-light.png</image>
+            <caption>Voice typing into the default text editor</caption>
+            <image>https://www.speedofsound.io/assets/screenshots/demo-light.png</image>
         </screenshot>
         <screenshot>
             <caption>The model library</caption>
             <image>https://www.speedofsound.io/assets/screenshots/preferences-light.png</image>
         </screenshot>
         <screenshot>
-            <caption>Keyboard shortcuts</caption>
-            <image>https://www.speedofsound.io/assets/screenshots/shortcuts-light.png</image>
+            <caption>Add personal context and custom words to improve accuracy</caption>
+            <image>https://www.speedofsound.io/assets/screenshots/preferences-personalization-light.png</image>
         </screenshot>
     </screenshots>
 


### PR DESCRIPTION
## Summary

- Replace main window screenshot with demo screenshot showing voice typing in action
- Replace keyboard shortcuts screenshot with personalization page (custom context and vocabulary)
- Update captions to be clearer and more user-facing for the Flathub store listing