### PR TITLE
feat: add NVIDIA Canary and Parakeet ASR model families

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 Speed of Sound is a voice-typing application for the Linux desktop.
-It captures microphone audio, transcribes it using ASR (the default is locally using Sherpa ONNX Whisper models),
+It captures microphone audio, transcribes it using ASR (locally via Sherpa ONNX — supports Whisper, Parakeet, and Canary model families),
 optionally polishes the text with an LLM (Anthropic/Google/OpenAI and compatible endpoints),
 and types the result into the active application via XDG Desktop Portal keyboard simulation.
 
@@ -42,7 +42,7 @@ Three Gradle modules with a shared convention plugin in `buildSrc/`:
 
 **Sample pipeline (orchestrated by `DefaultDirector`):**
 1. `JvmRecorder` — Captures PCM16 audio via `javax.sound.sampled`
-2. `SherpaWhisperAsr` — Transcribes audio using Sherpa ONNX (30-second max segments)
+2. `SherpaOfflineAsr` — Transcribes audio using Sherpa ONNX (Whisper, Parakeet, Canary)
 3. `LlmPlugin` — Polishes transcription (supports Anthropic, Google, OpenAI)
 
 **Director event flow:** `RecordingStarted` → `TranscriptionStarted` → `PolishingStarted` → `PipelineCompleted`

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Voice typing for the Linux desktop:
 
 ## Features
 
-- Offline, on-device transcription using Whisper. No data leaves your machine.
+- Offline, on-device transcription powered by Whisper, Parakeet, Canary, and more. No data leaves your machine.
 - Multiple activation options: click the in-app button or use a global keyboard shortcut.
 - Types the result directly into any focused application using Portals for wide desktop support (X11, Wayland).
