### PR TITLE
feat: tap language label to toggle between primary and secondary language

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -329,6 +329,11 @@ class MainViewModel(
         director.updateOptions(director.getOptions().copy(language = language))
     }
 
+    fun onLanguageToggled() {
+        val primaryLanguage = languageFromIso2(settingsClient.getDefaultLanguage()) ?: DEFAULT_LANGUAGE
+        if (state.currentLanguage() == primaryLanguage) onSecondaryLanguageSelected() else onPrimaryLanguageSelected()
+    }
+
     private fun onSecondaryLanguageUpdated() {
         val primaryLanguage = languageFromIso2(settingsClient.getDefaultLanguage()) ?: DEFAULT_LANGUAGE
         if (state.currentLanguage() == primaryLanguage) return

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
@@ -66,7 +66,7 @@ class MainWindow(
         portalsBanner = buildBannerWidget { viewModel.startPortalsSession() }
         notSupportedBanner = buildNotSupportedBannerWidget { viewModel.openUri(APPLICATION_URL_TROUBLESHOOTING) }
         audioWidget = AudioWidget(onToggle = { viewModel.toggleListening() })
-        statusWidget = StatusWidget()
+        statusWidget = StatusWidget(onLanguageClicked = { viewModel.onLanguageToggled() })
 
         val contentBox = Box.builder()
             .setOrientation(Orientation.VERTICAL)

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/StatusWidget.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/StatusWidget.kt
@@ -3,13 +3,17 @@ package com.zugaldia.speedofsound.app.screens.main
 import com.zugaldia.speedofsound.app.DEFAULT_BOX_SPACING
 import com.zugaldia.speedofsound.app.DEFAULT_MARGIN
 import com.zugaldia.speedofsound.app.SEPARATOR_CHARACTER
+import org.gnome.gdk.Cursor
 import org.gnome.gtk.Align
 import org.gnome.gtk.Box
+import org.gnome.gtk.GestureClick
 import org.gnome.gtk.Label
 import org.gnome.gtk.Orientation
 import org.gnome.pango.EllipsizeMode
 
-class StatusWidget : Box() {
+class StatusWidget(
+    private val onLanguageClicked: () -> Unit,
+) : Box() {
     private val asrModelLabel: Label
     private val llmModelSeparator: Label
     private val llmModelLabel: Label
@@ -41,7 +45,12 @@ class StatusWidget : Box() {
 
         append(createStatusLabel(SEPARATOR_CHARACTER, isDimmed = true))
 
-        languageLabel = createStatusLabel("", isDimmed = true)
+        languageLabel = createStatusLabel("", isDimmed = true).also {
+            it.cursor = Cursor.fromName("pointer", null)
+            it.addController(GestureClick().apply {
+                onReleased { _, _, _ -> onLanguageClicked() }
+            })
+        }
         append(languageLabel)
     }
 


### PR DESCRIPTION
## Summary

- Adds `onLanguageToggled()` to `MainViewModel`: checks current language against primary and delegates to the existing `onPrimaryLanguageSelected()` / `onSecondaryLanguageSelected()` methods
- Adds `onLanguageClicked` callback to `StatusWidget` (mirrors `AudioWidget` pattern); attaches a `GestureClick` controller and pointer cursor to the language label
- Wires the callback in `MainWindow` to `viewModel.onLanguageToggled()`

Partially addresses #155 — tablet/2-in-1 users whose on-screen keyboards don't send Shift events can now tap the language label to switch languages.