### PR TITLE
feat: show banner when remote desktop portal is not supported

### DIFF
--- a/app/flatpak-sources.json
+++ b/app/flatpak-sources.json
@@ -890,24 +890,24 @@
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.3.0/stargate-0.3.0.jar",
-    "sha512": "87339f91066c3ce530c26c876ae15b21762a01f299a917b291e277662412e3ceee14aeffd1dcd5158d968b4d68e76f5c4394d103eee9018b1ff0b463670a17d7",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.3.0",
-    "dest-filename": "stargate-0.3.0.jar"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.4.0/stargate-0.4.0.jar",
+    "sha512": "d9508d4e1466d3d33864ad53a9ca471d9949a42262065ffa1df138fb6dfe89e58e1d6b9698e9147d4760a39a0c1430d9d47e7e52bccf4348adfa42241a89ace1",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.4.0",
+    "dest-filename": "stargate-0.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.3.0/stargate-0.3.0.module",
-    "sha512": "04357e051e9c84faab44901505c068a05e5b5a6f2b49caea7a5febd2dadf8d2afc19cf06bc7838a6eb508138e288dadf6f50b28e01bdd43ec9d102e5a5b4e356",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.3.0",
-    "dest-filename": "stargate-0.3.0.module"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.4.0/stargate-0.4.0.module",
+    "sha512": "b258bc5084e9edb871fd6f1cc80d1d0d98c259f0cbf109020e4d0903442cf7bc35c31e81ad3cfe4641b27e046fde6310b18d2c1a3d1089047f14aa8f36371233",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.4.0",
+    "dest-filename": "stargate-0.4.0.module"
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.3.0/stargate-0.3.0.pom",
-    "sha512": "7420b9c32a9404cec86e8bf58c4154ede4d155742eda44d9dfa0792fa141567c92d830fff952a8dbccc3fd64908562c86843273971f7d84a317ec507ee49ac7f",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.3.0",
-    "dest-filename": "stargate-0.3.0.pom"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.4.0/stargate-0.4.0.pom",
+    "sha512": "2875cdf6477ccaa7d3ddaa4673b081fa507359f3e105e477e37ae04a66fc977fefa1031d769a8e93a4e5568fef1e8427728743202ff91d06c562653aa599113e",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.4.0",
+    "dest-filename": "stargate-0.4.0.pom"
   },
   {
     "type": "file",

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/AppConstants.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/AppConstants.kt
@@ -79,7 +79,7 @@ const val TRIGGER_ACTION = "trigger"
 
 const val SIGNAL_STAGE_CHANGED = "stage-changed"
 const val SIGNAL_RECORDING_LEVEL = "recording-level"
-const val SIGNAL_PORTALS_RESTORE_TOKEN_MISSING = "portals-restore-token-missing"
+const val SIGNAL_REMOTE_DESKTOP_STATUS = "remote-desktop-status"
 const val SIGNAL_PIPELINE_COMPLETED = "pipeline-completed"
 const val SIGNAL_LANGUAGE_CHANGED = "language-changed"
 const val SIGNAL_ASR_MODEL_CHANGED = "asr-model-changed"

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/portals/PortalsSessionManager.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/portals/PortalsSessionManager.kt
@@ -4,6 +4,8 @@ import com.zugaldia.speedofsound.core.desktop.portals.PortalsClient
 import com.zugaldia.stargate.sdk.globalshortcuts.ShortcutActivation
 import com.zugaldia.speedofsound.core.desktop.settings.SettingsClient
 import com.zugaldia.stargate.sdk.isSandboxed
+import com.zugaldia.stargate.sdk.request.PortalRequestException
+import com.zugaldia.stargate.sdk.request.RequestResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
@@ -19,7 +21,7 @@ class PortalsSessionManager(
     private val portalsClient: PortalsClient,
     private val settingsClient: SettingsClient,
     initialSessionDisconnected: Boolean = true,
-    initialRestoreTokenMissing: Boolean = true,
+    initialRemoteDesktopStatus: RemoteDesktopStatus = RemoteDesktopStatus.NeedToken,
 ) {
     private val logger = LoggerFactory.getLogger(PortalsSessionManager::class.java)
 
@@ -28,8 +30,8 @@ class PortalsSessionManager(
     private val _isSessionDisconnected = MutableStateFlow(initialSessionDisconnected)
     val isSessionDisconnected: StateFlow<Boolean> = _isSessionDisconnected.asStateFlow()
 
-    private val _isRestoreTokenMissing = MutableStateFlow(initialRestoreTokenMissing)
-    val isRestoreTokenMissing: StateFlow<Boolean> = _isRestoreTokenMissing.asStateFlow()
+    private val _remoteDesktopStatus = MutableStateFlow(initialRemoteDesktopStatus)
+    val remoteDesktopStatus: StateFlow<RemoteDesktopStatus> = _remoteDesktopStatus.asStateFlow()
 
     private val _shortcutActivated = MutableSharedFlow<ShortcutActivation>(extraBufferCapacity = 1)
     val shortcutActivated: Flow<ShortcutActivation> = _shortcutActivated.asSharedFlow()
@@ -82,19 +84,28 @@ class PortalsSessionManager(
                     settingsClient.setPortalsRestoreToken(newToken)
                 }
                 collectPortalsEvents(scope)
-                _isRestoreTokenMissing.value = newToken.isNullOrBlank()
+                _remoteDesktopStatus.value = if (newToken.isNullOrBlank()) {
+                    RemoteDesktopStatus.NeedToken
+                } else {
+                    RemoteDesktopStatus.Ready
+                }
                 _isSessionDisconnected.value = false
             }.onFailure { error ->
                 logger.error("Failed to start portals session", error)
+                val isCancelled = error is PortalRequestException && error.response == RequestResponse.CANCELLED
+                _remoteDesktopStatus.value = if (isCancelled) {
+                    RemoteDesktopStatus.NeedToken
+                } else {
+                    RemoteDesktopStatus.NotSupported
+                }
                 _isSessionDisconnected.value = true
-                _isRestoreTokenMissing.value = true
                 settingsClient.setPortalsRestoreToken("")
             }
         }
     }
 
     fun attemptReconnect(scope: CoroutineScope) {
-        if (_isSessionDisconnected.value) {
+        if (_isSessionDisconnected.value && _remoteDesktopStatus.value != RemoteDesktopStatus.NotSupported) {
             logger.info("Portal session disconnected, attempting to reconnect.")
             val restoreToken = settingsClient.getPortalsRestoreToken()
             startSession(scope, restoreToken.ifBlank { null })

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/portals/RemoteDesktopStatus.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/portals/RemoteDesktopStatus.kt
@@ -1,0 +1,12 @@
+package com.zugaldia.speedofsound.app.portals
+
+enum class RemoteDesktopStatus {
+    NeedToken,
+    Ready,
+    NotSupported;
+
+    companion object {
+        fun fromOrdinal(ordinal: Int): RemoteDesktopStatus =
+            entries.getOrElse(ordinal) { NeedToken }
+    }
+}

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/BannerWidget.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/BannerWidget.kt
@@ -8,3 +8,10 @@ fun buildBannerWidget(onAllow: () -> Unit): Banner =
         onButtonClicked { onAllow() }
         revealed = false
     }
+
+fun buildNotSupportedBannerWidget(onTroubleshoot: () -> Unit): Banner =
+    Banner("Remote desktop portal is not supported").apply {
+        buttonLabel = "Troubleshoot"
+        onButtonClicked { onTroubleshoot() }
+        revealed = false
+    }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainState.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainState.kt
@@ -4,9 +4,10 @@ import com.zugaldia.speedofsound.app.SIGNAL_ASR_MODEL_CHANGED
 import com.zugaldia.speedofsound.app.SIGNAL_LANGUAGE_CHANGED
 import com.zugaldia.speedofsound.app.SIGNAL_LLM_MODEL_CHANGED
 import com.zugaldia.speedofsound.app.SIGNAL_PIPELINE_COMPLETED
-import com.zugaldia.speedofsound.app.SIGNAL_PORTALS_RESTORE_TOKEN_MISSING
 import com.zugaldia.speedofsound.app.SIGNAL_RECORDING_LEVEL
+import com.zugaldia.speedofsound.app.SIGNAL_REMOTE_DESKTOP_STATUS
 import com.zugaldia.speedofsound.app.SIGNAL_STAGE_CHANGED
+import com.zugaldia.speedofsound.app.portals.RemoteDesktopStatus
 import com.zugaldia.speedofsound.core.Language
 import com.zugaldia.speedofsound.core.desktop.settings.DEFAULT_LANGUAGE
 import org.gnome.gobject.GObject
@@ -24,8 +25,8 @@ enum class AppStage {
 class MainState : GObject() {
     private var stageOrdinal: Int = AppStage.LOADING.ordinal
     private var maxRecordingLevel: Float = MIN_RECORDING_LEVEL
-    private var portalsRestoreTokenMissing: Boolean = true
     private var portalsSessionDisconnected: Boolean = false
+    private var remoteDesktopStatusOrdinal: Int = RemoteDesktopStatus.NeedToken.ordinal
     private var currentLanguage: Language = DEFAULT_LANGUAGE
     private var currentAsrModel: String = ""
     private var currentLlmModel: String = ""
@@ -44,13 +45,13 @@ class MainState : GObject() {
         emit(SIGNAL_RECORDING_LEVEL, scaledLevel.toDouble())
     }
 
-    fun updatePortalsRestoreTokenMissing(value: Boolean) {
-        portalsRestoreTokenMissing = value
-        emit(SIGNAL_PORTALS_RESTORE_TOKEN_MISSING, value)
-    }
-
     fun setPortalsSessionDisconnected(value: Boolean) {
         portalsSessionDisconnected = value
+    }
+
+    fun updateRemoteDesktopStatus(value: RemoteDesktopStatus) {
+        remoteDesktopStatusOrdinal = value.ordinal
+        emit(SIGNAL_REMOTE_DESKTOP_STATUS, value.ordinal)
     }
 
     fun emitPipelineCompleted() {
@@ -88,9 +89,9 @@ class MainState : GObject() {
         fun run(level: Double)
     }
 
-    @Signal(name = SIGNAL_PORTALS_RESTORE_TOKEN_MISSING)
-    fun interface PortalsRestoreTokenMissingChanged {
-        fun run(missing: Boolean)
+    @Signal(name = SIGNAL_REMOTE_DESKTOP_STATUS)
+    fun interface RemoteDesktopStatusChanged {
+        fun run(statusOrdinal: Int)
     }
 
     @Signal(name = SIGNAL_PIPELINE_COMPLETED)

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -4,6 +4,7 @@ import com.zugaldia.speedofsound.app.APPEND_SPACE_TEXT
 import com.zugaldia.speedofsound.app.isGStreamerDisabled
 import com.zugaldia.speedofsound.app.plugins.recorder.GStreamerRecorder
 import com.zugaldia.speedofsound.app.portals.PortalsSessionManager
+import com.zugaldia.speedofsound.app.portals.RemoteDesktopStatus
 import com.zugaldia.speedofsound.app.portals.TextUtils
 import com.zugaldia.speedofsound.app.settings.AsrProviderManager
 import com.zugaldia.speedofsound.app.settings.LlmProviderManager
@@ -67,7 +68,11 @@ class MainViewModel(
         portalsClient = portalsClient,
         settingsClient = settingsClient,
         initialSessionDisconnected = true,
-        initialRestoreTokenMissing = settingsClient.getPortalsRestoreToken().isBlank(),
+        initialRemoteDesktopStatus = if (settingsClient.getPortalsRestoreToken().isBlank()) {
+            RemoteDesktopStatus.NeedToken
+        } else {
+            RemoteDesktopStatus.Ready
+        },
     )
 
     private val asrProviderManager = AsrProviderManager(registry, settingsClient)
@@ -193,9 +198,9 @@ class MainViewModel(
             }
         }
         viewModelScope.launch {
-            portalsSessionManager.isRestoreTokenMissing.collect { isMissing ->
+            portalsSessionManager.remoteDesktopStatus.collect { status ->
                 GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
-                    state.updatePortalsRestoreTokenMissing(isMissing)
+                    state.updateRemoteDesktopStatus(status)
                     false // Return false for one-shot execution
                 }
             }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
@@ -9,9 +9,10 @@ import com.zugaldia.speedofsound.app.SIGNAL_ASR_MODEL_CHANGED
 import com.zugaldia.speedofsound.app.SIGNAL_LANGUAGE_CHANGED
 import com.zugaldia.speedofsound.app.SIGNAL_LLM_MODEL_CHANGED
 import com.zugaldia.speedofsound.app.SIGNAL_PIPELINE_COMPLETED
-import com.zugaldia.speedofsound.app.SIGNAL_PORTALS_RESTORE_TOKEN_MISSING
 import com.zugaldia.speedofsound.app.SIGNAL_RECORDING_LEVEL
+import com.zugaldia.speedofsound.app.SIGNAL_REMOTE_DESKTOP_STATUS
 import com.zugaldia.speedofsound.app.SIGNAL_STAGE_CHANGED
+import com.zugaldia.speedofsound.app.portals.RemoteDesktopStatus
 import com.zugaldia.speedofsound.app.screens.about.buildAboutDialog
 import com.zugaldia.speedofsound.app.screens.preferences.PreferencesDialog
 import com.zugaldia.speedofsound.app.screens.shortcuts.buildShortcutsWindow
@@ -19,6 +20,7 @@ import com.zugaldia.speedofsound.core.desktop.portals.PortalsClient
 import com.zugaldia.speedofsound.core.desktop.settings.SettingsClient
 import com.zugaldia.speedofsound.core.APPLICATION_NAME
 import com.zugaldia.speedofsound.core.APPLICATION_URL
+import com.zugaldia.speedofsound.core.APPLICATION_URL_TROUBLESHOOTING
 import org.gnome.adw.Banner
 import org.gnome.adw.Application
 import org.gnome.adw.ApplicationWindow
@@ -43,6 +45,7 @@ class MainWindow(
 ) : ApplicationWindow() {
     private val audioWidget: AudioWidget
     private val portalsBanner: Banner
+    private val notSupportedBanner: Banner
     private val statusWidget: StatusWidget
 
     // Track whether we should hide the window on pipeline completion
@@ -61,6 +64,7 @@ class MainWindow(
         })
 
         portalsBanner = buildBannerWidget { viewModel.startPortalsSession() }
+        notSupportedBanner = buildNotSupportedBannerWidget { viewModel.openUri(APPLICATION_URL_TROUBLESHOOTING) }
         audioWidget = AudioWidget(onToggle = { viewModel.toggleListening() })
         statusWidget = StatusWidget()
 
@@ -71,6 +75,7 @@ class MainWindow(
             .build()
             .apply {
                 append(portalsBanner)
+                append(notSupportedBanner)
                 append(audioWidget)
                 append(Separator(Orientation.HORIZONTAL))
                 append(statusWidget)
@@ -129,10 +134,26 @@ class MainWindow(
         })
 
         viewModel.state.connect(
-            SIGNAL_PORTALS_RESTORE_TOKEN_MISSING,
-            MainState.PortalsRestoreTokenMissingChanged { missing: Boolean ->
-                portalsBanner.revealed = missing
-                audioWidget.setPortalsReady(!missing)
+            SIGNAL_REMOTE_DESKTOP_STATUS,
+            MainState.RemoteDesktopStatusChanged { statusOrdinal: Int ->
+                val status = RemoteDesktopStatus.fromOrdinal(statusOrdinal)
+                when (status) {
+                    RemoteDesktopStatus.NeedToken -> {
+                        portalsBanner.revealed = true
+                        notSupportedBanner.revealed = false
+                        audioWidget.setPortalsReady(false)
+                    }
+                    RemoteDesktopStatus.Ready -> {
+                        portalsBanner.revealed = false
+                        notSupportedBanner.revealed = false
+                        audioWidget.setPortalsReady(true)
+                    }
+                    RemoteDesktopStatus.NotSupported -> {
+                        portalsBanner.revealed = false
+                        notSupportedBanner.revealed = true
+                        audioWidget.setPortalsReady(false)
+                    }
+                }
             }
         )
 

--- a/core/flatpak-sources.json
+++ b/core/flatpak-sources.json
@@ -841,24 +841,24 @@
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.3.0/stargate-0.3.0.jar",
-    "sha512": "87339f91066c3ce530c26c876ae15b21762a01f299a917b291e277662412e3ceee14aeffd1dcd5158d968b4d68e76f5c4394d103eee9018b1ff0b463670a17d7",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.3.0",
-    "dest-filename": "stargate-0.3.0.jar"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.4.0/stargate-0.4.0.jar",
+    "sha512": "d9508d4e1466d3d33864ad53a9ca471d9949a42262065ffa1df138fb6dfe89e58e1d6b9698e9147d4760a39a0c1430d9d47e7e52bccf4348adfa42241a89ace1",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.4.0",
+    "dest-filename": "stargate-0.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.3.0/stargate-0.3.0.module",
-    "sha512": "04357e051e9c84faab44901505c068a05e5b5a6f2b49caea7a5febd2dadf8d2afc19cf06bc7838a6eb508138e288dadf6f50b28e01bdd43ec9d102e5a5b4e356",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.3.0",
-    "dest-filename": "stargate-0.3.0.module"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.4.0/stargate-0.4.0.module",
+    "sha512": "b258bc5084e9edb871fd6f1cc80d1d0d98c259f0cbf109020e4d0903442cf7bc35c31e81ad3cfe4641b27e046fde6310b18d2c1a3d1089047f14aa8f36371233",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.4.0",
+    "dest-filename": "stargate-0.4.0.module"
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.3.0/stargate-0.3.0.pom",
-    "sha512": "7420b9c32a9404cec86e8bf58c4154ede4d155742eda44d9dfa0792fa141567c92d830fff952a8dbccc3fd64908562c86843273971f7d84a317ec507ee49ac7f",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.3.0",
-    "dest-filename": "stargate-0.3.0.pom"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.4.0/stargate-0.4.0.pom",
+    "sha512": "2875cdf6477ccaa7d3ddaa4673b081fa507359f3e105e477e37ae04a66fc977fefa1031d769a8e93a4e5568fef1e8427728743202ff91d06c562653aa599113e",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.4.0",
+    "dest-filename": "stargate-0.4.0.pom"
   },
   {
     "type": "file",

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/Constants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/Constants.kt
@@ -5,6 +5,7 @@ const val APPLICATION_ID = "io.speedofsound.SpeedOfSound"
 const val APPLICATION_SHORT = "speedofsound"
 const val APPLICATION_URL = "https://www.speedofsound.io"
 const val APPLICATION_URL_KEYBOARD_SHORTCUT = "$APPLICATION_URL/keyboard-shortcut/"
+const val APPLICATION_URL_TROUBLESHOOTING = "$APPLICATION_URL/troubleshooting/"
 
 const val ANTHROPIC_ENVIRONMENT_VARIABLE = "ANTHROPIC_API_KEY"
 const val GOOGLE_ENVIRONMENT_VARIABLE = "GOOGLE_API_KEY"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,19 @@
 # Troubleshooting
 
+## Remote desktop portal is not supported
+
+**Symptom:** A banner at the top of the main window says "Remote desktop portal is not supported."
+
+**Why this happens:** Speed of Sound relies on the [XDG Remote Desktop Portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.RemoteDesktop.html) standard
+to type text into other applications. This portal must be supported by your desktop environment's portal backend.
+However, not all desktop environments ship a backend that implements it
+([this table](https://wiki.archlinux.org/title/XDG_Desktop_Portal) provides a good compatibility matrix).
+
+**How to fix it:** We recommend reporting the missing support to your desktop environment's issue tracker.
+In the meantime, if possible, consider switching to a desktop environment that implements this portal (e.g. GNOME, KDE).
+We are also exploring alternatives such as clipboard-based text input.
+If that would be useful to you, [let us know](https://github.com/zugaldia/speedofsound/issues/19).
+
 ## Non-Latin text produces only spaces and punctuation
 
 **Symptom:** Dictating in a non-Latin language (e.g., Cyrillic, Arabic, CJK) outputs only spaces

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ onnx = "1.24.3"
 onnxExtensions = "0.13.0"
 openai = "4.30.0"
 shadow = "9.4.1"
-stargate = "0.3.0"
+stargate = "0.4.0"
 versionsPlugin = "0.53.0"
 
 [libraries]


### PR DESCRIPTION
## Summary
- Replace the binary `isRestoreTokenMissing` signal with a tri-state `RemoteDesktopStatus` enum (`NeedToken` / `Ready` / `NotSupported`) to distinguish between a missing restore token and an environment that doesn't implement the XDG Remote Desktop Portal
- Show a dedicated "Remote desktop portal is not supported" banner with a "Troubleshoot" button linking to docs, and prevent futile reconnection attempts when the portal is unsupported
- Bump stargate to 0.4.0 for `PortalRequestException` support and add a troubleshooting doc section explaining the issue

## Test plan
- [ ] Verify on a desktop with Remote Desktop Portal support (e.g. GNOME) that the "Allow" banner appears and transitions to Ready state
- [ ] Verify on a desktop without Remote Desktop Portal support that the "not supported" banner appears and the troubleshoot button opens the docs URL
- [ ] Verify that cancelling the portal dialog keeps the "Allow" banner (NeedToken state) and allows retry
- [ ] Verify that `attemptReconnect` does not retry when status is `NotSupported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)