### PR TITLE
feat: add "Stay hidden on activation" setting

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/App.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/App.kt
@@ -70,7 +70,7 @@ class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Appl
                     settingsClient.setWelcomeScreenShown(true)
                     mainWindow?.present()
                 }.present()
-            } else {
+            } else if (!settingsClient.getStayHiddenOnActivation()) {
                 mainWindow?.present()
             }
         }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
@@ -52,6 +52,9 @@ class PreferencesViewModel(
     fun getHideInsteadOfMinimize(): Boolean = settingsClient.getHideInsteadOfMinimize()
     fun setHideInsteadOfMinimize(value: Boolean): Boolean = settingsClient.setHideInsteadOfMinimize(value)
 
+    fun getStayHiddenOnActivation(): Boolean = settingsClient.getStayHiddenOnActivation()
+    fun setStayHiddenOnActivation(value: Boolean): Boolean = settingsClient.setStayHiddenOnActivation(value)
+
     fun getDefaultLanguage(): String = settingsClient.getDefaultLanguage()
     fun setDefaultLanguage(value: String): Boolean = settingsClient.setDefaultLanguage(value)
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
@@ -20,6 +20,7 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
     private val logger = LoggerFactory.getLogger(GeneralPage::class.java)
     private val scope = viewModel.viewModelScope
 
+    private val stayHiddenOnActivationRow: SwitchRow
     private val backgroundRecordingRow: SwitchRow
     private val hideInsteadOfMinimizeRow: SwitchRow
     private val primaryComboRow: LanguageComboRow
@@ -90,6 +91,12 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
             add(secondaryComboRow)
         }
 
