### PR TITLE
chore: add GitHub bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Report a problem with Speed of Sound
+labels: bug
+---
+
+## Pre-submission checklist
+
+- [ ] I have read the [troubleshooting documentation](https://www.speedofsound.io/troubleshooting/) and my issue is not covered there.
+
+## Description
+
+A short description of the problem.
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include any error messages or logs.
+
+## Additional context
+
+Any additional context that could help troubleshoot. For example:
+- Have you changed the default settings in any way?
+- Which Linux distro and desktop environment are you using?
+- Are you running Wayland or X11?
+- Does this only happen with English, or does it also happen with other languages?
+- Does it happen in multiple apps, or one specific app?
+- Which keyboard layout/input source do you have active when you see this issue?
+- Do you have a text model (LLM) enabled?
+
+## Environment
+
+Please include the debug information from the app, it helps identify your runtime environment and system configuration,
+which makes troubleshooting easier. To find it, open the About dialog (from the menu in the main window) and go to the
+Troubleshooting section. You can copy the debug information to your clipboard.
+
+```
+(paste debug information here)
+```


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/bug_report.md` with a structured bug report template
- Includes a pre-submission checklist requiring users to confirm they've read the [troubleshooting docs](https://www.speedofsound.io/troubleshooting/)
- Adds an Additional Context section with common diagnostic questions (distro/DE, Wayland/X11, language, app scope, keyboard layout, LLM enabled)
- Adds an Environment section prompting users to paste debug info from the app's About → Troubleshooting dialog