### PR TITLE
Fix expected SHA256 for Parakeet TDT 110M (English only)

### DIFF
--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaParakeetAsrModels.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaParakeetAsrModels.kt
@@ -74,7 +74,7 @@ val SUPPORTED_SHERPA_PARAKEET_ASR_MODELS = mapOf(
         archiveFile = VoiceModelFile(
             name = "sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000",
             url = "$SHERPA_ONNX_ASR_MODELS_URL/sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000.tar.bz2",
-            sha256sum = "4cb81f605eb7bc6fe0d69cd9d4045161e1691a64c2b7d4f1e7d5099e1d3bc024"
+            sha256sum = "20358a9587ce150a87afd7aa4984ee7aebb1e35c154fc38a6639a3ed9b6adbb6"
         ),
         components = listOf(
             VoiceModelFile(name = "encoder.onnx"),


### PR DESCRIPTION
### Summary

Fix #177 

Update the SHA256 checksum for the Parakeet TDT 110M (English only) model so the app accepts the current upstream archive published by Sherpa ONNX.

### What changed

- Updated the model catalog entry for `sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000` in `core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/SherpaParakeetAsrModels.kt`.
- Replaced the stale checksum with the current value from the published archive.

### Why

The archive download itself succeeds, but the app rejects it during the integrity check because the catalog still expects an older SHA256. This prevents the model from being installed.

### Verification

- Confirmed the model entry now uses the current checksum value.
- Verified the change is limited to the affected Parakeet catalog entry.

### Notes

No automated regression tests were added for this small catalog correction, since the change is a direct checksum update and the current environment is not set up for full app-level validation.
