### PR TITLE
chore: add GitHub Sponsors funding button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: zugaldia

--- a/README.md
+++ b/README.md
@@ -78,3 +78,5 @@ There are several ideas already tracked as tickets to improve the project. Every
 roadmap has a corresponding issue. If you'd like to contribute, please use those tickets to guide your
 work. You can also use GitHub emoji reactions on issues to vote for the ones that matter most to you,
 which helps with prioritization.
+
+If you find Speed of Sound useful, consider [sponsoring this work](https://github.com/sponsors/zugaldia).

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/about/AppAboutDialog.kt
@@ -30,6 +30,7 @@ fun buildAboutDialog(): AboutDialog {
     dialog.copyright = "Copyright (c) 2025-2026 Antonio Zugaldia"
     dialog.debugInfo = buildDebugInfo()
     dialog.debugInfoFilename = "$APPLICATION_SHORT-debug.txt"
+    dialog.addLink("Sponsor", "https://github.com/sponsors/zugaldia")
     dialog.addAcknowledgementSection(
         "Built on the Shoulders of Giants",
         arrayOf(

--- a/data/io.speedofsound.SpeedOfSound.metainfo.xml.in
+++ b/data/io.speedofsound.SpeedOfSound.metainfo.xml.in
@@ -31,6 +31,7 @@
     <url type="vcs-browser">https://github.com/zugaldia/speedofsound</url>
     <url type="bugtracker">https://github.com/zugaldia/speedofsound/issues</url>
     <url type="contribute">https://github.com/zugaldia/speedofsound/blob/main/README.md</url>
+    <url type="donation">https://github.com/sponsors/zugaldia</url>
 
     <url type="contact">https://www.zugaldia.com</url>
     <developer id="com.zugaldia">

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -95,6 +95,11 @@ The same is expected from any contributors to this project. You may or may not u
 this project, but the PR author is ultimately responsible for the quality of their contributions. Coding agents are
 not an excuse to take shortcuts. In fact, the opposite is true.
 
+## How can I support this project?
+
+If you find Speed of Sound useful, consider [sponsoring this work](https://github.com/sponsors/zugaldia).
+You can also contribute code, report bugs, or vote on issues.
+
 ## What do I do if I have another question not answered here?
 
 If you run into any issues, have questions, or need troubleshooting help, please open a ticket on the

--- a/docs/support.md
+++ b/docs/support.md
@@ -35,3 +35,7 @@ There are several ideas already tracked as tickets to improve the project. Every
 roadmap has a corresponding issue. If you'd like to contribute, please use those tickets to guide your
 work. You can also use GitHub emoji reactions on issues to vote for the ones that matter most to you,
 which helps with prioritization.
+
+## Sponsorship
+
+If you find Speed of Sound useful, consider [sponsoring this work](https://github.com/sponsors/zugaldia).


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` to display a Sponsor button on the repository page, linking to GitHub Sponsors.

## Test plan
- [ ] Verify the Sponsor button appears on the repository page after merging