### PR TITLE
feat: add system tray status indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Voice typing for the Linux desktop:
 ## Features
 
 - Offline, on-device transcription powered by Whisper, Parakeet, Canary, and more. No data leaves your machine.
-- Multiple activation options: click the in-app button or use a global keyboard shortcut.
+- Multiple activation options: click the in-app button, use a global keyboard shortcut, or control the app from the system tray.
 - Types the result directly into any focused application using Portals for wide desktop support (X11, Wayland).
 - Multi-language support with switchable primary and secondary languages on the fly.
 - Works out of the box with a built-in multilingual Whisper model. Download additional models from within the app to improve accuracy and language coverage.

--- a/app/flatpak-sources.json
+++ b/app/flatpak-sources.json
@@ -890,24 +890,24 @@
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.5.0/stargate-0.5.0.jar",
-    "sha512": "78fd39b525454bbb8dfd01f0b450ee161629fe5c41a2e25ac2eb5786f6aba214f6af0388d215bbdeee6a99f445021d6d4903a8c892dd384e15151af5120d3785",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.5.0",
-    "dest-filename": "stargate-0.5.0.jar"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.5.1/stargate-0.5.1.jar",
+    "sha512": "7b535088cf54c8b79eaee1af958bac0b939a5d30149dfa3d6c9c956ee06248e578fc1cc65262d818e68c6b7c167f00fb12298197dc509a0dec6fd0401ad71451",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.5.1",
+    "dest-filename": "stargate-0.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.5.0/stargate-0.5.0.module",
-    "sha512": "7233f5d83e1b7b8e3e5b49f394c2d398f4699074c309e2c65f092a9d8efed3f2a64d5a7ee5d8f1b1bef6ee9dfef142485233279992d3f22bf686eb65d9a82ac2",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.5.0",
-    "dest-filename": "stargate-0.5.0.module"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.5.1/stargate-0.5.1.module",
+    "sha512": "63d623a1e5e8d94f017ce9f27f511a2202a1d55b7d850eb61194c64dbe5c8b30682681c7bf4a4d61fc2d57d60cef44d8bce2ef06452082a85bd4cb8fcee87d35",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.5.1",
+    "dest-filename": "stargate-0.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.5.0/stargate-0.5.0.pom",
-    "sha512": "c79f01036b2b35a4cf87f4525faa1b5c633b0ee232645176248e01e2259fc499b15a4927f415400bac20815ffb7f1cabb2cf2bb092ca29c84fbf1407162b3168",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.5.0",
-    "dest-filename": "stargate-0.5.0.pom"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.5.1/stargate-0.5.1.pom",
+    "sha512": "24649d2f9f8d0c92bb8dde954158ac27e7642a5a9af01d5b62258e6eb5e01a78113d54fa0d4762c813abbeb8e6cf7164837348dd4f1b05128b307e1b0dbaa6e1",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.5.1",
+    "dest-filename": "stargate-0.5.1.pom"
   },
   {
     "type": "file",

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/App.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/App.kt
@@ -4,6 +4,7 @@ import com.zugaldia.speedofsound.app.screens.main.MainViewModel
 import com.zugaldia.speedofsound.app.screens.main.MainWindow
 import com.zugaldia.speedofsound.app.screens.welcome.WelcomeWindow
 import com.zugaldia.speedofsound.app.settings.GioStore
+import com.zugaldia.speedofsound.app.status.StatusNotifierService
 import com.zugaldia.speedofsound.core.desktop.settings.PropertiesStore
 import com.zugaldia.speedofsound.core.desktop.settings.SettingsClient
 import com.zugaldia.speedofsound.core.desktop.settings.SettingsStore
@@ -30,6 +31,7 @@ fun main(args: Array<String>) {
 class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Application(applicationId, flags) {
     private var mainWindow: MainWindow? = null
     private var isHoldingForHiddenStart = false
+    private var statusNotifierService: StatusNotifierService? = null
 
     private lateinit var settingsClient: SettingsClient
     private lateinit var portalsClient: PortalsClient
@@ -64,6 +66,7 @@ class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Appl
             logger.info("Application activated.")
             loadIconResources()
             ensureMainWindow()
+            ensureStatusNotifier()
 
             val isFirstLaunch = !settingsClient.getWelcomeScreenShown()
             if (isFirstLaunch) {
@@ -85,6 +88,7 @@ class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Appl
 
         onShutdown {
             logger.info("Application shutting down.")
+            statusNotifierService?.close()
             mainViewModel.shutdown()
         }
     }
@@ -122,6 +126,22 @@ class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Appl
     private fun ensureMainWindow() {
         if (mainWindow == null) {
             mainWindow = MainWindow(this, mainViewModel, settingsClient, portalsClient)
+        }
+    }
+
+    private fun ensureStatusNotifier() {
+        if (statusNotifierService == null) {
+            statusNotifierService = StatusNotifierService(
+                onTrigger = { token ->
+                    token?.let { mainWindow?.setStartupId(it) }
+                    handleTrigger()
+                },
+                onOpen = { token ->
+                    token?.let { mainWindow?.setStartupId(it) }
+                    presentMainWindow()
+                },
+                onQuit = { quit() },
+            ).also { it.connect() }
         }
     }
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/status/SosStatusNotifierItem.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/status/SosStatusNotifierItem.kt
@@ -28,15 +28,6 @@ class SosStatusNotifierItem(
         else -> STATUS_NOTIFIER_ICON_FALLBACK
     }
 
-    // In Flatpak and Snap the icons are inside the sandbox (e.g. $SNAP/usr/share/icons)
-    // which is not on the host's default icon theme search path. Provide the path so
-    // the tray host can locate our icon.
-    override fun getIconThemePath(): String = when (getRuntimeEnvironment()) {
-        RuntimeEnvironment.SNAP -> "${System.getenv("SNAP") ?: ""}/usr/share/icons"
-        RuntimeEnvironment.FLATPAK -> "/app/share/icons"
-        else -> ""
-    }
-
     override fun getToolTipInfo(): Pair<String, String> =
         Pair(APPLICATION_NAME, "Voice typing for the Linux desktop")
 }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/status/SosStatusNotifierItem.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/status/SosStatusNotifierItem.kt
@@ -28,6 +28,15 @@ class SosStatusNotifierItem(
         else -> STATUS_NOTIFIER_ICON_FALLBACK
     }
 
+    // In Flatpak and Snap the icons are inside the sandbox (e.g. $SNAP/usr/share/icons)
+    // which is not on the host's default icon theme search path. Provide the path so
+    // the tray host can locate our icon.
+    override fun getIconThemePath(): String = when (getRuntimeEnvironment()) {
+        RuntimeEnvironment.SNAP -> "${System.getenv("SNAP") ?: ""}/usr/share/icons"
+        RuntimeEnvironment.FLATPAK -> "/app/share/icons"
+        else -> ""
+    }
+
     override fun getToolTipInfo(): Pair<String, String> =
         Pair(APPLICATION_NAME, "Voice typing for the Linux desktop")
 }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/status/SosStatusNotifierItem.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/status/SosStatusNotifierItem.kt
@@ -20,11 +20,15 @@ class SosStatusNotifierItem(
     override fun getId(): String = APPLICATION_ID
     override fun getTitle(): String = APPLICATION_NAME
 
-    // In Flatpak and Snap the app icon is registered in the system theme under APPLICATION_ID.
-    // In other environments (app-image, JAR) it isn't, so fall back to the standard
-    // FreeDesktop microphone icon which is always available.
+    // Flatpak exports icons to the host theme, so the app icon is available by APPLICATION_ID.
+    // Snap does NOT export icons to the host, the extension cannot resolve names that only
+    // exist inside the sandbox, resulting in the three-dots fallback. Use a standard FreeDesktop
+    // icon instead until we implement IconPixmap (raw pixel data over D-Bus) or manually set
+    // getIconThemePath to /snap/speedofsound/current/usr/share/icons/ (?).
+    // See: https://github.com/ubuntu/gnome-shell-extension-appindicator/issues/232
+    // See: https://github.com/ubuntu/gnome-shell-extension-appindicator/issues/544
     override fun getIconName(): String = when (getRuntimeEnvironment()) {
-        RuntimeEnvironment.FLATPAK, RuntimeEnvironment.SNAP -> APPLICATION_ID
+        RuntimeEnvironment.FLATPAK -> APPLICATION_ID
         else -> STATUS_NOTIFIER_ICON_FALLBACK
     }
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/status/SosStatusNotifierItem.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/status/SosStatusNotifierItem.kt
@@ -1,0 +1,33 @@
+package com.zugaldia.speedofsound.app.status
+
+import com.zugaldia.speedofsound.core.APPLICATION_ID
+import com.zugaldia.speedofsound.core.APPLICATION_NAME
+import com.zugaldia.speedofsound.core.RuntimeEnvironment
+import com.zugaldia.speedofsound.core.getRuntimeEnvironment
+import com.zugaldia.stargate.sdk.status.StargateMenu
+import com.zugaldia.stargate.sdk.status.StargateStatusNotifierItem
+
+// Standard FreeDesktop icon name, available on any compliant desktop.
+// Used as fallback when the app icon isn't in the system theme.
+// https://specifications.freedesktop.org/icon-naming/latest/
+private const val STATUS_NOTIFIER_ICON_FALLBACK = "audio-input-microphone"
+
+class SosStatusNotifierItem(
+    menu: StargateMenu,
+    onActivate: (token: String?) -> Unit,
+    onSecondaryActivate: (token: String?) -> Unit,
+) : StargateStatusNotifierItem(menu, onActivate, onSecondaryActivate) {
+    override fun getId(): String = APPLICATION_ID
+    override fun getTitle(): String = APPLICATION_NAME
+
+    // In Flatpak and Snap the app icon is registered in the system theme under APPLICATION_ID.
+    // In other environments (app-image, JAR) it isn't, so fall back to the standard
+    // FreeDesktop microphone icon which is always available.
+    override fun getIconName(): String = when (getRuntimeEnvironment()) {
+        RuntimeEnvironment.FLATPAK, RuntimeEnvironment.SNAP -> APPLICATION_ID
+        else -> STATUS_NOTIFIER_ICON_FALLBACK
+    }
+
+    override fun getToolTipInfo(): Pair<String, String> =
+        Pair(APPLICATION_NAME, "Voice typing for the Linux desktop")
+}

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/status/StatusNotifierService.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/status/StatusNotifierService.kt
@@ -81,7 +81,10 @@ class StatusNotifierService(
                     },
                 )
 
-                val serviceName = connected.registerItem(item, APPLICATION_ID)
+                // Use a dot-separated child of APPLICATION_ID so the bus name
+                // (e.g. "io.speedofsound.SpeedOfSound.StatusNotifier-{pid}-1")
+                // matches the Snap AppArmor policy for our D-Bus slot.
+                val serviceName = connected.registerItem(item, "$APPLICATION_ID.StatusNotifier")
                 logger.info("Registered StatusNotifierItem as $serviceName")
             } catch (e: Exception) {
                 logger.error("Failed to connect to StatusNotifierWatcher", e)

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/status/StatusNotifierService.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/status/StatusNotifierService.kt
@@ -1,0 +1,97 @@
+package com.zugaldia.speedofsound.app.status
+
+import com.zugaldia.speedofsound.core.APPLICATION_ID
+import com.zugaldia.stargate.sdk.status.StargateMenu
+import com.zugaldia.stargate.sdk.status.StargateMenuItem
+import com.zugaldia.stargate.sdk.status.StatusNotifierManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.gnome.glib.GLib
+import org.slf4j.LoggerFactory
+
+class StatusNotifierService(
+    private val onTrigger: (token: String?) -> Unit,
+    private val onOpen: (token: String?) -> Unit,
+    private val onQuit: () -> Unit,
+) : AutoCloseable {
+    private val logger = LoggerFactory.getLogger(StatusNotifierService::class.java)
+
+    private val job: Job = SupervisorJob()
+    private val scope = CoroutineScope(job + Dispatchers.IO)
+
+    private var manager: StatusNotifierManager? = null
+
+    private fun onMenuClick(label: String, action: (token: String?) -> Unit): (tokenSupplier: () -> String?) -> Unit =
+        { tokenSupplier ->
+            GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
+                val token = tokenSupplier()
+                logger.info("Menu: $label (token=$token)")
+                action(token)
+                false
+            }
+        }
+
+    private fun buildMenu(): StargateMenu = StargateMenu(
+        items = listOf(
+            StargateMenuItem.Action(
+                id = 1, label = "Start/Stop Listening",
+                onClick = onMenuClick("Start/Stop Listening", onTrigger),
+            ),
+            StargateMenuItem.Action(
+                id = 2, label = "Open App",
+                onClick = onMenuClick("Open App", onOpen),
+            ),
+            StargateMenuItem.Separator(id = 3),
+            StargateMenuItem.Action(
+                id = 4, label = "Quit",
+                onClick = onMenuClick("Quit") { onQuit() },
+            ),
+        ),
+        onMenuOpened = { logger.info("Menu: opened") },
+        onMenuClosed = { logger.info("Menu: closed") },
+    )
+
+    @Suppress("TooGenericExceptionCaught")
+    fun connect() {
+        scope.launch {
+            try {
+                manager?.close()
+                val connected = StatusNotifierManager.connect()
+                manager = connected
+                logger.info("Connected to StatusNotifierWatcher")
+
+                val item = SosStatusNotifierItem(
+                    menu = buildMenu(),
+                    onActivate = { token ->
+                        GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
+                            logger.info("Activate (token=$token)")
+                            onOpen(token)
+                            false
+                        }
+                    },
+                    onSecondaryActivate = { token ->
+                        GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
+                            logger.info("SecondaryActivate (token=$token)")
+                            onOpen(token)
+                            false
+                        }
+                    },
+                )
+
+                val serviceName = connected.registerItem(item, APPLICATION_ID)
+                logger.info("Registered StatusNotifierItem as $serviceName")
+            } catch (e: Exception) {
+                logger.error("Failed to connect to StatusNotifierWatcher", e)
+            }
+        }
+    }
+
+    override fun close() {
+        job.cancel()
+        manager?.close()
+        manager = null
+    }
+}

