### PR TITLE
feat: add a close to background setting

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/App.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/App.kt
@@ -30,7 +30,7 @@ fun main(args: Array<String>) {
 
 class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Application(applicationId, flags) {
     private var mainWindow: MainWindow? = null
-    private var isHoldingForHiddenStart = false
+    private var isHoldingInBackground = false
     private var statusNotifierService: StatusNotifierService? = null
 
     private lateinit var settingsClient: SettingsClient
@@ -76,13 +76,8 @@ class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Appl
                 }.present()
             } else if (!settingsClient.getStayHiddenOnActivation()) {
                 presentMainWindow()
-            } else if (!isHoldingForHiddenStart) {
-                // Keep the app alive without a visible window. GApplication auto-quits
-                // when its use-count drops to zero (no visible windows), hold() prevents
-                // that until the user triggers the global shortcut for the first time.
-                // https://github.com/zugaldia/speedofsound/issues/141
-                hold()
-                isHoldingForHiddenStart = true
+            } else {
+                holdInBackground()
             }
         }
 
@@ -145,11 +140,27 @@ class SosApplication(applicationId: String, flags: Set<ApplicationFlags>) : Appl
         }
     }
 
-    private fun presentMainWindow() {
-        if (isHoldingForHiddenStart) {
-            release()
-            isHoldingForHiddenStart = false
+    /**
+     * Keeps the app alive without a visible window. GApplication auto-quits when its use-count drops to
+     * zero (no visible windows), hold() prevents that until the window is presented again.
+     * https://github.com/zugaldia/speedofsound/issues/141
+     */
+    fun holdInBackground() {
+        if (!isHoldingInBackground) {
+            hold()
+            isHoldingInBackground = true
         }
+    }
+
+    private fun releaseBackgroundHold() {
+        if (isHoldingInBackground) {
+            release()
+            isHoldingInBackground = false
+        }
+    }
+
+    private fun presentMainWindow() {
+        releaseBackgroundHold()
         mainWindow?.present()
     }
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainWindow.kt
@@ -2,6 +2,7 @@
 
 package com.zugaldia.speedofsound.app.screens.main
 
+import com.zugaldia.speedofsound.app.SosApplication
 import com.zugaldia.speedofsound.app.DEFAULT_WINDOW_HEIGHT
 import com.zugaldia.speedofsound.app.DEFAULT_WINDOW_WIDTH
 import com.zugaldia.speedofsound.app.ICON_MENU
@@ -38,7 +39,7 @@ import org.gnome.gtk.Orientation
 import org.gnome.gtk.Separator
 
 class MainWindow(
-    app: Application,
+    private val app: Application,
     private val viewModel: MainViewModel,
     private val settingsClient: SettingsClient,
     private val portalsClient: PortalsClient,
@@ -54,6 +55,9 @@ class MainWindow(
     // https://github.com/zugaldia/speedofsound/issues/29
     private var shouldHideOnCompletion = true
 
+    // Set while the app is actually quitting, so the close-to-background handler lets the window go
+    private var isQuitting = false
+
     init {
         application = app
         title = APPLICATION_NAME
@@ -62,6 +66,7 @@ class MainWindow(
         addController(EventControllerKey().apply {
             onKeyPressed { keyval, _, state -> keyPressed(keyval, state) }
         })
+        onCloseRequest { closeRequested() }
 
         portalsBanner = buildBannerWidget { viewModel.startPortalsSession() }
         notSupportedBanner = buildNotSupportedBannerWidget { viewModel.openUri(APPLICATION_URL_TROUBLESHOOTING) }
@@ -190,6 +195,22 @@ class MainWindow(
         }
     }
 
+    /**
+     * Handles the window close button. With "Close to background" enabled, the window is hidden and the app
+     * keeps running (reachable from the status icon, the global shortcut, and the dock) instead of quitting.
+     *
+     * @return true to stop the window from being destroyed, false to let the default handler close it.
+     */
+    private fun closeRequested(): Boolean {
+        if (isQuitting || !settingsClient.getCloseToBackground()) return false
+        // Closing the window stops any dictation in progress: closing is an explicit "I am done here",
+        // and a recording that survived it would keep the microphone open with no visible indication.
+        viewModel.cancelListening()
+        visible = false
+        (app as? SosApplication)?.holdInBackground()
+        return true
+    }
+
     private fun goAway() {
         if (settingsClient.getHideInsteadOfMinimize()) {
             // Hide the window so it restores on the current workspace (where the target app is),
@@ -235,7 +256,8 @@ class MainWindow(
     }
 
     private fun onQuit() {
+        isQuitting = true
         viewModel.cancelListening()
-        close()
+        app.quit()
     }
 }

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
@@ -55,6 +55,9 @@ class PreferencesViewModel(
     fun getStayHiddenOnActivation(): Boolean = settingsClient.getStayHiddenOnActivation()
     fun setStayHiddenOnActivation(value: Boolean): Boolean = settingsClient.setStayHiddenOnActivation(value)
 
+    fun getCloseToBackground(): Boolean = settingsClient.getCloseToBackground()
+    fun setCloseToBackground(value: Boolean): Boolean = settingsClient.setCloseToBackground(value)
+
     fun getDefaultLanguage(): String = settingsClient.getDefaultLanguage()
     fun setDefaultLanguage(value: String): Boolean = settingsClient.setDefaultLanguage(value)
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
@@ -23,6 +23,7 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
     private val stayHiddenOnActivationRow: SwitchRow
     private val backgroundRecordingRow: SwitchRow
     private val hideInsteadOfMinimizeRow: SwitchRow
+    private val closeToBackgroundRow: SwitchRow
     private val primaryComboRow: LanguageComboRow
     private val secondaryComboRow: LanguageComboRow
     private val textOutputMethodRow: TextOutputMethodComboRow
@@ -127,11 +128,19 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
             active = viewModel.getHideInsteadOfMinimize()
         }
 
+        closeToBackgroundRow = SwitchRow().apply {
+            title = "Close to background"
+            subtitle = "Closing the window keeps the app running, " +
+                "so the global shortcut and the status icon stay available."
+            active = viewModel.getCloseToBackground()
+        }
+
         val behaviorGroup = PreferencesGroup().apply {
             title = "App Behavior"
             add(stayHiddenOnActivationRow)
             add(backgroundRecordingRow)
             add(hideInsteadOfMinimizeRow)
+            add(closeToBackgroundRow)
         }
 
         add(globalShortcutGroup)
@@ -153,6 +162,7 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
         hideInsteadOfMinimizeRow.onNotify("active") {
             viewModel.setHideInsteadOfMinimize(hideInsteadOfMinimizeRow.active)
         }
+        closeToBackgroundRow.onNotify("active") { viewModel.setCloseToBackground(closeToBackgroundRow.active) }
     }
 
     fun refresh() {
@@ -163,6 +173,7 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
         stayHiddenOnActivationRow.active = viewModel.getStayHiddenOnActivation()
         backgroundRecordingRow.active = viewModel.getBackgroundRecording()
         hideInsteadOfMinimizeRow.active = viewModel.getHideInsteadOfMinimize()
+        closeToBackgroundRow.active = viewModel.getCloseToBackground()
     }
 
     /*

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
@@ -176,6 +176,14 @@ class SettingsClient(val settingsStore: SettingsStore) {
             if (success) _settingsChanged.tryEmit(KEY_STAY_HIDDEN_ON_ACTIVATION)
         }
 
+    fun getCloseToBackground(): Boolean =
+        settingsStore.getBoolean(KEY_CLOSE_TO_BACKGROUND, DEFAULT_CLOSE_TO_BACKGROUND)
+
+    fun setCloseToBackground(value: Boolean): Boolean =
+        settingsStore.setBoolean(KEY_CLOSE_TO_BACKGROUND, value).also { success ->
+            if (success) _settingsChanged.tryEmit(KEY_CLOSE_TO_BACKGROUND)
+        }
+
     fun getTextOutputMethod(): String =
         settingsStore.getString(KEY_TEXT_OUTPUT_METHOD, DEFAULT_TEXT_OUTPUT_METHOD)
 

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
@@ -35,6 +35,9 @@ const val DEFAULT_HIDE_INSTEAD_OF_MINIMIZE = false
 const val KEY_STAY_HIDDEN_ON_ACTIVATION = "stay-hidden-on-activation"
 const val DEFAULT_STAY_HIDDEN_ON_ACTIVATION = false
 
+const val KEY_CLOSE_TO_BACKGROUND = "close-to-background"
+const val DEFAULT_CLOSE_TO_BACKGROUND = false
+
 const val KEY_APPEND_SPACE = "append-space"
 const val DEFAULT_APPEND_SPACE = false
 

--- a/data/io.speedofsound.SpeedOfSound.gschema.xml
+++ b/data/io.speedofsound.SpeedOfSound.gschema.xml
@@ -56,6 +56,11 @@
       <summary>Stay hidden on activation</summary>
       <description>When enabled, the app starts without showing the main window. The global shortcut still works normally.</description>
     </key>
+    <key name="close-to-background" type="b">
+      <default>false</default>
+      <summary>Close to background</summary>
+      <description>When enabled, closing the main window hides it instead of quitting the application. The app keeps running in the background, so the global shortcut and the status icon remain available.</description>
+    </key>
 
     <!-- Cloud Credentials page -->
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -105,6 +105,11 @@ entirely in the background. You can still access the window at any time from the
 - Enable **Hide instead of minimize** to hide the main window instead of minimizing it when not in use. This is useful
 on multi-workspace setups where you want the window to restore on the current workspace.
 
+- Enable **Close to background** to keep the app running when you close the main window, instead of quitting. The
+window is hidden and the app stays reachable from the shortcut, the [system tray](#system-tray), and the dock. A
+dictation in progress is stopped when you close the window. Use **Quit** (from the menu, `Ctrl+Q`, or the system tray)
+to exit the app.
+
 ### Model Library
 
 Browse and manage the locally available voice models. You can download new models or remove ones you no longer need.


### PR DESCRIPTION
## What changed

Adds a **Close to background** setting (General → App Behavior, **off by default**). With it enabled, the
window's close button hides the window and holds the application instead of destroying the window; the app
stays reachable from the status icon, the global shortcut and the dock. Quit — menu, `Ctrl+Q`, status icon —
still exits.

The hold bookkeeping introduced in #141 is generalized so present/hide stay balanced: `holdInBackground()`
is idempotent and `presentMainWindow()` is the single release point.

## Why

Fixes #183. `MainWindow` has no `close-request` handler, so closing destroys the window, `GApplication`'s use
count drops to zero and the process exits — and for an app driven by a global shortcut that is easy to hit
by accident, because closing the window looks like putting it away rather than quitting.

A dictation in progress is stopped when the window is closed: closing reads as "I am done here", and a
recording that survived it would keep the microphone open with nothing on screen. Documented as such.

## Testing instructions

1. Enable **Close to background** (and, to match the reported setup, *Stay hidden on activation* + *Record in
   background*).
2. Open the window, close it with the title bar button → the process stays alive; the status icon is still
   there and the global shortcut still starts a dictation.
3. Status icon → **Open App** brings the window back; **Quit**, the menu item and `Ctrl+Q` all exit for real
   (no lingering process).
4. Turn the setting off → closing quits again, exactly as today.

Verified on Fedora Asahi Remix 43 (aarch64), GNOME Shell 49.8 on Wayland, Flatpak build.
`./gradlew check` passes (tests + detekt). The user guide is updated in the same commit.

Note: this touches `GeneralPage`/`PreferencesViewModel`, so it will conflict textually with my other two
PRs — happy to rebase in whatever order you prefer to merge them.
