### PR TITLE
Fix typing error propagation and add non-Latin docs

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -315,9 +315,11 @@ class MainViewModel(
             val finalText = event.finalResult.trim() + suffix
             val sanitize = settingsClient.getSanitizeSpecialChars()
             TextUtils.textToKeySym(finalText, filterNoKeySym = false, sanitize = sanitize)
-                .onSuccess { keySyms -> portalsClient.typeText(keySyms, settingsClient.getTypingDelayMs().toLong()) }
+                .mapCatching { keySyms ->
+                    portalsClient.typeText(keySyms, settingsClient.getTypingDelayMs().toLong()).getOrThrow()
+                }
                 .onFailure { error ->
-                    logger.error("Error converting text to key symbols: ${error.message}")
+                    logger.error("Error typing text: ${error.message}")
                     portalsClient.showNotification(body = "Failed to type text: ${error.message ?: "Unknown error"}")
                 }
         }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
@@ -162,11 +162,11 @@ class PortalsClient {
      * @param delayMs Delay in milliseconds between consecutive keystrokes. Set to 0 to disable.
      * Increase this if characters are dropped or appear out of order (or like a slower typing effect).
      */
-    suspend fun typeText(text: List<Int>, delayMs: Long) {
+    suspend fun typeText(text: List<Int>, delayMs: Long): Result<Unit> = runCatching {
         logger.info("Typing ${text.size} characters.")
         for (key in text) {
-            portal.remoteDesktop.notifyKeyboardKeySym(key, InputState.PRESSED)
-            portal.remoteDesktop.notifyKeyboardKeySym(key, InputState.RELEASED)
+            portal.remoteDesktop.notifyKeyboardKeySym(key, InputState.PRESSED).getOrThrow()
+            portal.remoteDesktop.notifyKeyboardKeySym(key, InputState.RELEASED).getOrThrow()
             if (delayMs > 0) delay(delayMs)
         }
     }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,41 @@
 # Troubleshooting
 
+## Non-Latin text produces only spaces and punctuation
+
+**Symptom:** Dictating in a non-Latin language (e.g., Cyrillic, Arabic, CJK) outputs only spaces
+and punctuation. Latin-script languages work fine.
+
+**Why this happens:** Speed of Sound sends keystrokes through the XDG Remote Desktop Portal.
+The compositor interprets them using the currently active keyboard layout. If no matching layout
+is active, non-Latin keysyms are silently dropped.
+
+**How to fix it:** Add the appropriate keyboard layout in your system's keyboard or input source
+settings and switch to it before dictating. For example, on GNOME, this is under `Settings` → `Keyboard` →
+`Input Sources`. You can switch between input sources with `Super` + `Space`. 
+
+## Transcribed text is incomplete
+
+**Symptom:** Typically, the beginning of the text is missing.
+
+**Why this happens:** After transcription, Speed of Sound minimizes or hides its main window,
+waits briefly to give the desktop environment time to do so, and then starts typing.
+If the wait is too short, the first few characters will be lost because they land in the
+Speed of Sound window rather than your target application.
+
+**How to fix it:** Increase the **Post-hide delay** in `Preferences` → `Advanced`. This is the pause
+between the window hiding and the first keystroke. Alternatively, enable **Record in background** (see above).
+
+## Some characters are missing or appear out of order
+
+**Symptom:** The transcribed text arrives with letters dropped or jumbled.
+
+**Why this happens:** Some applications cannot process keystrokes as fast as Speed of Sound sends them,
+causing characters to be lost or reordered.
+
+**How to fix it:** Increase the **Typing delay** in `Preferences` → `Advanced`. This adds a pause
+between each individual keystroke. You can also increase this value if you simply like the effect of
+text appearing more gradually.
+
 ## Speed of Sound appears on the wrong workspace and doesn't type into my active application
 
 **Symptom:** On a multi-workspace setup, the main Speed of Sound window opens on a different workspace,
@@ -28,29 +64,3 @@ When active, recording, transcription, and typing all run silently without showi
 **Note:** Because Speed of Sound uses the Desktop Portals standard, your desktop environment will still
 display a microphone in-use indicator while recording is active and while the app has typing permissions.
 This serves as a lightweight substitute for the in-app progress display.
-
-## Transcribed text is incomplete
-
-**Symptom:** Typically, the beginning of the text is missing.
-
-**Why this happens:** After transcription, Speed of Sound minimizes or hides its main window,
-waits briefly to give the desktop environment time to do so, and then starts typing.
-If the wait is too short, the first few characters will be lost because they land in the
-Speed of Sound window rather than your target application.
-
-**How to fix it:** Increase the **Post-hide delay** in `Preferences` → `Advanced`. This is the pause
-between the window hiding and the first keystroke. Alternatively, enable **Record in background** (see above).
-
-## Some characters are missing or appear out of order
-
-**Symptom:** The transcribed text arrives incomplete or with letters jumbled.
-
-**Why this happens:** Two things can cause this. First, some applications can't process
-keystrokes as fast as Speed of Sound sends them, causing dropped or reordered characters. Second, some desktop
-environments have trouble typing special characters like tildes or the `ñ` in `piñata`.
-
-**How to fix it:** Increase the **Typing delay** in `Preferences` → `Advanced`. This is the pause
-between each individual keystroke. You can also increase this value if you simply like the effect of
-text appearing more gradually. For special characters, Speed of Sound does some automatic sanitization
-(for example, replacing `á` with `a` or `ñ` with `n`). Customizing these substitutions is not currently supported.
-If the current behavior doesn't work for your use case, [let us know](https://www.speedofsound.io/support/).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -47,8 +47,14 @@ configuration to personalization and backup.
 entirely in the background. You can still access the window at any time from the dock.
 Set the primary language used for speech recognition in the **Language** section. You can optionally configure
 a secondary language and switch between the two using the `Left Shift` and `Right Shift` keys while the main window
-is focused. The **Output** section lets you configure how transcription results are delivered. Here you can enable
-**Append space after transcription** to automatically insert a trailing space after each result, which is useful
+is focused. The **Output** section lets you configure how transcription results are delivered.
+
+!!! note "Non-Latin scripts require a matching keyboard layout"
+    If you dictate in a non-Latin script, make sure the matching keyboard layout is active on your system
+    before dictating. See [Troubleshooting](troubleshooting.md#non-latin-text-produces-only-spaces-and-punctuation)
+    for details.
+
+Here you can enable **Append space after transcription** to automatically insert a trailing space after each result, which is useful
 when dictating consecutive sentences independently.
 
 **Model Library** — Browse and manage the locally available voice models. You can download new models or remove


### PR DESCRIPTION
## Summary

- **`PortalsClient.typeText`** now returns `Result<Unit>` and calls `getOrThrow()` on each D-Bus keystroke call, so errors are no longer silently swallowed
- **`MainViewModel`** chains the typing result with `mapCatching`/`getOrThrow` so both keysym-conversion and D-Bus typing failures surface via notification
- **Troubleshooting docs**: new section explaining why non-Latin scripts produce only spaces/punctuation (missing keyboard layout) and how to fix it; reordered existing sections; removed outdated special-character sanitization text
- **User guide**: added admonition note about non-Latin keyboard layout requirement in the Output settings section

## Test plan

- [ ] Dictate Latin text — verify typing works as before
- [ ] Dictate non-Latin text without matching layout — verify error notification appears
- [ ] Dictate non-Latin text with matching layout active — verify correct output
- [ ] Verify troubleshooting and user guide pages render correctly