-- [Multi-language support](https://github.com/openai/whisper#available-models-and-languages) with switchable primary and secondary languages on the fly.
-- Works out of the box with the built-in Whisper Tiny model. Download additional models from within the app to improve accuracy.
+- Multi-language support with switchable primary and secondary languages on the fly.
+- Works out of the box with a built-in multilingual Whisper model. Download additional models from within the app to improve accuracy and language coverage.
 - *Optional* text polishing with LLMs (Anthropic, Google, OpenAI), with support for a custom context and vocabulary.
 - Supports self-hosted services like vLLM, Ollama, and llama.cpp (cloud services supported but not required).
 
@@ -58,7 +58,7 @@ Speed of Sound stands on the shoulders of these excellent open source projects:
 - [Java-GI](https://github.com/jwharm/java-gi) — GTK/GNOME bindings for Java, enabling access to native libraries
   (including LibAdwaita and GStreamer) via the modern Panama framework.
 - [Sherpa ONNX](https://github.com/k2-fsa/sherpa-onnx) — On-device ASR (and more) using the performant ONNX Runtime,
-  including pre-built models for Whisper and many other popular models.
+  with pre-built models for Whisper, Parakeet, Canary, and many other popular models.
 - [Whisper](https://github.com/openai/whisper) — OpenAI's open-source speech recognition model.
   Its release transformed the on-device ASR landscape.
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/settings/AsrProviderManager.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/settings/AsrProviderManager.kt
@@ -4,6 +4,10 @@ import com.zugaldia.speedofsound.core.Language
 import com.zugaldia.speedofsound.core.desktop.settings.SettingsClient
 import com.zugaldia.speedofsound.core.plugins.AppPluginCategory
 import com.zugaldia.speedofsound.core.plugins.AppPluginRegistry
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaCanaryAsr
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaCanaryAsrOptions
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaParakeetAsr
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaParakeetAsrOptions
 import com.zugaldia.speedofsound.core.plugins.asr.SherpaWhisperAsr
 import com.zugaldia.speedofsound.core.plugins.asr.SherpaWhisperAsrOptions
 import com.zugaldia.speedofsound.core.plugins.asr.AsrPluginOptions
@@ -24,6 +28,8 @@ class AsrProviderManager(
 
     fun registerAsrPlugins() {
         registry.register(AppPluginCategory.ASR, OpenAiAsr())
+        registry.register(AppPluginCategory.ASR, SherpaCanaryAsr())
+        registry.register(AppPluginCategory.ASR, SherpaParakeetAsr())
         registry.register(AppPluginCategory.ASR, SherpaWhisperAsr())
     }
 
@@ -75,6 +81,8 @@ class AsrProviderManager(
         val activePlugin = registry.getActive(AppPluginCategory.ASR) ?: return
         when (activePlugin) {
             is OpenAiAsr -> activePlugin.updateOptions(activePlugin.getOptions().copy(language = language))
+            is SherpaCanaryAsr -> activePlugin.updateOptions(activePlugin.getOptions().copy(language = language))
+            is SherpaParakeetAsr -> activePlugin.updateOptions(activePlugin.getOptions().copy(language = language))
             is SherpaWhisperAsr -> activePlugin.updateOptions(activePlugin.getOptions().copy(language = language))
         }
     }
@@ -93,6 +101,8 @@ class AsrProviderManager(
         val plugin = registry.getPluginById(AppPluginCategory.ASR, pluginId) ?: return
         when (plugin) {
             is OpenAiAsr -> plugin.updateOptions(options as OpenAiAsrOptions)
+            is SherpaCanaryAsr -> plugin.updateOptions(options as SherpaCanaryAsrOptions)
+            is SherpaParakeetAsr -> plugin.updateOptions(options as SherpaParakeetAsrOptions)
             is SherpaWhisperAsr -> plugin.updateOptions(options as SherpaWhisperAsrOptions)
         }
     }

--- a/cli/src/main/kotlin/com/zugaldia/speedofsound/cli/AsrCommand.kt
+++ b/cli/src/main/kotlin/com/zugaldia/speedofsound/cli/AsrCommand.kt
@@ -9,9 +9,15 @@ import com.zugaldia.speedofsound.core.Language
 import com.zugaldia.speedofsound.core.audio.AudioInfo
 import com.zugaldia.speedofsound.core.audio.AudioManager
 import com.zugaldia.speedofsound.core.desktop.settings.DEFAULT_LANGUAGE
+import com.zugaldia.speedofsound.core.desktop.settings.SUPPORTED_LOCAL_ASR_MODELS
+import com.zugaldia.speedofsound.core.plugins.asr.AsrProvider
 import com.zugaldia.speedofsound.core.plugins.asr.DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
 import com.zugaldia.speedofsound.core.plugins.asr.AsrPlugin
 import com.zugaldia.speedofsound.core.plugins.asr.AsrRequest
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaCanaryAsr
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaCanaryAsrOptions
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaParakeetAsr
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaParakeetAsrOptions
 import com.zugaldia.speedofsound.core.plugins.asr.SherpaWhisperAsr
 import com.zugaldia.speedofsound.core.plugins.asr.OpenAiAsr
 import com.zugaldia.speedofsound.core.plugins.asr.SherpaWhisperAsrOptions
@@ -67,7 +73,17 @@ class AsrCommand : CliktCommand(name = "asr") {
         logger.info("Using provider: $provider, model: $modelId, language: ${language.name} ($languageCode)")
         val asr: AsrPlugin<*> = when (provider.lowercase()) {
             "onnx" -> OnnxWhisperAsr(OnnxWhisperAsrOptions())
-            "sherpa" -> SherpaWhisperAsr(SherpaWhisperAsrOptions(modelId = modelId, language = language))
+            "sherpa" -> {
+                val voiceModel = SUPPORTED_LOCAL_ASR_MODELS[modelId]
+                when (voiceModel?.provider) {
+                    AsrProvider.SHERPA_CANARY ->
+                        SherpaCanaryAsr(SherpaCanaryAsrOptions(modelId = modelId, language = language))
+                    AsrProvider.SHERPA_PARAKEET ->
+                        SherpaParakeetAsr(SherpaParakeetAsrOptions(modelId = modelId, language = language))
+                    else ->
+                        SherpaWhisperAsr(SherpaWhisperAsrOptions(modelId = modelId, language = language))
+                }
+            }
             "openai" -> OpenAiAsr(OpenAiAsrOptions(
                 baseUrl = baseUrl,
                 apiKey = apiKey,
@@ -83,7 +99,6 @@ class AsrCommand : CliktCommand(name = "asr") {
         logger.info("Transcribing audio.")
         val result = asr.transcribe(AsrRequest(audioData, audioInfo))
         result.onSuccess { response ->
-            logger.info("Transcription: ${response.text}")
             println(response.text)
         }.onFailure { error ->
             logger.error("Transcription failed: ${error.message}", error)

--- a/cli/src/main/kotlin/com/zugaldia/speedofsound/cli/DownloadCommand.kt
+++ b/cli/src/main/kotlin/com/zugaldia/speedofsound/cli/DownloadCommand.kt
@@ -6,8 +6,8 @@ import com.github.ajalt.clikt.parameters.arguments.optional
 import com.zugaldia.speedofsound.core.getDataDir
 import com.zugaldia.speedofsound.core.models.voice.ModelManager
 import com.zugaldia.speedofsound.core.models.voice.ModelManagerEvent
+import com.zugaldia.speedofsound.core.desktop.settings.SUPPORTED_LOCAL_ASR_MODELS
 import com.zugaldia.speedofsound.core.plugins.asr.DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
-import com.zugaldia.speedofsound.core.plugins.asr.SUPPORTED_SHERPA_WHISPER_ASR_MODELS
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -34,14 +34,14 @@ class DownloadCommand : CliktCommand(name = "download") {
     private fun listAvailableModels() {
         logger.info("Data folder: ${getDataDir()}")
         logger.info("Available models:")
-        SUPPORTED_SHERPA_WHISPER_ASR_MODELS.values.sortedBy { it.id }.forEach { model ->
+        SUPPORTED_LOCAL_ASR_MODELS.values.sortedBy { it.id }.forEach { model ->
             val downloaded = if (modelManager.isModelDownloaded(model.id)) { "[x]" } else { "[ ]" }
             logger.info("$downloaded [${model.id}] ${model.name} (${model.dataSizeMegabytes} MB)")
         }
     }
 
     private fun downloadModel(id: String) {
-        val model = SUPPORTED_SHERPA_WHISPER_ASR_MODELS[id]
+        val model = SUPPORTED_LOCAL_ASR_MODELS[id]
         if (model == null) {
             logger.error("Model not found: $id")
             return

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/Constants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/Constants.kt
@@ -14,5 +14,8 @@ const val OPENAI_ENVIRONMENT_VARIABLE = "OPENAI_API_KEY"
 // Placeholder API key for local/custom endpoints that require an API key but don't validate it
 const val LOCAL_API_KEY_PLACEHOLDER = "sk-$APPLICATION_SHORT"
 
+// Sherpa ONNX ASR models base URL
+const val SHERPA_ONNX_ASR_MODELS_URL = "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models"
+
 // Default app trigger shortcut for voice typing
 const val APPLICATION_SHORTCUT_TRIGGER = "Super+z"

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
@@ -5,6 +5,8 @@ import com.zugaldia.speedofsound.core.models.voice.ModelManager
 import com.zugaldia.speedofsound.core.plugins.asr.AsrPluginOptions
 import com.zugaldia.speedofsound.core.plugins.asr.AsrProvider
 import com.zugaldia.speedofsound.core.plugins.asr.OpenAiAsrOptions
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaCanaryAsrOptions
+import com.zugaldia.speedofsound.core.plugins.asr.SherpaParakeetAsrOptions
 import com.zugaldia.speedofsound.core.plugins.asr.SherpaWhisperAsrOptions
 import com.zugaldia.speedofsound.core.plugins.director.DirectorOptions
 import com.zugaldia.speedofsound.core.plugins.llm.AnthropicLlmOptions
@@ -45,6 +47,16 @@ class SettingsClient(val settingsStore: SettingsStore) {
                 language = language,
                 baseUrl = providerSetting.baseUrl,
                 apiKey = apiKey,
+            )
+
+            AsrProvider.SHERPA_CANARY -> SherpaCanaryAsrOptions(
+                modelId = providerSetting.modelId,
+                language = language,
+            )
+
+            AsrProvider.SHERPA_PARAKEET -> SherpaParakeetAsrOptions(
+                modelId = providerSetting.modelId,
+                language = language,
             )
 
             AsrProvider.SHERPA_WHISPER -> SherpaWhisperAsrOptions(

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
@@ -3,6 +3,8 @@ package com.zugaldia.speedofsound.core.desktop.settings
 import com.zugaldia.speedofsound.core.APPLICATION_SHORT
 import com.zugaldia.speedofsound.core.Language
 import com.zugaldia.speedofsound.core.plugins.asr.DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
+import com.zugaldia.speedofsound.core.plugins.asr.SUPPORTED_SHERPA_CANARY_ASR_MODELS
+import com.zugaldia.speedofsound.core.plugins.asr.SUPPORTED_SHERPA_PARAKEET_ASR_MODELS
 import com.zugaldia.speedofsound.core.plugins.asr.SUPPORTED_SHERPA_WHISPER_ASR_MODELS
 
 const val DEFAULT_PROPERTIES_FILENAME = "$APPLICATION_SHORT.properties"
@@ -43,9 +45,10 @@ const val DEFAULT_CREDENTIALS = "[]"
 
 // Voice Models page
 
-// Initially exposing only Sherpa Whisper models. The ONNX provider is intentionally excluded
-// as its current implementation is very limited and only offers another Whisper variant.
-val SUPPORTED_LOCAL_ASR_MODELS = SUPPORTED_SHERPA_WHISPER_ASR_MODELS
+// The ONNX provider is intentionally excluded as its current implementation is very limited
+// and only offers another Whisper variant.
+val SUPPORTED_LOCAL_ASR_MODELS =
+    SUPPORTED_SHERPA_WHISPER_ASR_MODELS + SUPPORTED_SHERPA_CANARY_ASR_MODELS + SUPPORTED_SHERPA_PARAKEET_ASR_MODELS
 
 const val KEY_VOICE_MODEL_PROVIDERS = "voice-model-providers"
 const val DEFAULT_VOICE_MODEL_PROVIDERS = "[]"

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/models/voice/VoiceModelCatalog.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/models/voice/VoiceModelCatalog.kt
@@ -1,7 +1,7 @@
 package com.zugaldia.speedofsound.core.models.voice
 
+import com.zugaldia.speedofsound.core.desktop.settings.SUPPORTED_LOCAL_ASR_MODELS
 import com.zugaldia.speedofsound.core.plugins.asr.DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID
-import com.zugaldia.speedofsound.core.plugins.asr.SUPPORTED_SHERPA_WHISPER_ASR_MODELS
 
 /**
  * Catalog for looking up voice models.
@@ -12,11 +12,11 @@ interface VoiceModelCatalog {
 }
 
 /**
- * Production implementation that uses the global SUPPORTED_SHERPA_WHISPER_ASR_MODELS.
+ * Production implementation that uses the global SUPPORTED_LOCAL_ASR_MODELS.
  */
 class DefaultVoiceModelCatalog : VoiceModelCatalog {
     override fun getModel(modelId: String): VoiceModel? {
-        return SUPPORTED_SHERPA_WHISPER_ASR_MODELS[modelId]
+        return SUPPORTED_LOCAL_ASR_MODELS[modelId]
     }
 
     override fun getDefaultModelId(): String {

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/AsrPluginOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/AsrPluginOptions.kt
@@ -18,6 +18,8 @@ enum class AsrProvider(
     val isLocallyManaged: Boolean
 ) : SelectableProvider {
     OPENAI("OpenAI", isLocallyManaged = false),
+    SHERPA_CANARY("Canary (Local)", isLocallyManaged = true),
+    SHERPA_PARAKEET("Parakeet (Local)", isLocallyManaged = true),
     SHERPA_WHISPER("Whisper (Local)", isLocallyManaged = true);
 
     companion object {
@@ -44,6 +46,8 @@ interface AsrPluginOptions : AppPluginOptions {
  */
 fun pluginIdForProvider(provider: AsrProvider): String = when (provider) {
     AsrProvider.OPENAI -> OpenAiAsr.ID
+    AsrProvider.SHERPA_CANARY -> SherpaCanaryAsr.ID
+    AsrProvider.SHERPA_PARAKEET -> SherpaParakeetAsr.ID
     AsrProvider.SHERPA_WHISPER -> SherpaWhisperAsr.ID
 }
 
@@ -56,6 +60,8 @@ fun pluginIdForProvider(provider: AsrProvider): String = when (provider) {
 fun getModelsForProvider(provider: AsrProvider): Map<String, VoiceModel> {
     return when (provider) {
         AsrProvider.OPENAI -> SUPPORTED_OPENAI_ASR_MODELS
+        AsrProvider.SHERPA_CANARY -> SUPPORTED_SHERPA_CANARY_ASR_MODELS
+        AsrProvider.SHERPA_PARAKEET -> SUPPORTED_SHERPA_PARAKEET_ASR_MODELS
         AsrProvider.SHERPA_WHISPER -> SUPPORTED_SHERPA_WHISPER_ASR_MODELS
     }
 }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaCanaryAsr.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaCanaryAsr.kt
@@ -1,0 +1,37 @@
+package com.zugaldia.speedofsound.core.plugins.asr
+
+import com.k2fsa.sherpa.onnx.OfflineCanaryModelConfig
+import com.k2fsa.sherpa.onnx.OfflineModelConfig
+import com.zugaldia.speedofsound.core.Language
+import com.zugaldia.speedofsound.core.models.voice.VoiceModel
+import java.nio.file.Path
+
+class SherpaCanaryAsr(
+    options: SherpaCanaryAsrOptions = SherpaCanaryAsrOptions(),
+) : SherpaOfflineAsr<SherpaCanaryAsrOptions>(initialOptions = options) {
+    override val id: String = ID
+
+    companion object {
+        const val ID = "ASR_SHERPA_CANARY"
+    }
+
+    override fun supportedModels(): Map<String, VoiceModel> = SUPPORTED_SHERPA_CANARY_ASR_MODELS
+
+    override fun applyModelSpecificConfig(
+        builder: OfflineModelConfig.Builder,
+        model: VoiceModel,
+        modelPath: Path,
+        language: Language,
+    ): OfflineModelConfig.Builder {
+        val encoder = modelPath.resolve(model.components[0].name).toString()
+        val decoder = modelPath.resolve(model.components[1].name).toString()
+        val canary = OfflineCanaryModelConfig.builder()
+            .setEncoder(encoder)
+            .setDecoder(decoder)
+            .setSrcLang(language.iso2)
+            .setTgtLang(language.iso2)
+            .setUsePnc(true)
+            .build()
+        return builder.setCanary(canary)
+    }
+}

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaCanaryAsrModels.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaCanaryAsrModels.kt
@@ -1,0 +1,26 @@
+package com.zugaldia.speedofsound.core.plugins.asr
+
+import com.zugaldia.speedofsound.core.Language
+import com.zugaldia.speedofsound.core.SHERPA_ONNX_ASR_MODELS_URL
+import com.zugaldia.speedofsound.core.models.voice.VoiceModel
+import com.zugaldia.speedofsound.core.models.voice.VoiceModelFile
+
+val SUPPORTED_SHERPA_CANARY_ASR_MODELS = mapOf(
+    DEFAULT_ASR_SHERPA_CANARY_MODEL_ID to VoiceModel(
+        id = DEFAULT_ASR_SHERPA_CANARY_MODEL_ID,
+        name = "Canary (English, Spanish, German, French)",
+        provider = AsrProvider.SHERPA_CANARY,
+        dataSizeMegabytes = 198L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8.tar.bz2",
+            sha256sum = "7a38ed8b13f014ad632b09ff8d22e0c6f1359dd046af9235d281dfae841b9ab9"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder.int8.onnx"),
+            VoiceModelFile(name = "decoder.int8.onnx"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(Language.ENGLISH, Language.SPANISH, Language.GERMAN, Language.FRENCH),
+    )
+)

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaCanaryAsrOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaCanaryAsrOptions.kt
@@ -1,0 +1,15 @@
+package com.zugaldia.speedofsound.core.plugins.asr
+
+import com.zugaldia.speedofsound.core.Language
+import com.zugaldia.speedofsound.core.desktop.settings.DEFAULT_LANGUAGE
+
+const val DEFAULT_ASR_SHERPA_CANARY_MODEL_ID = "sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8"
+
+/**
+ * Options for configuring the Sherpa Canary ASR plugin.
+ */
+data class SherpaCanaryAsrOptions(
+    override val modelId: String = DEFAULT_ASR_SHERPA_CANARY_MODEL_ID,
+    override val language: Language = DEFAULT_LANGUAGE,
+    override val enableDebug: Boolean = false,
+) : AsrPluginOptions

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaOfflineAsr.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaOfflineAsr.kt
@@ -1,0 +1,144 @@
+package com.zugaldia.speedofsound.core.plugins.asr
+
+import com.k2fsa.sherpa.onnx.OfflineModelConfig
+import com.k2fsa.sherpa.onnx.OfflineRecognizer
+import com.k2fsa.sherpa.onnx.OfflineRecognizerConfig
+import com.zugaldia.speedofsound.core.Language
+import com.zugaldia.speedofsound.core.audio.AudioManager
+import com.zugaldia.speedofsound.core.models.voice.ModelManager
+import com.zugaldia.speedofsound.core.models.voice.VoiceModel
+import java.nio.file.Path
+
+/**
+ * Abstract base class for Sherpa ONNX offline ASR plugins.
+ *
+ * Handles the common recognizer lifecycle (create, language switch, transcribe, close)
+ * while delegating the model-specific OfflineModelConfig setup to subclasses.
+ */
+abstract class SherpaOfflineAsr<Options : AsrPluginOptions>(
+    initialOptions: Options,
+) : AsrPlugin<Options>(initialOptions = initialOptions) {
+
+    companion object {
+        // Ideally, we use "cuda" for faster inference whenever available (Sherpa fallbacks to CPU if CUDA is not
+        // available). However, it seems that the official JAR files do not include this support. Assuming we can
+        // access the GPU from the sandboxed environment, we need a build of Sherpa with -DSHERPA_ONNX_ENABLE_GPU=ON.
+        // The next step is to make it work outside Flatpak/Snap (CLI), then we can tackle the sandboxes.
+        const val PROVIDER = "cpu"
+    }
+
+    private var recognizer: OfflineRecognizer? = null
+    private var recognizerLanguage: Language? = null
+
+    /**
+     * Returns the supported model registry for this plugin.
+     */
+    protected abstract fun supportedModels(): Map<String, VoiceModel>
+
+    /**
+     * Applies the model-specific configuration (e.g. Whisper, Canary, Transducer) to the
+     * [OfflineModelConfig.Builder].
+     *
+     * Subclasses should extract the component paths they need from [model] and [modelPath],
+     * call the appropriate setter (e.g. `setWhisper`, `setCanary`, `setTransducer`) on the builder,
+     * and return the resulting builder.
+     */
+    protected abstract fun applyModelSpecificConfig(
+        builder: OfflineModelConfig.Builder,
+        model: VoiceModel,
+        modelPath: Path,
+        language: Language,
+    ): OfflineModelConfig.Builder
+
+    /**
+     * Called before the recognizer is created. Override for any pre-creation setup
+     * such as extracting bundled models.
+     */
+    protected open fun onBeforeCreateRecognizer(modelManager: ModelManager) {
+        // Default: no-op
+    }
+
+    override fun enable() {
+        super.enable()
+        createRecognizer()
+    }
+
+    private fun createRecognizer() {
+        val modelManager = ModelManager()
+        onBeforeCreateRecognizer(modelManager)
+
+        val model = supportedModels()[currentOptions.modelId]
+        if (model == null || !modelManager.isModelDownloaded(currentOptions.modelId)) {
+            val reason = if (model == null) "not found" else "not downloaded"
+            throw IllegalStateException("Model ${currentOptions.modelId} $reason.")
+        }
+
+        val modelPath = modelManager.getModelPath(currentOptions.modelId)
+        val tokens = modelPath.resolve(model.components.last().name).toString()
+
+        val modelConfigBuilder = applyModelSpecificConfig(
+            OfflineModelConfig.builder(),
+            model,
+            modelPath,
+            currentOptions.language,
+        )
+
+        val modelConfig = modelConfigBuilder
+            .setTokens(tokens)
+            .setNumThreads(Runtime.getRuntime().availableProcessors())
+            .setProvider(PROVIDER)
+            .setDebug(currentOptions.enableDebug)
+            .build()
+
+        val config = OfflineRecognizerConfig.builder()
+            .setOfflineModelConfig(modelConfig)
+            .setDecodingMethod("greedy_search")
+            .build()
+
+        recognizer = OfflineRecognizer(config)
+        recognizerLanguage = currentOptions.language
+        log.info("Recognizer created: ${model.id}/${recognizerLanguage?.iso2}")
+    }
+
+    private fun ensureRecognizerLanguage() {
+        if (currentOptions.language != recognizerLanguage) {
+            log.info("Language changed, reinitializing.")
+            recognizer?.release()
+            createRecognizer()
+        }
+    }
+
+    override fun transcribe(request: AsrRequest): Result<AsrResponse> = runCatching {
+        ensureRecognizerLanguage()
+        val currentRecognizer = recognizer ?: error("Recognizer not initialized, plugin must be enabled first")
+        try {
+            val stream = currentRecognizer.createStream()
+            val floatArray = AudioManager.convertPcm16ToFloat(request.audioData)
+            stream.acceptWaveform(floatArray, request.audioInfo.sampleRate)
+
+            log.info("Transcribing with ${currentOptions.modelId}/$recognizerLanguage")
+            currentRecognizer.decode(stream)
+            val text = currentRecognizer.getResult(stream).text
+            stream.release()
+            AsrResponse(text)
+        } finally {
+            log.info("Transcription completed.")
+        }
+    }
+
+    private fun closeRecognizer() {
+        recognizer?.release()
+        recognizer = null
+        recognizerLanguage = null
+    }
+
+    override fun disable() {
+        super.disable()
+        closeRecognizer()
+    }
+
+    override fun shutdown() {
+        closeRecognizer()
+        super.shutdown()
+    }
+}

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaParakeetAsr.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaParakeetAsr.kt
@@ -1,0 +1,44 @@
+package com.zugaldia.speedofsound.core.plugins.asr
+
+import com.k2fsa.sherpa.onnx.OfflineModelConfig
+import com.k2fsa.sherpa.onnx.OfflineNemoEncDecCtcModelConfig
+import com.k2fsa.sherpa.onnx.OfflineTransducerModelConfig
+import com.zugaldia.speedofsound.core.Language
+import com.zugaldia.speedofsound.core.models.voice.VoiceModel
+import java.nio.file.Path
+
+class SherpaParakeetAsr(
+    options: SherpaParakeetAsrOptions = SherpaParakeetAsrOptions(),
+) : SherpaOfflineAsr<SherpaParakeetAsrOptions>(initialOptions = options) {
+    override val id: String = ID
+
+    companion object {
+        const val ID = "ASR_SHERPA_PARAKEET"
+        private const val TRANSDUCER_COMPONENT_COUNT = 4
+    }
+
+    override fun supportedModels(): Map<String, VoiceModel> = SUPPORTED_SHERPA_PARAKEET_ASR_MODELS
+
+    override fun applyModelSpecificConfig(
+        builder: OfflineModelConfig.Builder,
+        model: VoiceModel,
+        modelPath: Path,
+        language: Language,
+    ): OfflineModelConfig.Builder {
+        return if (model.components.size == TRANSDUCER_COMPONENT_COUNT) {
+            // Transducer model: encoder, decoder, joiner, tokens
+            val transducer = OfflineTransducerModelConfig.builder()
+                .setEncoder(modelPath.resolve(model.components[0].name).toString())
+                .setDecoder(modelPath.resolve(model.components[1].name).toString())
+                .setJoiner(modelPath.resolve(model.components[2].name).toString())
+                .build()
+            builder.setTransducer(transducer)
+        } else {
+            // CTC model: model, tokens
+            val nemo = OfflineNemoEncDecCtcModelConfig.builder()
+                .setModel(modelPath.resolve(model.components[0].name).toString())
+                .build()
+            builder.setNemo(nemo)
+        }
+    }
+}

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaParakeetAsrModels.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaParakeetAsrModels.kt
@@ -1,0 +1,103 @@
+package com.zugaldia.speedofsound.core.plugins.asr
+
+import com.zugaldia.speedofsound.core.Language
+import com.zugaldia.speedofsound.core.SHERPA_ONNX_ASR_MODELS_URL
+import com.zugaldia.speedofsound.core.models.voice.VoiceModel
+import com.zugaldia.speedofsound.core.models.voice.VoiceModelFile
+
+val SUPPORTED_SHERPA_PARAKEET_ASR_MODELS = mapOf(
+    DEFAULT_ASR_SHERPA_PARAKEET_MODEL_ID to VoiceModel(
+        id = DEFAULT_ASR_SHERPA_PARAKEET_MODEL_ID,
+        name = "Parakeet TDT 0.6B (25 EU languages)",
+        provider = AsrProvider.SHERPA_PARAKEET,
+        dataSizeMegabytes = 640L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8.tar.bz2",
+            sha256sum = "5793d0fd397c5778d2cf2126994d58e9d56b1be7c04d13c7a15bb1b4eafb16bf"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder.int8.onnx"),
+            VoiceModelFile(name = "decoder.int8.onnx"),
+            VoiceModelFile(name = "joiner.int8.onnx"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(
+            Language.BULGARIAN,
+            Language.CROATIAN,
+            Language.CZECH,
+            Language.DANISH,
+            Language.DUTCH,
+            Language.ENGLISH,
+            Language.ESTONIAN,
+            Language.FINNISH,
+            Language.FRENCH,
+            Language.GERMAN,
+            Language.MODERN_GREEK,
+            Language.HUNGARIAN,
+            Language.ITALIAN,
+            Language.LATVIAN,
+            Language.LITHUANIAN,
+            Language.MALTESE,
+            Language.POLISH,
+            Language.PORTUGUESE,
+            Language.ROMANIAN,
+            Language.RUSSIAN,
+            Language.SLOVAK,
+            Language.SLOVENIAN,
+            Language.SPANISH,
+            Language.SWEDISH,
+            Language.UKRAINIAN,
+        ),
+    ),
+    "sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8" to VoiceModel(
+        id = "sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8",
+        name = "Parakeet TDT-CTC 0.6B (Japanese only)",
+        provider = AsrProvider.SHERPA_PARAKEET,
+        dataSizeMegabytes = 626L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8.tar.bz2",
+            sha256sum = "4b0a800ef29f4f4c8667339bf6f60d5bfdc2852ddc9dc5741aea65b6f8d1306b"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "model.int8.onnx"),
+            VoiceModelFile(name = "tokens.txt"),
+        ),
+        languages = listOf(Language.JAPANESE),
+    ),
+    "sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000" to VoiceModel(
+        id = "sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000",
+        name = "Parakeet TDT 110M (English only)",
+        provider = AsrProvider.SHERPA_PARAKEET,
+        dataSizeMegabytes = 456L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000.tar.bz2",
+            sha256sum = "4cb81f605eb7bc6fe0d69cd9d4045161e1691a64c2b7d4f1e7d5099e1d3bc024"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "encoder.onnx"),
+            VoiceModelFile(name = "decoder.onnx"),
+            VoiceModelFile(name = "joiner.onnx"),
+            VoiceModelFile(name = "tokens.txt")
+        ),
+        languages = listOf(Language.ENGLISH),
+    ),
+    "sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8" to VoiceModel(
+        id = "sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8",
+        name = "Parakeet TDT-CTC 110M (English only)",
+        provider = AsrProvider.SHERPA_PARAKEET,
+        dataSizeMegabytes = 126L,
+        archiveFile = VoiceModelFile(
+            name = "sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8",
+            url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8.tar.bz2",
+            sha256sum = "17f945007b52ccd8b7200ffc7c5652e9e8e961dfdf479cefcabd06cf5703630b"
+        ),
+        components = listOf(
+            VoiceModelFile(name = "model.int8.onnx"),
+            VoiceModelFile(name = "tokens.txt"),
+        ),
+        languages = listOf(Language.ENGLISH),
+    )
+)

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaParakeetAsrOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaParakeetAsrOptions.kt
@@ -1,0 +1,15 @@
+package com.zugaldia.speedofsound.core.plugins.asr
+
+import com.zugaldia.speedofsound.core.Language
+import com.zugaldia.speedofsound.core.desktop.settings.DEFAULT_LANGUAGE
+
+const val DEFAULT_ASR_SHERPA_PARAKEET_MODEL_ID = "sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8"
+
+/**
+ * Options for configuring the Sherpa Parakeet ASR plugin.
+ */
+data class SherpaParakeetAsrOptions(
+    override val modelId: String = DEFAULT_ASR_SHERPA_PARAKEET_MODEL_ID,
+    override val language: Language = DEFAULT_LANGUAGE,
+    override val enableDebug: Boolean = false,
+) : AsrPluginOptions

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaWhisperAsr.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaWhisperAsr.kt
@@ -1,126 +1,47 @@
 package com.zugaldia.speedofsound.core.plugins.asr
 
 import com.k2fsa.sherpa.onnx.OfflineModelConfig
-import com.k2fsa.sherpa.onnx.OfflineRecognizer
-import com.k2fsa.sherpa.onnx.OfflineRecognizerConfig
 import com.k2fsa.sherpa.onnx.OfflineWhisperModelConfig
 import com.zugaldia.speedofsound.core.FatalStartupException
 import com.zugaldia.speedofsound.core.Language
-import com.zugaldia.speedofsound.core.audio.AudioManager
 import com.zugaldia.speedofsound.core.models.voice.ModelManager
+import com.zugaldia.speedofsound.core.models.voice.VoiceModel
+import java.nio.file.Path
 
 class SherpaWhisperAsr(
     options: SherpaWhisperAsrOptions = SherpaWhisperAsrOptions(),
-) : AsrPlugin<SherpaWhisperAsrOptions>(initialOptions = options) {
+) : SherpaOfflineAsr<SherpaWhisperAsrOptions>(initialOptions = options) {
     override val id: String = ID
 
     companion object {
         const val ID = "ASR_SHERPA_WHISPER"
-
-        // Ideally, we use "cuda" for faster inference whenever available (Sherpa fallbacks to CPU if CUDA is not
-        // available). However, it seems that the official JAR files do not include this support. Assuming we can
-        // access the GPU from the sandboxed environment, we need a build of Sherpa with -DSHERPA_ONNX_ENABLE_GPU=ON.
-        // The next step is to make it work outside Flatpak/Snap (CLI), then we can tackle the sandboxes.
-        const val PROVIDER = "cpu"
     }
 
-    private var recognizer: OfflineRecognizer? = null
-    private var recognizerLanguage: Language? = null
+    override fun supportedModels(): Map<String, VoiceModel> = SUPPORTED_SHERPA_WHISPER_ASR_MODELS
 
-    override fun enable() {
-        super.enable()
-        createRecognizer()
+    override fun applyModelSpecificConfig(
+        builder: OfflineModelConfig.Builder,
+        model: VoiceModel,
+        modelPath: Path,
+        language: Language,
+    ): OfflineModelConfig.Builder {
+        val encoder = modelPath.resolve(model.components[0].name).toString()
+        val decoder = modelPath.resolve(model.components[1].name).toString()
+        val whisper = OfflineWhisperModelConfig.builder()
+            .setEncoder(encoder)
+            .setDecoder(decoder)
+            .setLanguage(language.iso2)
+            .setTask("transcribe")
+            .build()
+        return builder.setWhisper(whisper)
     }
 
-    private fun extractDefaultModelIfNeeded(modelManager: ModelManager) {
+    override fun onBeforeCreateRecognizer(modelManager: ModelManager) {
         if (currentOptions.modelId == DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID) {
             modelManager.extractDefaultModel().onFailure { error ->
                 if (error is FatalStartupException) throw error
                 throw IllegalStateException("Failed to extract default model: ${error.message}", error)
             }
         }
-    }
-
-    private fun createRecognizer() {
-        val modelManager = ModelManager()
-        extractDefaultModelIfNeeded(modelManager)
-
-        // Validate model exists in the registry and is downloaded
-        val model = SUPPORTED_SHERPA_WHISPER_ASR_MODELS[currentOptions.modelId]
-        if (model == null || !modelManager.isModelDownloaded(currentOptions.modelId)) {
-            val reason = if (model == null) "not found" else "not downloaded"
-            throw IllegalStateException("Model ${currentOptions.modelId} $reason.")
-        }
-
-        val modelPath = modelManager.getModelPath(currentOptions.modelId)
-        val encoder = modelPath.resolve(model.components[0].name).toString()
-        val decoder = modelPath.resolve(model.components[1].name).toString()
-        val tokens = modelPath.resolve(model.components[2].name).toString()
-
-        val whisper = OfflineWhisperModelConfig.builder()
-            .setEncoder(encoder)
-            .setDecoder(decoder)
-            .setLanguage(currentOptions.language.iso2)
-            .setTask("transcribe")
-            .build()
-
-        val modelConfig = OfflineModelConfig.builder()
-            .setWhisper(whisper)
-            .setTokens(tokens)
-            .setNumThreads(Runtime.getRuntime().availableProcessors()) // Use all available CPU cores
-            .setProvider(PROVIDER)
-            .setDebug(currentOptions.enableDebug)
-            .build()
-
-        val config = OfflineRecognizerConfig.builder()
-            .setOfflineModelConfig(modelConfig)
-            .setDecodingMethod("greedy_search")
-            .build()
-
-        recognizer = OfflineRecognizer(config)
-        recognizerLanguage = currentOptions.language
-        log.info("Recognizer created: ${model.id}/${recognizerLanguage?.iso2}")
-    }
-
-    private fun ensureRecognizerLanguage() {
-        if (currentOptions.language != recognizerLanguage) {
-            log.info("Language changed, reinitializing.")
-            recognizer?.release()
-            createRecognizer()
-        }
-    }
-
-    override fun transcribe(request: AsrRequest): Result<AsrResponse> = runCatching {
-        ensureRecognizerLanguage()
-        val currentRecognizer = recognizer ?: error("Recognizer not initialized, plugin must be enabled first")
-        try {
-            val stream = currentRecognizer.createStream()
-            val floatArray = AudioManager.convertPcm16ToFloat(request.audioData)
-            stream.acceptWaveform(floatArray, request.audioInfo.sampleRate)
-
-            log.info("Transcribing with ${currentOptions.modelId}")
-            currentRecognizer.decode(stream)
-            val text = currentRecognizer.getResult(stream).text
-            stream.release()
-            AsrResponse(text)
-        } finally {
-            log.info("Transcription completed.")
-        }
-    }
-
-    private fun closeRecognizer() {
-        recognizer?.release()
-        recognizer = null
-        recognizerLanguage = null
-    }
-
-    override fun disable() {
-        super.disable()
-        closeRecognizer()
-    }
-
-    override fun shutdown() {
-        closeRecognizer()
-        super.shutdown()
     }
 }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaWhisperAsrModels.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaWhisperAsrModels.kt
@@ -1,20 +1,9 @@
 package com.zugaldia.speedofsound.core.plugins.asr
 
 import com.zugaldia.speedofsound.core.Language
+import com.zugaldia.speedofsound.core.SHERPA_ONNX_ASR_MODELS_URL
 import com.zugaldia.speedofsound.core.models.voice.VoiceModel
 import com.zugaldia.speedofsound.core.models.voice.VoiceModelFile
-
-/*
- * We support all the Whisper models for the initial walking skeleton, after we'll include some other options. See:
- * https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
- *
- * Currently on the radar:
- * - Meta Omnilingual
- * - NVIDIA Canary & Parakeet
- * - Useful Sensors Moonshine (or use https://github.com/moonshine-ai/moonshine directly)
- */
-
-private const val SHERPA_ONNX_ASR_MODELS_URL = "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models"
 
 val SUPPORTED_SHERPA_WHISPER_ASR_MODELS = mapOf(
     DEFAULT_ASR_SHERPA_WHISPER_MODEL_ID to VoiceModel(

--- a/data/io.speedofsound.SpeedOfSound.metainfo.xml.in
+++ b/data/io.speedofsound.SpeedOfSound.metainfo.xml.in
@@ -11,12 +11,12 @@
             Speed of Sound is a voice-typing app for the Linux desktop.
         </p>
         <p>
-            By default, transcription runs on-device using Whisper, so no audio ever leaves your machine.
-            The app comes with a built-in multilingual Whisper Tiny model and works out of the box.
-            Additional models can be downloaded from within the app to improve accuracy.
+            By default, transcription runs entirely on-device, so no audio ever leaves your machine.
+            The app ships with a built-in multilingual Whisper model and supports additional models from the
+            Whisper, Parakeet, and Canary families to improve accuracy.
         </p>
         <ul>
-            <li>Offline, private transcription with the bundled multilingual Whisper Tiny model</li>
+            <li>Offline, private transcription with popular open speech models (Whisper, Parakeet, Canary)</li>
             <li>Multiple activation options: click the in-app button or use a global keyboard shortcut</li>
             <li>Types directly into any app via XDG Desktop Portals (supports X11 and Wayland)</li>
             <li>Optional text polishing with LLMs, supports self-hosted services like Ollama, vLLM, and llama.cpp</li>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -29,13 +29,13 @@ requesting access to simulate keyboard input. It is the standard sandboxed mecha
 applications without requiring root or elevated privileges. It is also the only way to make typing work inside
 sandboxed packaging formats like Flatpak and Snap. The app cannot type anything without your explicit approval.
 
-## Which Whisper model should I use?
+## Which voice model should I use?
 
-The bundled Whisper Tiny model is a good starting point and works well for some use cases. If you need
+The bundled Whisper Tiny model is a good starting point and works well for many use cases. If you need
 better accuracy, especially for technical vocabulary or challenging accents, download a larger model
-from within the app. All models in the Whisper family are supported (Tiny, Base, Small, Medium, Large, Turbo),
-including English-only and optimized ones ("distilled"). Larger models are slower and use more memory, so it is
-worth trying smaller ones first.
+from within the app. The full Whisper family is supported (Tiny, Base, Small, Medium, Large, Turbo),
+including English-only and optimized variants. You can also try models from other families, like NVIDIA Parakeet
+and Canary. Larger models are slower and use more memory, so it is worth trying smaller ones first.
 
 ## What does text polishing do, and do I need it?
 
@@ -43,7 +43,7 @@ Text polishing is an optional step that sends the raw transcript to an LLM for f
 It is disabled by default and, if enabled, it adds some latency depending on the provider and model you choose.
 It is most useful in two ways: giving the LLM instructions (writing style, your intended audience, etc.)
 and supplying a custom vocabulary of names, companies, or technical terms that speech recognition tends to mishear.
-Whisper alone might get you 95% of the way there, polishing with the right context can close that gap.
+On-device transcription alone might get you 95% of the way there, polishing with the right context can close that gap.
 
 ## I have multiple microphones, can I choose which one to use?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,11 +9,11 @@ Voice typing for the Linux desktop:
 
 ## Features
 
-- Offline, on-device transcription using Whisper. No data leaves your machine.
+- Offline, on-device transcription powered by Whisper, Parakeet, Canary, and more. No data leaves your machine.
 - Multiple activation options: click the in-app button or use a global keyboard shortcut.
 - Types the result directly into any focused application using Portals for wide desktop support (X11, Wayland).
 - Multi-language support with switchable primary and secondary languages on the fly.
-- Works out of the box with the built-in Whisper Tiny model. Download additional models from within the app to improve accuracy.
+- Works out of the box with a built-in multilingual Whisper model. Download additional models from within the app to improve accuracy and language coverage.
 - *Optional* text polishing with LLMs (Anthropic, Google, OpenAI), with support for a custom context and vocabulary.
 - Supports self-hosted services like vLLM, Ollama, and llama.cpp (cloud services supported but not required).
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -91,8 +91,8 @@ when configuring voice or text model providers.
 ### Voice Models
 
 Configure the speech recognition provider used to transcribe your audio. By default, Speed of Sound transcribes
-locally using a Whisper model. You can add additional providers, including cloud-based ones, and select which one
-is active.
+locally using an on-device model (Whisper by default). Multiple model families are available, including
+Whisper, Parakeet, and Canary. You can also add cloud-based providers and select which one is active.
 
 ### Text Models
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,10 +3,10 @@ adopt-info: speedofsound
 summary: Voice typing for the Linux desktop.
 description: |
   Voice typing for the Linux desktop.
-  - Offline, on-device transcription using Whisper. No data leaves your machine.
+  - Offline, on-device transcription powered by Whisper, Parakeet, Canary, and more. No data leaves your machine.
   - Multiple activation options: click the in-app button or use a global keyboard shortcut.
   - Types the result directly into any focused application using Portals for wide desktop support (X11, Wayland).
-  - Works out of the box with the built-in multilingual Whisper Tiny model. Download additional models from within the app to improve accuracy.
+  - Works out of the box with a built-in multilingual Whisper model. Download additional models from within the app to improve accuracy and language coverage.
   - Optional text polishing with LLMs (Anthropic, Google, OpenAI), with support for custom context and vocabulary.
   - Supports self-hosted services like vLLM, Ollama, and llama.cpp (cloud services supported but not required).
 


### PR DESCRIPTION
## Summary

- Extracts the common Sherpa ONNX offline recognizer lifecycle (create, language switch, transcribe, close) into a new `SherpaOfflineAsr` abstract base class, reducing duplication across model families
- Adds `SherpaCanaryAsr` plugin with the Canary 180M Flash model supporting English, Spanish, German, and French
- Adds `SherpaParakeetAsr` plugin with four models: Parakeet TDT 0.6B (25 EU languages), Parakeet TDT-CTC 0.6B (Japanese), Parakeet TDT 110M (English), and Parakeet TDT-CTC 110M (English)
- Refactors `SherpaWhisperAsr` to extend the new base class, keeping only its Whisper-specific config and default model extraction logic
- Wires new providers into the `AsrProvider` enum, plugin registry, settings client, CLI, and GUI

## Test plan

- [ ] Build succeeds: `make build`
- [ ] Static analysis passes: `make check`
- [ ] CLI: transcribe with a Whisper model to confirm no regression (`./cli.sh asr --provider sherpa --model sherpa-onnx-whisper-tiny ...`)
- [ ] CLI: download and transcribe with Canary model (`./cli.sh download --model sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8`, then `./cli.sh asr --provider sherpa --model sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8 ...`)
- [ ] CLI: download and transcribe with a Parakeet model (e.g., `sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8`)
- [ ] GUI: new Canary/Parakeet providers appear in Voice Models preferences page
- [ ] GUI: selecting a Canary or Parakeet model and transcribing produces correct output