### PR TITLE
chore: update LLM model options to latest versions

### DIFF
--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/llm/AnthropicLlmOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/llm/AnthropicLlmOptions.kt
@@ -3,17 +3,17 @@ package com.zugaldia.speedofsound.core.plugins.llm
 import com.anthropic.models.messages.Model
 import com.zugaldia.speedofsound.core.models.text.TextModel
 
-val DEFAULT_LLM_ANTHROPIC_MODEL_ID = Model.CLAUDE_SONNET_4_5.asString()
+val DEFAULT_LLM_ANTHROPIC_MODEL_ID = Model.CLAUDE_SONNET_4_6.asString()
 
 val SUPPORTED_ANTHROPIC_TEXT_MODELS = mapOf(
-    Model.CLAUDE_OPUS_4_5.asString() to TextModel(
-        id = Model.CLAUDE_OPUS_4_5.asString(),
-        name = "Claude Opus 4.5",
+    Model.CLAUDE_OPUS_4_7.asString() to TextModel(
+        id = Model.CLAUDE_OPUS_4_7.asString(),
+        name = "Claude Opus 4.7",
         provider = LlmProvider.ANTHROPIC
     ),
-    Model.CLAUDE_SONNET_4_5.asString() to TextModel(
-        id = Model.CLAUDE_SONNET_4_5.asString(),
-        name = "Claude Sonnet 4.5",
+    Model.CLAUDE_SONNET_4_6.asString() to TextModel(
+        id = Model.CLAUDE_SONNET_4_6.asString(),
+        name = "Claude Sonnet 4.6",
         provider = LlmProvider.ANTHROPIC
     ),
     Model.CLAUDE_HAIKU_4_5.asString() to TextModel(

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/llm/GoogleLlmOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/llm/GoogleLlmOptions.kt
@@ -2,37 +2,17 @@ package com.zugaldia.speedofsound.core.plugins.llm
 
 import com.zugaldia.speedofsound.core.models.text.TextModel
 
-const val DEFAULT_LLM_GOOGLE_MODEL_ID = "gemini-2.5-flash-lite"
+const val DEFAULT_LLM_GOOGLE_MODEL_ID = "gemini-3.1-flash-lite"
 
 val SUPPORTED_GOOGLE_TEXT_MODELS = mapOf(
-    "gemini-3.1-pro-preview" to TextModel(
-        id = "gemini-3.1-pro-preview",
-        name = "Gemini 3.1 Pro Preview",
+    "gemini-3.5-flash" to TextModel(
+        id = "gemini-3.5-flash",
+        name = "Gemini 3.5 Flash",
         provider = LlmProvider.GOOGLE
     ),
-    "gemini-3.1-flash-lite-preview" to TextModel(
-        id = "gemini-3.1-flash-lite-preview",
-        name = "Gemini 3.1 Flash Lite Preview",
-        provider = LlmProvider.GOOGLE
-    ),
-    "gemini-3-flash-preview" to TextModel(
-        id = "gemini-3-flash-preview",
-        name = "Gemini 3 Flash Preview",
-        provider = LlmProvider.GOOGLE
-    ),
-    "gemini-2.5-pro" to TextModel(
-        id = "gemini-2.5-pro",
-        name = "Gemini 2.5 Pro",
-        provider = LlmProvider.GOOGLE
-    ),
-    "gemini-2.5-flash" to TextModel(
-        id = "gemini-2.5-flash",
-        name = "Gemini 2.5 Flash",
-        provider = LlmProvider.GOOGLE
-    ),
-    "gemini-2.5-flash-lite" to TextModel(
-        id = "gemini-2.5-flash-lite",
-        name = "Gemini 2.5 Flash Lite",
+    "gemini-3.1-flash-lite" to TextModel(
+        id = "gemini-3.1-flash-lite",
+        name = "Gemini 3.1 Flash Lite",
         provider = LlmProvider.GOOGLE
     ),
 )

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/llm/OpenAiLlmOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/llm/OpenAiLlmOptions.kt
@@ -21,11 +21,6 @@ val SUPPORTED_OPENAI_TEXT_MODELS = mapOf(
         name = "GPT 5.4 Nano",
         provider = LlmProvider.OPENAI
     ),
-    ChatModel.GPT_5_2_PRO.asString() to TextModel(
-        id = ChatModel.GPT_5_2_PRO.asString(),
-        name = "GPT 5.2 Pro",
-        provider = LlmProvider.OPENAI
-    ),
 )
 
 data class OpenAiLlmOptions(


### PR DESCRIPTION
## Summary

- **Anthropic:** bump default from Sonnet 4.5 to Sonnet 4.6; replace Opus 4.5 with Opus 4.7
- **Google:** switch default to `gemini-3.1-flash-lite`; replace the previous list with stable `gemini-3.5-flash` and `gemini-3.1-flash-lite` entries
- **OpenAI:** remove `GPT 5.2 Pro` from the supported-models map

## Motivation

The goal is to keep the supported model list aligned with the latest stable model IDs from each provider. Preview and versioned-preview model names (e.g. `gemini-3.1-flash-lite-preview`, `gemini-3-flash-preview`) tend to be deprecated faster than their stable counterparts, which causes silent API failures for users who configured the app with those IDs. Removing them in favour of stable, GA model names reduces churn and avoids broken configurations on provider-side deprecations.

## Test plan

- [ ] Build passes (`make build`)
- [ ] Static analysis clean (`make check`)
- [ ] Add-provider dialog shows updated model names for Anthropic, Google, and OpenAI
- [ ] Default model is pre-selected correctly for each provider in a fresh configuration