### PR TITLE
fix: prevent auto-quit when stay-hidden-on-activation is enabled

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/App.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/App.kt
@@ -29,6 +29,7 @@ fun main(args: Array<String>) {
 
 class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Application(applicationId, flags) {
     private var mainWindow: MainWindow? = null
+    private var isHoldingForHiddenStart = false
 
     private lateinit var settingsClient: SettingsClient
     private lateinit var portalsClient: PortalsClient
@@ -68,10 +69,17 @@ class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Appl
             if (isFirstLaunch) {
                 WelcomeWindow(this) {
                     settingsClient.setWelcomeScreenShown(true)
-                    mainWindow?.present()
+                    presentMainWindow()
                 }.present()
             } else if (!settingsClient.getStayHiddenOnActivation()) {
-                mainWindow?.present()
+                presentMainWindow()
+            } else if (!isHoldingForHiddenStart) {
+                // Keep the app alive without a visible window. GApplication auto-quits
+                // when its use-count drops to zero (no visible windows), hold() prevents
+                // that until the user triggers the global shortcut for the first time.
+                // https://github.com/zugaldia/speedofsound/issues/141
+                hold()
+                isHoldingForHiddenStart = true
             }
         }
 
@@ -117,9 +125,17 @@ class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Appl
         }
     }
 
+    private fun presentMainWindow() {
+        if (isHoldingForHiddenStart) {
+            release()
+            isHoldingForHiddenStart = false
+        }
+        mainWindow?.present()
+    }
+
     private fun handleTrigger() {
         ensureMainWindow()
-        if (!settingsClient.getBackgroundRecording()) mainWindow?.present()
+        if (!settingsClient.getBackgroundRecording()) presentMainWindow()
         mainWindow?.let { mainViewModel.onTriggerAction() }
     }
 


### PR DESCRIPTION
## Summary

- Use `GApplication.hold()`/`release()` to keep the app alive when "Stay hidden on activation" is enabled. Without this, GApplication auto-quits after a few seconds because no visible window is present to maintain the use-count.
- Extract `presentMainWindow()` helper that calls `release()` before presenting, ensuring the hold is properly cleaned up when the user triggers the window via global shortcut, welcome screen, or re-activation.

Fixes #141

## Test plan

- [ ] Enable "Stay hidden on activation" in Preferences > General > App Behavior
- [ ] Quit and relaunch the app — verify it stays alive in the background (no auto-quit after 5 seconds)
- [ ] Use the global shortcut (Super-Z) to trigger the app — verify the window appears
- [ ] Disable "Stay hidden on activation" and relaunch — verify normal window presentation still works
- [ ] First-launch flow (welcome screen) still works correctly