### PR TITLE
docs: clarify regional language variant support via LLM polishing

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -41,8 +41,11 @@ and Canary. Larger models are slower and use more memory, so it is worth trying 
 
 Text polishing is an optional step that sends the raw transcript to an LLM for further improvement.
 It is disabled by default and, if enabled, it adds some latency depending on the provider and model you choose.
-It is most useful in two ways: giving the LLM instructions (writing style, your intended audience, etc.)
-and supplying a custom vocabulary of names, companies, or technical terms that speech recognition tends to mishear.
+It is most useful giving the LLM instructions and supplying a custom vocabulary of names, companies, or technical
+terms that speech recognition tends to mishear. For example, if you need region-specific spelling or vocabulary
+(e.g. British vs. Australian English), you can instruct the LLM accordingly, since the underlying ASR models do
+not distinguish between regional variants of the same language.
+
 On-device transcription alone might get you 95% of the way there, polishing with the right context can close that gap.
 
 ## I have multiple microphones, can I choose which one to use?

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -51,6 +51,11 @@ There are 4 groups of settings here: Global Shortcut, Language, App Behavior, an
 **Language** — Set the primary language used for speech recognition. You can optionally configure a secondary
 language and switch between the two using the `Left Shift` and `Right Shift` keys while the main window is focused.
 
+!!! tip "Regional spelling and vocabulary variants"
+    ASR models do not distinguish between regional variants of the same language (e.g. British vs. Australian
+    English, or Spanish from Spain vs. Colombia). If you need region-specific spelling or vocabulary,
+    enable text polishing (see below) and instruct the LLM accordingly in the Personalization settings.
+
 !!! note "Non-Latin scripts require a matching keyboard layout"
     If you dictate in a non-Latin script, make sure the matching keyboard layout is active on your system
     before dictating. See [Troubleshooting](troubleshooting.md#non-latin-text-produces-only-spaces-and-punctuation)


### PR DESCRIPTION
## Summary

- Added a `tip` admonition to the User Guide (Language section) explaining that ASR models don't distinguish regional language variants and pointing users to the LLM polish step as a workaround
- Expanded the FAQ answer on text polishing with an example covering regional spelling variants (e.g. British vs. Australian English, Spanish from Spain vs. Colombia)

Closes #112