### PR TITLE
fix: remove transcription text from log output

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -363,7 +363,7 @@ class MainViewModel(
     }
 
     private fun onPipelineCompleted(event: DirectorEvent.PipelineCompleted) {
-        logger.info("Pipeline completed: $event")
+        logger.info("Pipeline completed.")
         if (event.finalResult.isBlank()) {
             hideAndReset()
             return

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/director/DefaultDirector.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/director/DefaultDirector.kt
@@ -155,7 +155,7 @@ class DefaultDirector(
             llmResult.isSuccess -> llmResult.getOrNull()?.text
             else -> {
                 val error = llmResult.exceptionOrNull() ?: Exception("Unknown error")
-                log.error("LLM failed: ${error.message}. Raw transcription was: $rawTranscription.")
+                log.error("LLM failed: ${error.message}.")
                 emitEvent(DirectorEvent.PipelineError(PipelineStage.POLISHING, error))
                 null
             }


### PR DESCRIPTION
Fixes #168.

Transcription content was leaking into system logs via two log statements, contradicting the FAQ's privacy guarantee. Removed the transcription text from both.