--- a/core/flatpak-sources.json
+++ b/core/flatpak-sources.json
@@ -841,24 +841,24 @@
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.5.0/stargate-0.5.0.jar",
-    "sha512": "78fd39b525454bbb8dfd01f0b450ee161629fe5c41a2e25ac2eb5786f6aba214f6af0388d215bbdeee6a99f445021d6d4903a8c892dd384e15151af5120d3785",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.5.0",
-    "dest-filename": "stargate-0.5.0.jar"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.5.1/stargate-0.5.1.jar",
+    "sha512": "7b535088cf54c8b79eaee1af958bac0b939a5d30149dfa3d6c9c956ee06248e578fc1cc65262d818e68c6b7c167f00fb12298197dc509a0dec6fd0401ad71451",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.5.1",
+    "dest-filename": "stargate-0.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.5.0/stargate-0.5.0.module",
-    "sha512": "7233f5d83e1b7b8e3e5b49f394c2d398f4699074c309e2c65f092a9d8efed3f2a64d5a7ee5d8f1b1bef6ee9dfef142485233279992d3f22bf686eb65d9a82ac2",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.5.0",
-    "dest-filename": "stargate-0.5.0.module"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.5.1/stargate-0.5.1.module",
+    "sha512": "63d623a1e5e8d94f017ce9f27f511a2202a1d55b7d850eb61194c64dbe5c8b30682681c7bf4a4d61fc2d57d60cef44d8bce2ef06452082a85bd4cb8fcee87d35",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.5.1",
+    "dest-filename": "stargate-0.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.5.0/stargate-0.5.0.pom",
-    "sha512": "c79f01036b2b35a4cf87f4525faa1b5c633b0ee232645176248e01e2259fc499b15a4927f415400bac20815ffb7f1cabb2cf2bb092ca29c84fbf1407162b3168",
-    "dest": "offline-repository/com/github/zugaldia/stargate/0.5.0",
-    "dest-filename": "stargate-0.5.0.pom"
+    "url": "https://plugins.gradle.org/m2/com/github/zugaldia/stargate/0.5.1/stargate-0.5.1.pom",
+    "sha512": "24649d2f9f8d0c92bb8dde954158ac27e7642a5a9af01d5b62258e6eb5e01a78113d54fa0d4762c813abbeb8e6cf7164837348dd4f1b05128b307e1b0dbaa6e1",
+    "dest": "offline-repository/com/github/zugaldia/stargate/0.5.1",
+    "dest-filename": "stargate-0.5.1.pom"
   },
   {
     "type": "file",

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Voice typing for the Linux desktop:
 ## Features
 
 - Offline, on-device transcription powered by Whisper, Parakeet, Canary, and more. No data leaves your machine.
-- Multiple activation options: click the in-app button or use a global keyboard shortcut.
+- Multiple activation options: click the in-app button, use a global keyboard shortcut, or control the app from the system tray.
 - Types the result directly into any focused application using Portals for wide desktop support (X11, Wayland).
 - Multi-language support with switchable primary and secondary languages on the fly.
 - Works out of the box with a built-in multilingual Whisper model. Download additional models from within the app to improve accuracy and language coverage.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -79,8 +79,8 @@ By default, Speed of Sound minimizes the main window before typing.
 **How to fix it:** Enable **Hide instead of minimize** in `Preferences` → `General` → `App Behavior`.
 A hidden window is typically restored on the active workspace instead.
 
-**Trade-off:** The app no longer appears in the dock. To bring the main window back, you can, for example, use a
-global shortcut (`Preferences` → `General` → `Global Shortcut`).
+**Trade-off:** The app no longer appears in the dock. To bring the main window back, you can use the
+[system tray](user-guide.md#system-tray) icon or a global shortcut (`Preferences` → `General` → `Global Shortcut`).
 
 ### I cannot change or reset my global shortcut
 
@@ -115,6 +115,7 @@ to show recording and transcription progress.
 
 **How to fix it:** Enable **Record in background** in `Preferences` → `General` → `App Behavior`.
 When active, recording, transcription, and typing all run silently without showing the main window.
+You can still control the app from the [system tray](user-guide.md#system-tray) icon.
 
 **Note:** Because Speed of Sound uses the Desktop Portals standard, your desktop environment will still
 display a microphone in-use indicator while recording is active and while the app has typing permissions.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -15,6 +15,23 @@ opens a menu where you can access Preferences, Keyboard Shortcuts, the About scr
 !!! note "Recording limit"
     Each recording is capped at 30 seconds. When the limit is reached, transcription starts automatically.
 
+## System Tray
+
+Speed of Sound includes a system tray icon on desktops that support it, such as KDE Plasma and XFCE. This uses the
+standard [FreeDesktop specification](https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/),
+so it works with any compatible desktop. Left-clicking the icon opens the main window, right-clicking shows a context
+menu with options to start or stop listening, open the app, or quit.
+
+This is especially useful in combination with **Stay hidden on activation** and **Record in background**
+(see [Preferences](#preferences) below), which let the app run entirely in the background with the tray as your
+primary access point.
+
+!!! note "GNOME users"
+    Some GNOME-based distributions do not display status tray icons by default. On Ubuntu, the
+    [AppIndicator Support](https://extensions.gnome.org/extension/615/appindicator-support/)
+    extension comes pre-installed and the tray icon will appear automatically. On other distributions,
+    like Fedora, you will need to install that extension manually to see the tray icon.
+
 ## Keyboard shortcuts
 
 Most shortcuts are only active when the Speed of Sound main window is open and focused. The exception is `Super+Z`
@@ -71,7 +88,8 @@ Speed of Sound to your system's startup applications, the app will be ready in t
 can begin dictating using the shortcut without any window appearing first.
 
 - Enable **Record in background** to keep the main window hidden during recordings. In this case, the pipeline runs
-entirely in the background. You can still access the window at any time from the dock.
+entirely in the background. You can still access the window at any time from the dock or the
+[system tray](#system-tray).
 
 - Enable **Hide instead of minimize** to hide the main window instead of minimizing it when not in use. This is useful
 on multi-workspace setups where you want the window to restore on the current workspace.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ onnx = "1.24.3"
 onnxExtensions = "0.13.0"
 openai = "4.30.0"
 shadow = "9.4.1"
-stargate = "0.5.0"
+stargate = "0.5.1"
 versionsPlugin = "0.53.0"
 
 [libraries]

--- a/io.speedofsound.SpeedOfSound.yml
+++ b/io.speedofsound.SpeedOfSound.yml
@@ -15,6 +15,7 @@ finish-args:
   - --socket=fallback-x11    # Show windows using X11 if Wayland is not available
   - --share=ipc              # Share IPC namespace with the host (needed for X11 performance)
   - --socket=pulseaudio      # Access to PulseAudio (includes mic input)
+  - --talk-name=org.kde.StatusNotifierWatcher  # System tray via StatusNotifier/AppIndicator
   - --env=JAVA_HOME=/app/jre # See: https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk25
 
 modules:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,6 +78,7 @@ apps:
       - audio-playback # Required alongside audio-record by Snap Store policy
       - alsa           # Java (javax.sound) uses ALSA
       - gsettings     # GSettings access for GioStore
+      - unity7        # StatusNotifier/AppIndicator support on non-GNOME desktops
     environment:
       JAVA_HOME: $SNAP/usr/lib/jvm/java-25-openjdk-amd64
       PATH: $SNAP/usr/lib/jvm/java-25-openjdk-amd64/bin:$PATH


### PR DESCRIPTION
## Summary
- Add a system tray icon using the StatusNotifier D-Bus protocol (via Stargate SDK)
- Tray menu provides Start/Stop Listening, Open App, and Quit actions
- Uses the app icon in Flatpak/Snap; falls back to the standard FreeDesktop microphone icon in other environments
- Integrates into the app lifecycle with proper thread safety (GLib.idleAdd) and cleanup on shutdown

## Test plan
- [ ] Verify tray icon appears on GNOME (with AppIndicator extension), KDE, and other StatusNotifier-supporting desktops
- [ ] Test Start/Stop Listening menu action toggles recording
- [ ] Test Open App menu action presents the main window
- [ ] Test Quit menu action exits the application
- [ ] Test left-click (Activate) and right-click (SecondaryActivate) open the app
- [ ] Verify app still works correctly when StatusNotifierWatcher is unavailable (e.g., no tray support)
- [ ] Verify icon shows correctly in Flatpak, Snap, and JAR/AppImage environments