### PR TITLE
fix: replace accidental code paste in getting-started shortcut section

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,10 +42,8 @@ and works on both X11 and Wayland.
 
 ## 3. Set up a shortcut
 
-"By default, [$APPLICATION_SHORTCUT_TRIGGER] starts and stops listening, but only when " +
-"the $APPLICATION_NAME window is open and focused.\n\n" +
-"For a better experience, we recommend setting up a global shortcut in Preferences. " +
-"This lets you keep the window minimized or hidden and trigger $APPLICATION_NAME " +
-"from anywhere, typing directly into any app.",
+By default, the `Super+Z` keyboard shortcut starts and stops listening, but only when the Speed of Sound window is
+open and focused. For a better experience, we recommend setting up a global shortcut in Preferences. This lets you
+keep the window minimized or hidden and trigger Speed of Sound from anywhere, typing directly into any app.
 
 Follow the instructions under [Set Up a Keyboard Shortcut](keyboard-shortcut.md).


### PR DESCRIPTION
## Summary

- Removed raw Kotlin string concatenation code with unreplaced template variables (`$APPLICATION_NAME`, `$APPLICATION_SHORTCUT_TRIGGER`) that was accidentally pasted into the Section 3 shortcut paragraph of `docs/getting-started.md`
- Replaced with proper prose referencing `Super+Z` and "Speed of Sound" by name