### PR TITLE
fix: ensure Sherpa stream is released on transcription failure

### DIFF
--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaOfflineAsr.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaOfflineAsr.kt
@@ -111,17 +111,16 @@ abstract class SherpaOfflineAsr<Options : AsrPluginOptions>(
     override fun transcribe(request: AsrRequest): Result<AsrResponse> = runCatching {
         ensureRecognizerLanguage()
         val currentRecognizer = recognizer ?: error("Recognizer not initialized, plugin must be enabled first")
+        val stream = currentRecognizer.createStream()
         try {
-            val stream = currentRecognizer.createStream()
+            log.info("Transcribing with ${currentOptions.modelId}/$recognizerLanguage")
             val floatArray = AudioManager.convertPcm16ToFloat(request.audioData)
             stream.acceptWaveform(floatArray, request.audioInfo.sampleRate)
-
-            log.info("Transcribing with ${currentOptions.modelId}/$recognizerLanguage")
             currentRecognizer.decode(stream)
             val text = currentRecognizer.getResult(stream).text
-            stream.release()
             AsrResponse(text)
         } finally {
+            stream.release()
             log.info("Transcription completed.")
         }
     }


### PR DESCRIPTION
## Summary
- Moves `stream.release()` into the `finally` block in `SherpaOfflineAsr.transcribe()` so the native stream resource is always freed, even when an exception occurs during audio conversion, decoding, or result retrieval.
- Moves stream creation before the `try` block to follow the standard acquire-outside / release-in-finally pattern.

## Test plan
- [ ] Run `make check` to verify detekt and compilation pass
- [ ] Trigger a transcription to confirm normal path still works
- [ ] Verify stream cleanup by inspecting logs after a forced transcription error