### PR TITLE
feat: add Moonshine V2 ASR support

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/settings/AsrProviderManager.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/settings/AsrProviderManager.kt
@@ -4,6 +4,8 @@ import com.zugaldia.speedofsound.core.Language
 import com.zugaldia.speedofsound.core.desktop.settings.SettingsClient
 import com.zugaldia.speedofsound.core.plugins.AppPluginCategory
 import com.zugaldia.speedofsound.core.plugins.AppPluginRegistry
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaMoonshineAsr
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaMoonshineAsrOptions
 import com.zugaldia.speedofsound.core.plugins.asr.SherpaWhisperAsr
 import com.zugaldia.speedofsound.core.plugins.asr.SherpaWhisperAsrOptions
 import com.zugaldia.speedofsound.core.plugins.asr.AsrPluginOptions
@@ -25,6 +27,7 @@ class AsrProviderManager(
     fun registerAsrPlugins() {
         registry.register(AppPluginCategory.ASR, OpenAiAsr())
         registry.register(AppPluginCategory.ASR, SherpaWhisperAsr())
+        registry.register(AppPluginCategory.ASR, SherpaMoonshineAsr())
     }
 
     /**
@@ -76,6 +79,7 @@ class AsrProviderManager(
         when (activePlugin) {
             is OpenAiAsr -> activePlugin.updateOptions(activePlugin.getOptions().copy(language = language))
             is SherpaWhisperAsr -> activePlugin.updateOptions(activePlugin.getOptions().copy(language = language))
+            is SherpaMoonshineAsr -> activePlugin.updateOptions(activePlugin.getOptions().copy(language = language))
         }
     }
 
@@ -94,6 +98,7 @@ class AsrProviderManager(
         when (plugin) {
             is OpenAiAsr -> plugin.updateOptions(options as OpenAiAsrOptions)
             is SherpaWhisperAsr -> plugin.updateOptions(options as SherpaWhisperAsrOptions)
+            is SherpaMoonshineAsr -> plugin.updateOptions(options as SherpaMoonshineAsrOptions)
         }
     }
 }

--- a/cli/src/main/kotlin/com/zugaldia/speedofsound/cli/AsrCommand.kt
+++ b/cli/src/main/kotlin/com/zugaldia/speedofsound/cli/AsrCommand.kt
@@ -13,6 +13,8 @@ import com.zugaldia.speedofsound.core.plugins.asr.DEFAULT_ASR_SHERPA_WHISPER_MOD
 import com.zugaldia.speedofsound.core.plugins.asr.AsrPlugin
 import com.zugaldia.speedofsound.core.plugins.asr.AsrRequest
 import com.zugaldia.speedofsound.core.plugins.asr.SherpaWhisperAsr
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaMoonshineAsr
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaMoonshineAsrOptions
 import com.zugaldia.speedofsound.core.plugins.asr.OpenAiAsr
 import com.zugaldia.speedofsound.core.plugins.asr.SherpaWhisperAsrOptions
 import com.zugaldia.speedofsound.core.plugins.asr.OpenAiAsrOptions
@@ -42,8 +44,8 @@ class AsrCommand : CliktCommand(name = "asr") {
 
     private val provider: String by option(
         "--provider", "-p",
-        help = "ASR provider to use (onnx, sherpa, or openai)"
-    ).default("sherpa")
+        help = "ASR provider to use (onnx, whisper, moonshine, or openai)"
+    ).default("whisper")
 
     private val apiKey: String? by option(
         "--api-key",
@@ -67,14 +69,15 @@ class AsrCommand : CliktCommand(name = "asr") {
         logger.info("Using provider: $provider, model: $modelId, language: ${language.name} ($languageCode)")
         val asr: AsrPlugin<*> = when (provider.lowercase()) {
             "onnx" -> OnnxWhisperAsr(OnnxWhisperAsrOptions())
-            "sherpa" -> SherpaWhisperAsr(SherpaWhisperAsrOptions(modelId = modelId, language = language))
+            "whisper" -> SherpaWhisperAsr(SherpaWhisperAsrOptions(modelId = modelId, language = language))
+            "moonshine" -> SherpaMoonshineAsr(SherpaMoonshineAsrOptions(modelId = modelId, language = language))
             "openai" -> OpenAiAsr(OpenAiAsrOptions(
                 baseUrl = baseUrl,
                 apiKey = apiKey,
                 modelId = modelId,
                 language = language
             ))
-            else -> throw IllegalArgumentException("Unknown provider: $provider. Use 'onnx', 'sherpa', or 'openai'.")
+            else -> throw IllegalArgumentException("Unknown provider: $provider. Use 'onnx', 'whisper', 'moonshine', or 'openai'.")
         }
 
         asr.initialize()

--- a/cli/src/main/kotlin/com/zugaldia/speedofsound/cli/AsrCommand.kt
+++ b/cli/src/main/kotlin/com/zugaldia/speedofsound/cli/AsrCommand.kt
@@ -77,7 +77,9 @@ class AsrCommand : CliktCommand(name = "asr") {
                 modelId = modelId,
                 language = language
             ))
-            else -> throw IllegalArgumentException("Unknown provider: $provider. Use 'onnx', 'whisper', 'moonshine', or 'openai'.")
+            else -> throw IllegalArgumentException(
+                "Unknown provider: $provider. Use 'onnx', 'whisper', 'moonshine', or 'openai'."
+            )
         }
 
         asr.initialize()

--- a/cli/src/main/kotlin/com/zugaldia/speedofsound/cli/DownloadCommand.kt
+++ b/cli/src/main/kotlin/com/zugaldia/speedofsound/cli/DownloadCommand.kt
@@ -7,6 +7,7 @@ import com.zugaldia.speedofsound.core.getDataDir
 import com.zugaldia.speedofsound.core.models.voice.ModelManager
 import com.zugaldia.speedofsound.core.models.voice.ModelManagerEvent
 import com.zugaldia.speedofsound.core.plugins.asr.DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
+import com.zugaldia.speedofsound.core.plugins.asr.SUPPORTED_SHERPA_MOONSHINE_ASR_MODELS
 import com.zugaldia.speedofsound.core.plugins.asr.SUPPORTED_SHERPA_WHISPER_ASR_MODELS
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -34,14 +35,15 @@ class DownloadCommand : CliktCommand(name = "download") {
     private fun listAvailableModels() {
         logger.info("Data folder: ${getDataDir()}")
         logger.info("Available models:")
-        SUPPORTED_SHERPA_WHISPER_ASR_MODELS.values.sortedBy { it.id }.forEach { model ->
+        val allModels = (SUPPORTED_SHERPA_WHISPER_ASR_MODELS + SUPPORTED_SHERPA_MOONSHINE_ASR_MODELS).values
+        allModels.sortedBy { it.id }.forEach { model ->
             val downloaded = if (modelManager.isModelDownloaded(model.id)) { "[x]" } else { "[ ]" }
             logger.info("$downloaded [${model.id}] ${model.name} (${model.dataSizeMegabytes} MB)")
         }
     }
 
     private fun downloadModel(id: String) {
-        val model = SUPPORTED_SHERPA_WHISPER_ASR_MODELS[id]
+        val model = (SUPPORTED_SHERPA_WHISPER_ASR_MODELS + SUPPORTED_SHERPA_MOONSHINE_ASR_MODELS)[id]
         if (model == null) {
             logger.error("Model not found: $id")
             return

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/Constants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/Constants.kt
@@ -6,6 +6,7 @@ const val APPLICATION_SHORT = "speedofsound"
 const val APPLICATION_URL = "https://www.speedofsound.io"
 const val APPLICATION_URL_KEYBOARD_SHORTCUT = "$APPLICATION_URL/keyboard-shortcut/"
 
+const val SHERPA_ONNX_ASR_MODELS_URL = "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models"
 const val ANTHROPIC_ENVIRONMENT_VARIABLE = "ANTHROPIC_API_KEY"
 const val GOOGLE_ENVIRONMENT_VARIABLE = "GOOGLE_API_KEY"
 const val OPENAI_ENVIRONMENT_VARIABLE = "OPENAI_API_KEY"

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
@@ -5,6 +5,7 @@ import com.zugaldia.speedofsound.core.models.voice.ModelManager
 import com.zugaldia.speedofsound.core.plugins.asr.AsrPluginOptions
 import com.zugaldia.speedofsound.core.plugins.asr.AsrProvider
 import com.zugaldia.speedofsound.core.plugins.asr.OpenAiAsrOptions
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaMoonshineAsrOptions
 import com.zugaldia.speedofsound.core.plugins.asr.SherpaWhisperAsrOptions
 import com.zugaldia.speedofsound.core.plugins.director.DirectorOptions
 import com.zugaldia.speedofsound.core.plugins.llm.AnthropicLlmOptions
@@ -48,6 +49,11 @@ class SettingsClient(val settingsStore: SettingsStore) {
             )
 
             AsrProvider.SHERPA_WHISPER -> SherpaWhisperAsrOptions(
+                modelId = providerSetting.modelId,
+                language = language,
+            )
+
+            AsrProvider.SHERPA_MOONSHINE -> SherpaMoonshineAsrOptions(
                 modelId = providerSetting.modelId,
                 language = language,
             )

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
@@ -3,6 +3,7 @@ package com.zugaldia.speedofsound.core.desktop.settings
 import com.zugaldia.speedofsound.core.APPLICATION_SHORT
 import com.zugaldia.speedofsound.core.Language
 import com.zugaldia.speedofsound.core.plugins.asr.DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
+import com.zugaldia.speedofsound.core.plugins.asr.SUPPORTED_SHERPA_MOONSHINE_ASR_MODELS
 import com.zugaldia.speedofsound.core.plugins.asr.SUPPORTED_SHERPA_WHISPER_ASR_MODELS
 
 const val DEFAULT_PROPERTIES_FILENAME = "$APPLICATION_SHORT.properties"
@@ -40,9 +41,7 @@ const val DEFAULT_CREDENTIALS = "[]"
 
 // Voice Models page
 
-// Initially exposing only Sherpa Whisper models. The ONNX provider is intentionally excluded
-// as its current implementation is very limited and only offers another Whisper variant.
-val SUPPORTED_LOCAL_ASR_MODELS = SUPPORTED_SHERPA_WHISPER_ASR_MODELS
+val SUPPORTED_LOCAL_ASR_MODELS = SUPPORTED_SHERPA_WHISPER_ASR_MODELS + SUPPORTED_SHERPA_MOONSHINE_ASR_MODELS
 
 const val KEY_VOICE_MODEL_PROVIDERS = "voice-model-providers"
 const val DEFAULT_VOICE_MODEL_PROVIDERS = "[]"

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/models/voice/VoiceModelCatalog.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/models/voice/VoiceModelCatalog.kt
@@ -1,6 +1,7 @@
 package com.zugaldia.speedofsound.core.models.voice
 
 import com.zugaldia.speedofsound.core.plugins.asr.DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
+import com.zugaldia.speedofsound.core.plugins.asr.SUPPORTED_SHERPA_MOONSHINE_ASR_MODELS
 import com.zugaldia.speedofsound.core.plugins.asr.SUPPORTED_SHERPA_WHISPER_ASR_MODELS
 
 /**
@@ -12,11 +13,12 @@ interface VoiceModelCatalog {
 }
 
 /**
- * Production implementation that uses the global SUPPORTED_SHERPA_WHISPER_ASR_MODELS.
+ * Production implementation that uses the global model maps.
  */
 class DefaultVoiceModelCatalog : VoiceModelCatalog {
     override fun getModel(modelId: String): VoiceModel? {
         return SUPPORTED_SHERPA_WHISPER_ASR_MODELS[modelId]
+            ?: SUPPORTED_SHERPA_MOONSHINE_ASR_MODELS[modelId]
     }
 
     override fun getDefaultModelId(): String {

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/AsrPluginOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/AsrPluginOptions.kt
@@ -18,7 +18,8 @@ enum class AsrProvider(
     val isLocallyManaged: Boolean
 ) : SelectableProvider {
     OPENAI("OpenAI", isLocallyManaged = false),
-    SHERPA_WHISPER("Whisper (Local)", isLocallyManaged = true);
+    SHERPA_WHISPER("Whisper (Local)", isLocallyManaged = true),
+    SHERPA_MOONSHINE("Moonshine (Local)", isLocallyManaged = true);
 
     companion object {
         /**
@@ -45,6 +46,7 @@ interface AsrPluginOptions : AppPluginOptions {
 fun pluginIdForProvider(provider: AsrProvider): String = when (provider) {
     AsrProvider.OPENAI -> OpenAiAsr.ID
     AsrProvider.SHERPA_WHISPER -> SherpaWhisperAsr.ID
+    AsrProvider.SHERPA_MOONSHINE -> SherpaMoonshineAsr.ID
 }
 
 /**
@@ -57,5 +59,6 @@ fun getModelsForProvider(provider: AsrProvider): Map<String, VoiceModel> {
     return when (provider) {
         AsrProvider.OPENAI -> SUPPORTED_OPENAI_ASR_MODELS
         AsrProvider.SHERPA_WHISPER -> SUPPORTED_SHERPA_WHISPER_ASR_MODELS
+        AsrProvider.SHERPA_MOONSHINE -> SUPPORTED_SHERPA_MOONSHINE_ASR_MODELS
     }
 }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaMoonshineAsr.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaMoonshineAsr.kt
@@ -1,0 +1,106 @@
+package com.zugaldia.speedofsound.core.plugins.asr
+
+import com.k2fsa.sherpa.onnx.OfflineModelConfig
+import com.k2fsa.sherpa.onnx.OfflineRecognizer
+import com.k2fsa.sherpa.onnx.OfflineRecognizerConfig
+import com.k2fsa.sherpa.onnx.OfflineMoonshineModelConfig
+import com.zugaldia.speedofsound.core.audio.AudioManager
+import com.zugaldia.speedofsound.core.models.voice.ModelManager
+
+class SherpaMoonshineAsr(
+    options: SherpaMoonshineAsrOptions = SherpaMoonshineAsrOptions(),
+) : AsrPlugin<SherpaMoonshineAsrOptions>(initialOptions = options) {
+    override val id: String = ID
+
+    companion object {
+        const val ID = "ASR_SHERPA_MOONSHINE"
+        const val PROVIDER = "cpu"
+    }
+
+    private var recognizer: OfflineRecognizer? = null
+
+    override fun enable() {
+        super.enable()
+        createRecognizer()
+    }
+
+    private fun createRecognizer() {
+        val modelManager = ModelManager()
+
+        // Validate model exists in the registry and is downloaded
+        val model = SUPPORTED_SHERPA_MOONSHINE_ASR_MODELS[currentOptions.modelId]
+        if (model == null || !modelManager.isModelDownloaded(currentOptions.modelId)) {
+            val reason = if (model == null) "not found" else "not downloaded"
+            throw IllegalStateException("Model ${currentOptions.modelId} $reason.")
+        }
+
+        val modelPath = modelManager.getModelPath(currentOptions.modelId)
+        val encoder = modelPath.resolve(model.components[0].name).toString()
+        val decoder = modelPath.resolve(model.components[1].name).toString()
+        val tokens = modelPath.resolve(model.components[2].name).toString()
+
+        val moonshine = OfflineMoonshineModelConfig.builder()
+            .setEncoder(encoder)
+            .setMergedDecoder(decoder)
+            .build()
+
+        val modelConfig = OfflineModelConfig.builder()
+            .setMoonshine(moonshine)
+            .setTokens(tokens)
+            .setNumThreads(Runtime.getRuntime().availableProcessors()) // Use all available CPU cores
+            .setProvider(PROVIDER)
+            .setDebug(currentOptions.enableDebug)
+            .build()
+
+        val config = OfflineRecognizerConfig.builder()
+            .setOfflineModelConfig(modelConfig)
+            .setDecodingMethod("greedy_search")
+            .build()
+
+        recognizer = OfflineRecognizer(config)
+        log.info("Recognizer created: ${model.id}")
+    }
+
+    private fun ensureRecognizerLanguage() {
+        val model = SUPPORTED_SHERPA_MOONSHINE_ASR_MODELS[currentOptions.modelId] ?: return
+        if (currentOptions.language !in model.languages) {
+            log.warn(
+                "Language ${currentOptions.language.iso2} is not supported by model ${currentOptions.modelId}. " +
+                    "Supported: ${model.languages.joinToString { it.iso2 }}"
+            )
+        }
+    }
+
+    override fun transcribe(request: AsrRequest): Result<AsrResponse> = runCatching {
+        ensureRecognizerLanguage()
+        val currentRecognizer = recognizer ?: error("Recognizer not initialized, plugin must be enabled first")
+        try {
+            val stream = currentRecognizer.createStream()
+            val floatArray = AudioManager.convertPcm16ToFloat(request.audioData)
+            stream.acceptWaveform(floatArray, request.audioInfo.sampleRate)
+
+            log.info("Transcribing with ${currentOptions.modelId}")
+            currentRecognizer.decode(stream)
+            val text = currentRecognizer.getResult(stream).text
+            stream.release()
+            AsrResponse(text)
+        } finally {
+            log.info("Transcription completed.")
+        }
+    }
+
+    private fun closeRecognizer() {
+        recognizer?.release()
+        recognizer = null
+    }
+
+    override fun disable() {
+        super.disable()
+        closeRecognizer()
+    }
+
+    override fun shutdown() {
+        closeRecognizer()
+        super.shutdown()
+    }
+}

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaMoonshineAsrModels.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaMoonshineAsrModels.kt
@@ -1,0 +1,179 @@
+package com.zugaldia.speedofsound.core.plugins.asr
+
+import com.zugaldia.speedofsound.core.Language
+import com.zugaldia.speedofsound.core.SHERPA_ONNX_ASR_MODELS_URL
+import com.zugaldia.speedofsound.core.models.voice.VoiceModel
+import com.zugaldia.speedofsound.core.models.voice.VoiceModelFile
+
+val SUPPORTED_SHERPA_MOONSHINE_ASR_MODELS = mapOf(
+    DEFAULT_ASR_SHERPA_MOONSHINE_MODEL_ID to VoiceModel(
+        id = DEFAULT_ASR_SHERPA_MOONSHINE_MODEL_ID,
+        name = "Moonshine Tiny (English only)",
+        provider = AsrProvider.SHERPA_MOONSHINE,
+        dataSizeMegabytes = 43L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27.tar.bz2",
+            sha256sum = "9ec31b342d8fa3240c3b81b8f82e1cf7e3ac467c93ca5a999b741d5887164f8d"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder_model.ort"),
+            VoiceModelFile(name = "decoder_model_merged.ort"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(Language.ENGLISH),
+    ),
+    "sherpa-onnx-moonshine-tiny-ja-quantized-2026-02-27" to VoiceModel(
+        id = "sherpa-onnx-moonshine-tiny-ja-quantized-2026-02-27",
+        name = "Moonshine Tiny (Japanese only)",
+        provider = AsrProvider.SHERPA_MOONSHINE,
+        dataSizeMegabytes = 69L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-moonshine-tiny-ja-quantized-2026-02-27",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-moonshine-tiny-ja-quantized-2026-02-27.tar.bz2",
+            sha256sum = "880305c9a6c33572ab269ff9731977ea42ca34c8cffcdd5d99558a9ea2b47cc2"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder_model.ort"),
+            VoiceModelFile(name = "decoder_model_merged.ort"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(Language.JAPANESE),
+    ),
+    "sherpa-onnx-moonshine-tiny-ko-quantized-2026-02-27" to VoiceModel(
+        id = "sherpa-onnx-moonshine-tiny-ko-quantized-2026-02-27",
+        name = "Moonshine Tiny (Korean only)",
+        provider = AsrProvider.SHERPA_MOONSHINE,
+        dataSizeMegabytes = 69L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-moonshine-tiny-ko-quantized-2026-02-27",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-moonshine-tiny-ko-quantized-2026-02-27.tar.bz2",
+            sha256sum = "d3b6c5390a7859c9ef20ff4f20b0766fcbad1dc06c0f509fe4840a3a302112dc"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder_model.ort"),
+            VoiceModelFile(name = "decoder_model_merged.ort"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(Language.KOREAN),
+    ),
+    "sherpa-onnx-moonshine-base-en-quantized-2026-02-27" to VoiceModel(
+        id = "sherpa-onnx-moonshine-base-en-quantized-2026-02-27",
+        name = "Moonshine Base (English only)",
+        provider = AsrProvider.SHERPA_MOONSHINE,
+        dataSizeMegabytes = 135L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-moonshine-base-en-quantized-2026-02-27",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-moonshine-base-en-quantized-2026-02-27.tar.bz2",
+            sha256sum = "43232c1d13013d37317163baec3135bd771a186a4356f28c889bab453bb0e891"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder_model.ort"),
+            VoiceModelFile(name = "decoder_model_merged.ort"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(Language.ENGLISH),
+    ),
+    "sherpa-onnx-moonshine-base-ja-quantized-2026-02-27" to VoiceModel(
+        id = "sherpa-onnx-moonshine-base-ja-quantized-2026-02-27",
+        name = "Moonshine Base (Japanese only)",
+        provider = AsrProvider.SHERPA_MOONSHINE,
+        dataSizeMegabytes = 135L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-moonshine-base-ja-quantized-2026-02-27",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-moonshine-base-ja-quantized-2026-02-27.tar.bz2",
+            sha256sum = "c66eb87d229a52d43bbe3b7c52a1d23f6208c0fd7c2e81802ecbda83b192798a"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder_model.ort"),
+            VoiceModelFile(name = "decoder_model_merged.ort"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(Language.JAPANESE),
+    ),
+    "sherpa-onnx-moonshine-base-es-quantized-2026-02-27" to VoiceModel(
+        id = "sherpa-onnx-moonshine-base-es-quantized-2026-02-27",
+        name = "Moonshine Base (Spanish only)",
+        provider = AsrProvider.SHERPA_MOONSHINE,
+        dataSizeMegabytes = 63L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-moonshine-base-es-quantized-2026-02-27",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-moonshine-base-es-quantized-2026-02-27.tar.bz2",
+            sha256sum = "850c3dcc5dfccc8b1feb10bb221b11d6039b6f5c626241729f46863771016383"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder_model.ort"),
+            VoiceModelFile(name = "decoder_model_merged.ort"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(Language.SPANISH),
+    ),
+    "sherpa-onnx-moonshine-base-zh-quantized-2026-02-27" to VoiceModel(
+        id = "sherpa-onnx-moonshine-base-zh-quantized-2026-02-27",
+        name = "Moonshine Base (Chinese only)",
+        provider = AsrProvider.SHERPA_MOONSHINE,
+        dataSizeMegabytes = 135L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-moonshine-base-zh-quantized-2026-02-27",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-moonshine-base-zh-quantized-2026-02-27.tar.bz2",
+            sha256sum = "6495d4240f66bcdd2bbbbfefaa687c463150d467854001270934e88940b733c1"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder_model.ort"),
+            VoiceModelFile(name = "decoder_model_merged.ort"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(Language.CHINESE),
+    ),
+    "sherpa-onnx-moonshine-base-vi-quantized-2026-02-27" to VoiceModel(
+        id = "sherpa-onnx-moonshine-base-vi-quantized-2026-02-27",
+        name = "Moonshine Base (Vietnamese only)",
+        provider = AsrProvider.SHERPA_MOONSHINE,
+        dataSizeMegabytes = 135L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-moonshine-base-vi-quantized-2026-02-27",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-moonshine-base-vi-quantized-2026-02-27.tar.bz2",
+            sha256sum = "97b53f5fb75a2a9dd6327440a34f45fc06c927ed2fa7217e5ebe54058e269416"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder_model.ort"),
+            VoiceModelFile(name = "decoder_model_merged.ort"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(Language.VIETNAMESE),
+    ),
+    "sherpa-onnx-moonshine-base-uk-quantized-2026-02-27" to VoiceModel(
+        id = "sherpa-onnx-moonshine-base-uk-quantized-2026-02-27",
+        name = "Moonshine Base (Ukrainian only)",
+        provider = AsrProvider.SHERPA_MOONSHINE,
+        dataSizeMegabytes = 135L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-moonshine-base-uk-quantized-2026-02-27",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-moonshine-base-uk-quantized-2026-02-27.tar.bz2",
+            sha256sum = "d8489b159afabf4cfb734002ae8a5361781ff8a381fa18d284d32d1eeb1c0376"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder_model.ort"),
+            VoiceModelFile(name = "decoder_model_merged.ort"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(Language.UKRAINIAN),
+    ),
+    "sherpa-onnx-moonshine-base-ar-quantized-2026-02-27" to VoiceModel(
+        id = "sherpa-onnx-moonshine-base-ar-quantized-2026-02-27",
+        name = "Moonshine Base (Arabic only)",
+        provider = AsrProvider.SHERPA_MOONSHINE,
+        dataSizeMegabytes = 135L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-moonshine-base-ar-quantized-2026-02-27",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-moonshine-base-ar-quantized-2026-02-27.tar.bz2",
+            sha256sum = "4d3f16fe354d8536d3323d3eaf4c12fafb1976b5dc0a12862ab25934da94285b"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder_model.ort"),
+            VoiceModelFile(name = "decoder_model_merged.ort"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(Language.ARABIC),
+    ),
+)

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaMoonshineAsrOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaMoonshineAsrOptions.kt
@@ -1,0 +1,15 @@
+package com.zugaldia.speedofsound.core.plugins.asr
+
+import com.zugaldia.speedofsound.core.Language
+import com.zugaldia.speedofsound.core.desktop.settings.DEFAULT_LANGUAGE
+
+const val DEFAULT_ASR_SHERPA_MOONSHINE_MODEL_ID = "sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27"
+
+/**
+ * Options for configuring the Sherpa Moonshine ASR plugin.
+ */
+data class SherpaMoonshineAsrOptions(
+    override val modelId: String = DEFAULT_ASR_SHERPA_MOONSHINE_MODEL_ID,
+    override val language: Language = DEFAULT_LANGUAGE,
+    override val enableDebug: Boolean = false,
+) : AsrPluginOptions


### PR DESCRIPTION
## Summary

- Add `SherpaMoonshineAsr` plugin with 10 quantized models (Tiny/Base variants in English, Japanese, Korean, Spanish, Chinese, Vietnamese, Ukrainian, and Arabic)
- Add `SHERPA_MOONSHINE` to `AsrProvider` enum and wire it into `AsrPluginOptions`, `VoiceModelCatalog`, `SettingsClient`, and `SettingsConstants`
- Register the plugin in `AsrProviderManager` (app) and expose it via `--provider moonshine` in the CLI `asr` and `download` commands
- Centralize the sherpa-onnx model download base URL as `SHERPA_ONNX_ASR_MODELS_URL`

## Status

Draft — blocked on upstream issue [k2-fsa/sherpa-onnx#3471](https://github.com/k2-fsa/sherpa-onnx/issues/3471).