### PR TITLE
feat: add configurable recording timeout setting in General preferences

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -17,6 +17,7 @@ import com.zugaldia.speedofsound.core.desktop.settings.KEY_CREDENTIALS
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_CUSTOM_CONTEXT
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_CUSTOM_VOCABULARY
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_DEFAULT_LANGUAGE
+import com.zugaldia.speedofsound.core.desktop.settings.KEY_MAX_RECORDING_DURATION_S
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_SECONDARY_LANGUAGE
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_SELECTED_TEXT_MODEL_PROVIDER_ID
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_SELECTED_VOICE_MODEL_PROVIDER_ID
@@ -276,6 +277,10 @@ class MainViewModel(
                 asrProviderManager.refreshProviderConfiguration()
                 llmProviderManager.refreshProviderConfiguration()
             }
+
+            KEY_MAX_RECORDING_DURATION_S -> director.updateOptions(
+                director.getOptions().copy(maxRecordingDurationMs = settingsClient.getMaxRecordingDurationMs())
+            )
 
             KEY_TEXT_OUTPUT_METHOD -> activateSelectedTextOutput()
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
@@ -61,6 +61,10 @@ class PreferencesViewModel(
     fun getSecondaryLanguage(): String = settingsClient.getSecondaryLanguage()
     fun setSecondaryLanguage(value: String): Boolean = settingsClient.setSecondaryLanguage(value)
 
+    fun getMaxRecordingDurationS(): Int = (settingsClient.getMaxRecordingDurationMs() / 1000L).toInt()
+    fun setMaxRecordingDurationS(value: Int): Boolean =
+        settingsClient.setMaxRecordingDurationMs(value.toLong() * 1000L)
+
     fun getAppendSpace(): Boolean = settingsClient.getAppendSpace()
     fun setAppendSpace(value: Boolean): Boolean = settingsClient.setAppendSpace(value)
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import org.gnome.adw.ActionRow
 import org.gnome.adw.PreferencesGroup
 import org.gnome.adw.PreferencesPage
+import org.gnome.adw.SpinRow
 import org.gnome.adw.SwitchRow
 import org.gnome.glib.GLib
 import org.gnome.gtk.Align
@@ -26,6 +27,7 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
     private val primaryComboRow: LanguageComboRow
     private val secondaryComboRow: LanguageComboRow
     private val textOutputMethodRow: TextOutputMethodComboRow
+    private val maxRecordingDurationRow: SpinRow
     private val appendSpaceRow: SwitchRow
     private val shortcutManualRow: ActionRow
     private val shortcutSetupRow: ActionRow
@@ -103,9 +105,17 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
             active = viewModel.getAppendSpace()
         }
 
+        maxRecordingDurationRow = SpinRow.withRange(RECORDING_DURATION_MIN, RECORDING_DURATION_MAX, RECORDING_DURATION_STEP).apply {
+            title = "Recording Timeout"
+            subtitle = "Maximum recording duration in seconds."
+            digits = 0
+            value = viewModel.getMaxRecordingDurationS().toDouble()
+        }
+
         val outputGroup = PreferencesGroup().apply {
             title = "Output"
             add(textOutputMethodRow)
+            add(maxRecordingDurationRow)
             add(appendSpaceRow)
         }
 
@@ -145,6 +155,9 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
         primaryComboRow.setupNotifications()
         secondaryComboRow.setupNotifications()
         textOutputMethodRow.setupNotifications()
+        maxRecordingDurationRow.onNotify("value") {
+            viewModel.setMaxRecordingDurationS(maxRecordingDurationRow.value.toInt())
+        }
         appendSpaceRow.onNotify("active") { viewModel.setAppendSpace(appendSpaceRow.active) }
         stayHiddenOnActivationRow.onNotify("active") {
             viewModel.setStayHiddenOnActivation(stayHiddenOnActivationRow.active)
@@ -159,6 +172,7 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
         primaryComboRow.refresh()
         secondaryComboRow.refresh()
         textOutputMethodRow.refresh()
+        maxRecordingDurationRow.value = viewModel.getMaxRecordingDurationS().toDouble()
         appendSpaceRow.active = viewModel.getAppendSpace()
         stayHiddenOnActivationRow.active = viewModel.getStayHiddenOnActivation()
         backgroundRecordingRow.active = viewModel.getBackgroundRecording()
@@ -286,5 +300,11 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
     private fun createHelpButton(): Button = Button.withLabel("Help").apply {
         valign = Align.CENTER
         onClicked { scope.launch { viewModel.openDocumentationUri() } }
+    }
+
+    companion object {
+        private const val RECORDING_DURATION_MIN = 10.0
+        private const val RECORDING_DURATION_MAX = 600.0
+        private const val RECORDING_DURATION_STEP = 5.0
     }
 }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
