### PR TITLE
fix: update main window when secondary language changes in preferences

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -14,6 +14,7 @@ import com.zugaldia.speedofsound.core.desktop.settings.KEY_CREDENTIALS
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_CUSTOM_CONTEXT
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_CUSTOM_VOCABULARY
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_DEFAULT_LANGUAGE
+import com.zugaldia.speedofsound.core.desktop.settings.KEY_SECONDARY_LANGUAGE
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_SELECTED_TEXT_MODEL_PROVIDER_ID
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_SELECTED_VOICE_MODEL_PROVIDER_ID
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_TEXT_MODEL_PROVIDERS
@@ -208,6 +209,7 @@ class MainViewModel(
     private fun refreshSettings(key: String) {
         when (key) {
             KEY_DEFAULT_LANGUAGE -> onPrimaryLanguageSelected()
+            KEY_SECONDARY_LANGUAGE -> onSecondaryLanguageUpdated()
             KEY_CUSTOM_CONTEXT -> director.updateOptions(
                 director.getOptions().copy(customContext = settingsClient.getCustomContext())
             )
@@ -279,6 +281,12 @@ class MainViewModel(
         state.updateLanguage(language)
         asrProviderManager.updateLanguage(language)
         director.updateOptions(director.getOptions().copy(language = language))
+    }
+
+    private fun onSecondaryLanguageUpdated() {
+        val primaryLanguage = languageFromIso2(settingsClient.getDefaultLanguage()) ?: DEFAULT_LANGUAGE
+        if (state.currentLanguage() == primaryLanguage) return
+        onSecondaryLanguageSelected()
     }
 
     fun toggleListening() {


### PR DESCRIPTION
## Summary

- Fix bug where changing the secondary language in Preferences didn't update the main window when the secondary language was already active
- Added `KEY_SECONDARY_LANGUAGE` handler to `refreshSettings()` in `MainViewModel`
- New `onSecondaryLanguageUpdated()` only refreshes the language if the user is currently on the secondary (non-primary) language

Closes #129

## Test plan

- [ ] Set secondary language to French in Preferences
- [ ] Press Right Shift to switch to French in the main window
- [ ] Open Preferences and change secondary language to Arabic
- [ ] Verify the main window updates to show Arabic
- [ ] Verify that changing secondary language while on primary language doesn't switch away from primary