### PR TITLE
docs: add troubleshooting section for resetting global shortcut

### DIFF
--- a/docs/keyboard-shortcut.md
+++ b/docs/keyboard-shortcut.md
@@ -31,6 +31,11 @@ which is supported across desktop environments like GNOME and KDE, on both X11 a
 Once set up, the Preferences page will update to show the shortcut(s) you selected. That's it.
 You can now trigger Speed of Sound from anywhere.
 
+!!! tip "Need to change or reset your shortcut?"
+    If the **Configure** button is not available on your desktop, see the
+    [troubleshooting guide](troubleshooting.md#i-cannot-change-or-reset-my-global-shortcut)
+    for alternative options.
+
 ## Option 2: Use Your Desktop Environment Settings
 
 In this step, you will manually assign a global keyboard shortcut using your desktop environment settings.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,6 +51,30 @@ A hidden window is typically restored on the active workspace instead.
 **Trade-off:** The app no longer appears in the dock. To bring the main window back, you can, for example, use a
 global shortcut (`Preferences` → `General` → `Global Shortcut`).
 
+## I cannot change or reset my global shortcut
+
+**Symptom:** A global shortcut was set up via the Preferences dialog, but the shortcut no longer works
+(or was set incorrectly), and there is no way to change or clear it from the UI.
+
+**Why this happens:** Speed of Sound uses the
+[`ConfigureShortcuts`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GlobalShortcuts.html#org-freedesktop-portal-globalshortcuts-configureshortcuts)
+portal method to let you reassign your shortcut after initial setup. This method was added recently and is
+only available on newer desktop environments, so Speed of Sound only shows the **Configure** button when it
+detects support for it. If the button is absent, your desktop does not yet expose that capability.
+
+**How to fix it:** You have two options:
+
+1. **Switch to the manual method.** Instead of the automatic portal-based setup, follow
+   [Option 2](keyboard-shortcut.md#option-2-use-your-desktop-environment-settings) in the keyboard shortcut
+   documentation to assign a shortcut directly in your desktop environment settings. This gives you full
+   control over the key combination and lets you change or remove it at any time.
+
+2. **Reset the shortcut from the command line.** Follow the
+   [testing instructions](https://github.com/zugaldia/stargate/blob/main/docs/TESTING.md) from the Stargate
+   project, replacing the application ID with `io.speedofsound.SpeedOfSound`. This will delete the existing
+   shortcut binding. Restart Speed of Sound afterward, the **Set Up** button will reappear, and you can
+   configure a new shortcut.
+
 ## I don't want the Speed of Sound main window to show every time I dictate.
 
 **Symptom:** The main window appears on every dictation, which feels intrusive for frequent voice typing.


### PR DESCRIPTION
## Summary

- Adds a new troubleshooting entry ("I cannot change or reset my global shortcut") explaining why the **Configure** button may be absent (`ConfigureShortcuts` is a recent portal addition) and providing two workarounds: switch to manual setup or reset via the Stargate CLI instructions.
- Adds a highlighted tip block at the end of Option 1 in `keyboard-shortcut.md` linking to the new section.

Related to #121