@@ -99,8 +99,17 @@ class SettingsClient(val settingsStore: SettingsStore) {
         enableTextProcessing = getTextProcessingEnabled(),
         language = languageFromIso2(getDefaultLanguage()) ?: DEFAULT_LANGUAGE,
         customVocabulary = getCustomVocabulary(),
-        customContext = getCustomContext()
+        customContext = getCustomContext(),
+        maxRecordingDurationMs = getMaxRecordingDurationMs()
     )
+
+    fun getMaxRecordingDurationMs(): Long =
+        settingsStore.getInt(KEY_MAX_RECORDING_DURATION_S, DEFAULT_MAX_RECORDING_DURATION_S).toLong() * 1000L
+
+    fun setMaxRecordingDurationMs(value: Long): Boolean =
+        settingsStore.setInt(KEY_MAX_RECORDING_DURATION_S, (value / 1000L).toInt()).also { success ->
+            if (success) _settingsChanged.tryEmit(KEY_MAX_RECORDING_DURATION_S)
+        }
 
     /*
      * Not exposed to the UI

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
@@ -35,6 +35,9 @@ const val DEFAULT_HIDE_INSTEAD_OF_MINIMIZE = false
 const val KEY_STAY_HIDDEN_ON_ACTIVATION = "stay-hidden-on-activation"
 const val DEFAULT_STAY_HIDDEN_ON_ACTIVATION = false
 
+const val KEY_MAX_RECORDING_DURATION_S = "max-recording-duration-s"
+const val DEFAULT_MAX_RECORDING_DURATION_S = 30
+
 const val KEY_APPEND_SPACE = "append-space"
 const val DEFAULT_APPEND_SPACE = false
 

--- a/data/io.speedofsound.SpeedOfSound.gschema.xml
+++ b/data/io.speedofsound.SpeedOfSound.gschema.xml
@@ -41,6 +41,12 @@
       <summary>Text output method</summary>
       <description>How transcribed text is delivered to the active application. 'portal' simulates keyboard input via the XDG Remote Desktop Portal. 'clipboard' copies the text to the clipboard and simulates Ctrl+V to paste it.</description>
     </key>
+    <key name="max-recording-duration-s" type="i">
+      <range min="10" max="600"/>
+      <default>30</default>
+      <summary>Maximum recording duration (s)</summary>
+      <description>Maximum duration in seconds for each recording. The recording automatically stops and transcription starts when this limit is reached.</description>
+    </key>
     <key name="append-space" type="b">
       <default>false</default>
       <summary>Append space after transcription</summary>


### PR DESCRIPTION
## Summary

Adds a **Recording Timeout** setting to the General preferences page, allowing users to adjust the maximum recording duration from the default 30s up to 600s (10 minutes).
Previously, the recording timeout was a hardcoded constant (`DEFAULT_MAX_RECORDING_DURATION_MS`). This change wires it through the settings pipeline so it persists and can be changed from the UI.

## Changes
- **`gschema.xml`** — Added `max-recording-duration-s` key (type `int`, range 10–600, default 30)
- **`SettingsConstants.kt`** — Added `KEY_MAX_RECORDING_DURATION_S` and `DEFAULT_MAX_RECORDING_DURATION_S`
- **`SettingsClient.kt`** — Added `getMaxRecordingDurationMs()` / `setMaxRecordingDurationMs()`, included in `getDirectorOptions()` so the director picks it up
- **`PreferencesViewModel.kt`** — Delegate methods converting between stored seconds and UI
- **`GeneralPage.kt`** — Added `SpinRow.withRange(10, 600, 5)` labeled "Recording Timeout" in the Output preferences group
- **`MainViewModel.kt`** — Reacts to setting changes and updates the director via `director.updateOptions()`