+        stayHiddenOnActivationRow = SwitchRow().apply {
+            title = "Stay hidden on activation"
+            subtitle = "Launch without showing the main window. Use the shortcut to start voice typing."
+            active = viewModel.getStayHiddenOnActivation()
+        }
+
         backgroundRecordingRow = SwitchRow().apply {
             title = "Record in background"
             subtitle = "Keep the main window hidden while listening."
@@ -104,6 +111,7 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
 
         val behaviorGroup = PreferencesGroup().apply {
             title = "App Behavior"
+            add(stayHiddenOnActivationRow)
             add(backgroundRecordingRow)
             add(hideInsteadOfMinimizeRow)
         }
@@ -129,6 +137,9 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
         // Set up notifications after all widgets are initialized
         primaryComboRow.setupNotifications()
         secondaryComboRow.setupNotifications()
+        stayHiddenOnActivationRow.onNotify("active") {
+            viewModel.setStayHiddenOnActivation(stayHiddenOnActivationRow.active)
+        }
         backgroundRecordingRow.onNotify("active") { viewModel.setBackgroundRecording(backgroundRecordingRow.active) }
         hideInsteadOfMinimizeRow.onNotify("active") {
             viewModel.setHideInsteadOfMinimize(hideInsteadOfMinimizeRow.active)
@@ -139,6 +150,7 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
     fun refresh() {
         primaryComboRow.refresh()
         secondaryComboRow.refresh()
+        stayHiddenOnActivationRow.active = viewModel.getStayHiddenOnActivation()
         backgroundRecordingRow.active = viewModel.getBackgroundRecording()
         hideInsteadOfMinimizeRow.active = viewModel.getHideInsteadOfMinimize()
         appendSpaceRow.active = viewModel.getAppendSpace()

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/importexport/ImportExportManager.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/importexport/ImportExportManager.kt
@@ -32,6 +32,7 @@ class ImportExportManager(private val viewModel: PreferencesViewModel) {
             secondaryLanguage = viewModel.getSecondaryLanguage(),
             backgroundRecording = viewModel.getBackgroundRecording(),
             hideInsteadOfMinimize = viewModel.getHideInsteadOfMinimize(),
+            stayHiddenOnActivation = viewModel.getStayHiddenOnActivation(),
             appendSpace = viewModel.getAppendSpace(),
             credentials = viewModel.getCredentials(),
             voiceModelProviders = viewModel.getVoiceModelProviders()
@@ -63,6 +64,7 @@ class ImportExportManager(private val viewModel: PreferencesViewModel) {
         viewModel.setSecondaryLanguage(exportData.secondaryLanguage)
         viewModel.setBackgroundRecording(exportData.backgroundRecording)
         viewModel.setHideInsteadOfMinimize(exportData.hideInsteadOfMinimize)
+        viewModel.setStayHiddenOnActivation(exportData.stayHiddenOnActivation)
         viewModel.setAppendSpace(exportData.appendSpace)
         viewModel.setSanitizeSpecialChars(exportData.sanitizeSpecialChars)
         viewModel.setPostHideDelayMs(exportData.postHideDelayMs)

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
@@ -153,6 +153,14 @@ class SettingsClient(val settingsStore: SettingsStore) {
             if (success) _settingsChanged.tryEmit(KEY_HIDE_INSTEAD_OF_MINIMIZE)
         }
 
+    fun getStayHiddenOnActivation(): Boolean =
+        settingsStore.getBoolean(KEY_STAY_HIDDEN_ON_ACTIVATION, DEFAULT_STAY_HIDDEN_ON_ACTIVATION)
+
+    fun setStayHiddenOnActivation(value: Boolean): Boolean =
+        settingsStore.setBoolean(KEY_STAY_HIDDEN_ON_ACTIVATION, value).also { success ->
+            if (success) _settingsChanged.tryEmit(KEY_STAY_HIDDEN_ON_ACTIVATION)
+        }
+
     /*
      * Cloud Credentials page
      */

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
@@ -30,6 +30,9 @@ const val DEFAULT_BACKGROUND_RECORDING = false
 const val KEY_HIDE_INSTEAD_OF_MINIMIZE = "hide-instead-of-minimize"
 const val DEFAULT_HIDE_INSTEAD_OF_MINIMIZE = false
 
+const val KEY_STAY_HIDDEN_ON_ACTIVATION = "stay-hidden-on-activation"
+const val DEFAULT_STAY_HIDDEN_ON_ACTIVATION = false
+
 const val KEY_APPEND_SPACE = "append-space"
 const val DEFAULT_APPEND_SPACE = false
 

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsModels.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsModels.kt
@@ -70,6 +70,7 @@ data class SettingsExport(
     val secondaryLanguage: String = DEFAULT_SECONDARY_LANGUAGE.iso2,
     val backgroundRecording: Boolean = DEFAULT_BACKGROUND_RECORDING,
     val hideInsteadOfMinimize: Boolean = DEFAULT_HIDE_INSTEAD_OF_MINIMIZE,
+    val stayHiddenOnActivation: Boolean = DEFAULT_STAY_HIDDEN_ON_ACTIVATION,
     val appendSpace: Boolean = DEFAULT_APPEND_SPACE,
     val credentials: List<CredentialSetting> = emptyList(),
     val voiceModelProviders: List<VoiceModelProviderSetting> = emptyList(),

--- a/data/io.speedofsound.SpeedOfSound.gschema.xml
+++ b/data/io.speedofsound.SpeedOfSound.gschema.xml
@@ -46,6 +46,11 @@
       <summary>Hide instead of minimize</summary>
       <description>When enabled, the main window is hidden instead of minimized when not in use. Useful for multi-workspace setups.</description>
     </key>
+    <key name="stay-hidden-on-activation" type="b">
+      <default>false</default>
+      <summary>Stay hidden on activation</summary>
+      <description>When enabled, the app starts without showing the main window. The global shortcut still works normally.</description>
+    </key>
 
     <!-- Cloud Credentials page -->
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,26 +42,45 @@ configuration to personalization and backup.
 ![Preferences](assets/screenshots/preferences-light.png#only-light)
 ![Preferences](assets/screenshots/preferences-dark.png#only-dark)
 
-**General** — The **App Behavior** section lets you configure how shortcut-triggered sessions behave. Enable
-**Record in background** to keep the main window hidden during recordings. In this case, the pipeline runs
-entirely in the background. You can still access the window at any time from the dock.
-Enable **Stay hidden on activation** to launch the app without showing the main window. This is useful when adding
-Speed of Sound to your system's startup applications — the app will be ready in the background immediately, and you
-can begin dictating using the global shortcut without any window appearing first.
-Set the primary language used for speech recognition in the **Language** section. You can optionally configure
-a secondary language and switch between the two using the `Left Shift` and `Right Shift` keys while the main window
-is focused. The **Output** section lets you configure how transcription results are delivered.
+### General
+
+There are 4 groups of settings here: Global Shortcut, Language, App Behavior, and Output.
+
+**Global Shortcut** — Described in more detail on the [Set Up a Keyboard Shortcut](keyboard-shortcut.md) page.
+
+**Language** — Set the primary language used for speech recognition. You can optionally configure a secondary
+language and switch between the two using the `Left Shift` and `Right Shift` keys while the main window is focused.
 
 !!! note "Non-Latin scripts require a matching keyboard layout"
     If you dictate in a non-Latin script, make sure the matching keyboard layout is active on your system
     before dictating. See [Troubleshooting](troubleshooting.md#non-latin-text-produces-only-spaces-and-punctuation)
     for details.
 
-Here you can enable **Append space after transcription** to automatically insert a trailing space after each result, which is useful
-when dictating consecutive sentences independently.
+**App Behavior** — Configure the general application flow:
 
-**Model Library** — Browse and manage the locally available voice models. You can download new models or remove
-ones you no longer need. Keep this window open while a download is in progress.
+- Enable **Stay hidden on activation** to launch the app without showing the main window. This is useful when adding
+Speed of Sound to your system's startup applications, the app will be ready in the background immediately, and you
+can begin dictating using the shortcut without any window appearing first.
+
+- Enable **Record in background** to keep the main window hidden during recordings. In this case, the pipeline runs
+entirely in the background. You can still access the window at any time from the dock.
+
+- Enable **Hide instead of minimize** to hide the main window instead of minimizing it when not in use. This is useful
+on multi-workspace setups where you want the window to restore on the current workspace.
+
+**Output** — Enable **Append space after transcription** to automatically insert a trailing space after each result,
+which is useful when dictating consecutive sentences independently.
+
+### Model Library
+
+Browse and manage the locally available voice models. You can download new models or remove ones you no longer need.
+Keep this window open while a download is in progress.
+
+### Cloud Credentials
+
+Store API keys for cloud services. Speed of Sound supports Anthropic, Google, and OpenAI directly, as well as any
+third-party provider that offers compatible endpoints, such as OpenRouter. Credentials saved here can be referenced
+when configuring voice or text model providers.
 
 !!! note "Cloud providers are optional"
     Using cloud providers is entirely optional and not required to use Speed of Sound.
@@ -69,21 +88,28 @@ ones you no longer need. Keep this window open while a download is in progress.
     or for cases where a large cloud-only model is needed to meet specific accuracy or latency requirements.
     See the [FAQ](faq.md) for more information.
 
-**Cloud Credentials** — Store API keys for cloud services. Speed of Sound supports Anthropic, Google, and OpenAI
-directly, as well as any third-party provider that offers compatible endpoints, such as OpenRouter.
-Credentials saved here can be referenced when configuring voice or text model providers.
+### Voice Models
 
-**Voice Models** — Configure the speech recognition provider used to transcribe your audio. By default,
-Speed of Sound transcribes locally using a Whisper model. You can add additional providers, including cloud-based ones,
-and select which one is active.
+Configure the speech recognition provider used to transcribe your audio. By default, Speed of Sound transcribes
+locally using a Whisper model. You can add additional providers, including cloud-based ones, and select which one
+is active.
 
-**Text Models** — Optionally enable an LLM to post-process your transcriptions for improved accuracy, grammar,
-and formatting. You can add one or more providers and choose which one is active. This step is disabled by default.
+### Text Models
 
-**Personalization** — Provide optional context to improve transcription quality. You can, for example, add
-information about your writing style and add custom vocabulary entries such as names, technical terms, or
-acronyms that the model should recognize.
+Optionally enable an LLM to post-process your transcriptions for improved accuracy, grammar, and formatting. You can
+add one or more providers and choose which one is active. This step is disabled by default.
 
-**Advanced** — Fine-tune low-level typing behavior. You can adjust the delay between hiding the main window and issuing keystrokes, as well as the delay between individual keystrokes. The defaults work well for most desktop environments and do not normally need to be changed.
+### Personalization
 
-**Import / Export** — Back up your preferences to a file, useful to set up Speed of Sound on a different machine.
+Provide optional context to improve transcription quality. You can, for example, add information about your writing
+style and add custom vocabulary entries such as names, technical terms, or acronyms that the model should recognize.
+
+### Advanced
+
+Fine-tune low-level typing behavior. You can adjust the delay between hiding the main window and issuing keystrokes,
+as well as the delay between individual keystrokes. The defaults work well for most desktop environments and do not
+normally need to be changed.
+
+### Import / Export
+
+Back up your preferences to a file, useful to set up Speed of Sound on a different machine.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -45,6 +45,9 @@ configuration to personalization and backup.
 **General** — The **App Behavior** section lets you configure how shortcut-triggered sessions behave. Enable
 **Record in background** to keep the main window hidden during recordings. In this case, the pipeline runs
 entirely in the background. You can still access the window at any time from the dock.
+Enable **Stay hidden on activation** to launch the app without showing the main window. This is useful when adding
+Speed of Sound to your system's startup applications — the app will be ready in the background immediately, and you
+can begin dictating using the global shortcut without any window appearing first.
 Set the primary language used for speech recognition in the **Language** section. You can optionally configure
 a secondary language and switch between the two using the `Left Shift` and `Right Shift` keys while the main window
 is focused. The **Output** section lets you configure how transcription results are delivered.


### PR DESCRIPTION
## Summary

- Adds a new **Stay hidden on activation** toggle in Preferences → General → App Behavior
- When enabled, the app launches without showing the main window — the global shortcut still works normally
- Designed for users who add Speed of Sound to system startup applications (closes #118)

## Changes

- `gschema.xml` — new `stay-hidden-on-activation` GSettings key
- `SettingsConstants` / `SettingsClient` — key constant, getter/setter, change emission
- `SettingsModels` — field added to `SettingsExport` (with default for backward compat)
- `PreferencesViewModel` — delegation to settings client
- `GeneralPage` — new `SwitchRow` wired with `onNotify` and `refresh()`
- `ImportExportManager` — included in both export and import
- `App.kt` — activation handler skips `present()` when setting is enabled
- `docs/user-guide.md` — usage note added