### PR TITLE
feat: make the recording timeout configurable, capped per ASR backend

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -17,6 +17,7 @@ import com.zugaldia.speedofsound.core.desktop.settings.KEY_CREDENTIALS
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_CUSTOM_CONTEXT
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_CUSTOM_VOCABULARY
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_DEFAULT_LANGUAGE
+import com.zugaldia.speedofsound.core.desktop.settings.KEY_MAX_RECORDING_DURATION_S
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_SECONDARY_LANGUAGE
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_SELECTED_TEXT_MODEL_PROVIDER_ID
 import com.zugaldia.speedofsound.core.desktop.settings.KEY_SELECTED_VOICE_MODEL_PROVIDER_ID
@@ -254,6 +255,8 @@ class MainViewModel(
 
             KEY_SELECTED_VOICE_MODEL_PROVIDER_ID -> {
                 asrProviderManager.activateSelectedProvider()
+                // The recording timeout is capped for backends that cannot transcribe longer audio
+                updateMaxRecordingDuration()
                 updateModelLabels()
             }
 
@@ -277,6 +280,12 @@ class MainViewModel(
                 llmProviderManager.refreshProviderConfiguration()
             }
 
+            else -> refreshOutputSettings(key)
+        }
+    }
+
+    private fun refreshOutputSettings(key: String) {
+        when (key) {
             KEY_TEXT_OUTPUT_METHOD -> activateSelectedTextOutput()
 
             KEY_TYPING_DELAY_MS -> portalTextOutput.updateOptions(
@@ -286,7 +295,15 @@ class MainViewModel(
             KEY_SANITIZE_SPECIAL_CHARS -> portalTextOutput.updateOptions(
                 portalTextOutput.getOptions().copy(sanitizeSpecialChars = settingsClient.getSanitizeSpecialChars())
             )
+
+            KEY_MAX_RECORDING_DURATION_S -> updateMaxRecordingDuration()
         }
+    }
+
+    private fun updateMaxRecordingDuration() {
+        director.updateOptions(
+            director.getOptions().copy(maxRecordingDurationMs = settingsClient.getEffectiveMaxRecordingDurationMs())
+        )
     }
 
     private fun updateModelLabels() {

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/PreferencesViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.SharedFlow
 import org.slf4j.LoggerFactory
 
 @Suppress("TooManyFunctions") // ViewModel delegates to SettingsClient for all preference properties
@@ -21,6 +22,9 @@ class PreferencesViewModel(
 ) {
     private val logger = LoggerFactory.getLogger(PreferencesViewModel::class.java)
     val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /** Emits the key of every setting changed elsewhere in the app, so pages can stay in sync. */
+    val settingsChanged: SharedFlow<String> = settingsClient.settingsChanged
 
     init {
         logger.info("Initializing.")
@@ -54,6 +58,11 @@ class PreferencesViewModel(
 
     fun getStayHiddenOnActivation(): Boolean = settingsClient.getStayHiddenOnActivation()
     fun setStayHiddenOnActivation(value: Boolean): Boolean = settingsClient.setStayHiddenOnActivation(value)
+
+    fun getMaxRecordingDurationS(): Int = settingsClient.getMaxRecordingDurationS()
+    fun setMaxRecordingDurationS(value: Int): Boolean = settingsClient.setMaxRecordingDurationS(value)
+
+    fun isSelectedVoiceProviderLimitedTo30s(): Boolean = settingsClient.isSelectedVoiceProviderLimitedTo30s()
 
     fun getDefaultLanguage(): String = settingsClient.getDefaultLanguage()
     fun setDefaultLanguage(value: String): Boolean = settingsClient.setDefaultLanguage(value)

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/preferences/general/GeneralPage.kt
@@ -2,14 +2,19 @@ package com.zugaldia.speedofsound.app.screens.preferences.general
 
 import com.zugaldia.speedofsound.app.ICON_PREFERENCES_SYSTEM
 import com.zugaldia.speedofsound.app.STYLE_CLASS_SUGGESTED_ACTION
+import com.zugaldia.speedofsound.app.STYLE_CLASS_WARNING
 import com.zugaldia.speedofsound.app.screens.preferences.PreferencesViewModel
 import com.zugaldia.speedofsound.core.APPLICATION_SHORTCUT_TRIGGER
+import com.zugaldia.speedofsound.core.desktop.settings.KEY_SELECTED_VOICE_MODEL_PROVIDER_ID
+import com.zugaldia.speedofsound.core.desktop.settings.MAX_MAX_RECORDING_DURATION_S
+import com.zugaldia.speedofsound.core.desktop.settings.MIN_MAX_RECORDING_DURATION_S
 import com.zugaldia.stargate.sdk.globalshortcuts.BoundShortcut
 import com.zugaldia.stargate.sdk.isSandboxed
 import kotlinx.coroutines.launch
 import org.gnome.adw.ActionRow
 import org.gnome.adw.PreferencesGroup
 import org.gnome.adw.PreferencesPage
+import org.gnome.adw.SpinRow
 import org.gnome.adw.SwitchRow
 import org.gnome.glib.GLib
 import org.gnome.gtk.Align
@@ -20,6 +25,16 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
     private val logger = LoggerFactory.getLogger(GeneralPage::class.java)
     private val scope = viewModel.viewModelScope
 
+    companion object {
+        private val RECORDING_TIMEOUT_MIN = MIN_MAX_RECORDING_DURATION_S.toDouble()
+        private val RECORDING_TIMEOUT_MAX = MAX_MAX_RECORDING_DURATION_S.toDouble()
+        private const val RECORDING_TIMEOUT_STEP = 5.0
+        private const val TIMEOUT_NOTE = "Recording stops automatically after this many seconds."
+        private const val WHISPER_LIMIT_NOTE =
+            "Capped at 30 seconds: the selected Whisper model discards longer audio. " +
+                "Switch to Parakeet or Canary for longer dictations."
+    }
+
     private val stayHiddenOnActivationRow: SwitchRow
     private val backgroundRecordingRow: SwitchRow
     private val hideInsteadOfMinimizeRow: SwitchRow
@@ -27,6 +42,7 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
     private val secondaryComboRow: LanguageComboRow
     private val textOutputMethodRow: TextOutputMethodComboRow
     private val appendSpaceRow: SwitchRow
+    private val recordingTimeoutRow: SpinRow
     private val shortcutManualRow: ActionRow
     private val shortcutSetupRow: ActionRow
     private val shortcutActiveRow: ActionRow
@@ -103,10 +119,20 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
             active = viewModel.getAppendSpace()
         }
 
+        recordingTimeoutRow = SpinRow.withRange(
+            RECORDING_TIMEOUT_MIN, RECORDING_TIMEOUT_MAX, RECORDING_TIMEOUT_STEP
+        ).apply {
+            title = "Recording Timeout (seconds)"
+            digits = 0
+            subtitleLines = 0 // Wrap instead of ellipsizing, the spin button leaves little room
+            value = viewModel.getMaxRecordingDurationS().toDouble()
+        }
+
         val outputGroup = PreferencesGroup().apply {
             title = "Output"
             add(textOutputMethodRow)
             add(appendSpaceRow)
+            add(recordingTimeoutRow)
         }
 
         stayHiddenOnActivationRow = SwitchRow().apply {
@@ -153,6 +179,25 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
         hideInsteadOfMinimizeRow.onNotify("active") {
             viewModel.setHideInsteadOfMinimize(hideInsteadOfMinimizeRow.active)
         }
+        recordingTimeoutRow.onNotify("value") {
+            viewModel.setMaxRecordingDurationS(recordingTimeoutRow.value.toInt())
+        }
+        updateRecordingTimeoutSubtitle()
+        watchSelectedVoiceModel()
+    }
+
+    /**
+     * The Whisper 30 second cap note has to follow the model selected on the Voice Models page, which the
+     * user can change while this page is already built.
+     */
+    private fun watchSelectedVoiceModel() {
+        scope.launch {
+            viewModel.settingsChanged.collect { key ->
+                if (key == KEY_SELECTED_VOICE_MODEL_PROVIDER_ID) {
+                    GLib.idleAdd(GLib.PRIORITY_DEFAULT) { updateRecordingTimeoutSubtitle(); false }
+                }
+            }
+        }
     }
 
     fun refresh() {
@@ -163,6 +208,22 @@ class GeneralPage(private val viewModel: PreferencesViewModel) : PreferencesPage
         stayHiddenOnActivationRow.active = viewModel.getStayHiddenOnActivation()
         backgroundRecordingRow.active = viewModel.getBackgroundRecording()
         hideInsteadOfMinimizeRow.active = viewModel.getHideInsteadOfMinimize()
+        recordingTimeoutRow.value = viewModel.getMaxRecordingDurationS().toDouble()
+        updateRecordingTimeoutSubtitle()
+    }
+
+    /**
+     * The timeout is capped at 30 seconds while a local Whisper model is selected, because the model itself
+     * cannot transcribe longer audio. Say so instead of silently ignoring the setting.
+     */
+    private fun updateRecordingTimeoutSubtitle() {
+        val limited = viewModel.isSelectedVoiceProviderLimitedTo30s()
+        recordingTimeoutRow.subtitle = if (limited) WHISPER_LIMIT_NOTE else TIMEOUT_NOTE
+        if (limited) {
+            recordingTimeoutRow.addCssClass(STYLE_CLASS_WARNING)
+        } else {
+            recordingTimeoutRow.removeCssClass(STYLE_CLASS_WARNING)
+        }
     }
 
     /*

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsClient.kt
@@ -4,6 +4,8 @@ import com.zugaldia.speedofsound.core.languageFromIso2
 import com.zugaldia.speedofsound.core.models.voice.ModelManager
 import com.zugaldia.speedofsound.core.plugins.asr.AsrPluginOptions
 import com.zugaldia.speedofsound.core.plugins.asr.AsrProvider
+import com.zugaldia.speedofsound.core.plugins.asr.clampRecordingDurationMs
+import com.zugaldia.speedofsound.core.plugins.asr.isLimitedToThirtySeconds
 import com.zugaldia.speedofsound.core.plugins.asr.OpenAiAsrOptions
 import com.zugaldia.speedofsound.core.plugins.asr.SherpaCanaryAsrOptions
 import com.zugaldia.speedofsound.core.plugins.asr.SherpaParakeetAsrOptions
@@ -24,6 +26,10 @@ import org.slf4j.LoggerFactory
 @Suppress("TooManyFunctions")
 class SettingsClient(val settingsStore: SettingsStore) {
     private val logger = LoggerFactory.getLogger(SettingsClient::class.java)
+
+    companion object {
+        private const val MILLIS_PER_SECOND = 1_000L
+    }
 
     private val _settingsChanged = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val settingsChanged: SharedFlow<String> = _settingsChanged.asSharedFlow()
@@ -99,8 +105,33 @@ class SettingsClient(val settingsStore: SettingsStore) {
         enableTextProcessing = getTextProcessingEnabled(),
         language = languageFromIso2(getDefaultLanguage()) ?: DEFAULT_LANGUAGE,
         customVocabulary = getCustomVocabulary(),
-        customContext = getCustomContext()
+        customContext = getCustomContext(),
+        maxRecordingDurationMs = getEffectiveMaxRecordingDurationMs(),
     )
+
+    /**
+     * Returns the recording timeout to apply to the pipeline, in milliseconds.
+     *
+     * The user-configured value is capped for backends that cannot process longer audio: the Sherpa ONNX
+     * offline Whisper recognizer truncates anything past 30 seconds, so a longer timeout there would only
+     * record audio that is silently discarded. Every other backend (Parakeet, Canary, cloud providers)
+     * gets the configured value.
+     */
+    fun getEffectiveMaxRecordingDurationMs(): Long =
+        clampRecordingDurationMs(getMaxRecordingDurationMs(), getSelectedVoiceProvider())
+
+    /**
+     * Whether the active speech recognition backend is capped at 30 seconds of audio.
+     */
+    fun isSelectedVoiceProviderLimitedTo30s(): Boolean = isLimitedToThirtySeconds(getSelectedVoiceProvider())
+
+    private fun getSelectedVoiceProvider(): AsrProvider? {
+        val selectedId = getSelectedVoiceModelProviderId()
+        // Fall back to the model registry: a local model that is not downloaded (yet) is not listed as a
+        // configured provider, but we still know which backend it belongs to.
+        return getVoiceModelProviders().find { it.id == selectedId }?.provider
+            ?: SUPPORTED_LOCAL_ASR_MODELS[selectedId]?.provider
+    }
 
     /*
      * Not exposed to the UI
@@ -174,6 +205,17 @@ class SettingsClient(val settingsStore: SettingsStore) {
     fun setStayHiddenOnActivation(value: Boolean): Boolean =
         settingsStore.setBoolean(KEY_STAY_HIDDEN_ON_ACTIVATION, value).also { success ->
             if (success) _settingsChanged.tryEmit(KEY_STAY_HIDDEN_ON_ACTIVATION)
+        }
+
+    fun getMaxRecordingDurationS(): Int =
+        settingsStore.getInt(KEY_MAX_RECORDING_DURATION_S, DEFAULT_MAX_RECORDING_DURATION_S)
+
+    fun getMaxRecordingDurationMs(): Long =
+        getMaxRecordingDurationS().toLong() * MILLIS_PER_SECOND
+
+    fun setMaxRecordingDurationS(value: Int): Boolean =
+        settingsStore.setInt(KEY_MAX_RECORDING_DURATION_S, value).also { success ->
+            if (success) _settingsChanged.tryEmit(KEY_MAX_RECORDING_DURATION_S)
         }
 
     fun getTextOutputMethod(): String =

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/settings/SettingsConstants.kt
@@ -35,6 +35,11 @@ const val DEFAULT_HIDE_INSTEAD_OF_MINIMIZE = false
 const val KEY_STAY_HIDDEN_ON_ACTIVATION = "stay-hidden-on-activation"
 const val DEFAULT_STAY_HIDDEN_ON_ACTIVATION = false
 
+const val KEY_MAX_RECORDING_DURATION_S = "max-recording-duration-s"
+const val DEFAULT_MAX_RECORDING_DURATION_S = 30
+const val MIN_MAX_RECORDING_DURATION_S = 10
+const val MAX_MAX_RECORDING_DURATION_S = 300
+
 const val KEY_APPEND_SPACE = "append-space"
 const val DEFAULT_APPEND_SPACE = false
 

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/RecordingLimits.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/asr/RecordingLimits.kt
@@ -1,0 +1,22 @@
+package com.zugaldia.speedofsound.core.plugins.asr
+
+import com.zugaldia.speedofsound.core.plugins.director.WHISPER_MAX_RECORDING_DURATION_MS
+
+/**
+ * Whether a speech recognition backend can only transcribe the first 30 seconds of a recording.
+ *
+ * The Sherpa ONNX offline Whisper recognizer truncates anything past that, it is a limitation of the model
+ * itself. Transducer models (Parakeet), Canary, and cloud providers accept longer audio.
+ */
+fun isLimitedToThirtySeconds(provider: AsrProvider?): Boolean = provider == AsrProvider.SHERPA_WHISPER
+
+/**
+ * Caps a configured recording timeout to what the active backend can actually transcribe, so that we never
+ * record audio that would be silently discarded.
+ */
+fun clampRecordingDurationMs(configuredMs: Long, provider: AsrProvider?): Long =
+    if (isLimitedToThirtySeconds(provider)) {
+        minOf(configuredMs, WHISPER_MAX_RECORDING_DURATION_MS)
+    } else {
+        configuredMs
+    }

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/director/DirectorOptions.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/plugins/director/DirectorOptions.kt
@@ -5,7 +5,9 @@ import com.zugaldia.speedofsound.core.Language
 import com.zugaldia.speedofsound.core.desktop.settings.DEFAULT_LANGUAGE
 
 // Sherpa ONNX offline Whisper recognizer has a hard 30-second limit, longer audio is truncated
-const val DEFAULT_MAX_RECORDING_DURATION_MS = 30_000L
+const val WHISPER_MAX_RECORDING_DURATION_MS = 30_000L
+
+const val DEFAULT_MAX_RECORDING_DURATION_MS = WHISPER_MAX_RECORDING_DURATION_MS
 
 // Default timeout for LLM polishing operations to ensure a quick response
 const val DEFAULT_LLM_TIMEOUT_MS = 5_000L

--- a/core/src/test/kotlin/com/zugaldia/speedofsound/core/plugins/asr/RecordingLimitsTest.kt
+++ b/core/src/test/kotlin/com/zugaldia/speedofsound/core/plugins/asr/RecordingLimitsTest.kt
@@ -1,0 +1,38 @@
+package com.zugaldia.speedofsound.core.plugins.asr
+
+import com.zugaldia.speedofsound.core.plugins.director.WHISPER_MAX_RECORDING_DURATION_MS
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RecordingLimitsTest {
+
+    @Test
+    fun `only sherpa whisper is limited to thirty seconds`() {
+        assertTrue(isLimitedToThirtySeconds(AsrProvider.SHERPA_WHISPER))
+        assertFalse(isLimitedToThirtySeconds(AsrProvider.SHERPA_PARAKEET))
+        assertFalse(isLimitedToThirtySeconds(AsrProvider.SHERPA_CANARY))
+        assertFalse(isLimitedToThirtySeconds(AsrProvider.OPENAI))
+        assertFalse(isLimitedToThirtySeconds(null))
+    }
+
+    @Test
+    fun `whisper caps longer timeouts`() {
+        assertEquals(
+            WHISPER_MAX_RECORDING_DURATION_MS,
+            clampRecordingDurationMs(300_000L, AsrProvider.SHERPA_WHISPER)
+        )
+    }
+
+    @Test
+    fun `whisper keeps shorter timeouts`() {
+        assertEquals(10_000L, clampRecordingDurationMs(10_000L, AsrProvider.SHERPA_WHISPER))
+    }
+
+    @Test
+    fun `other backends keep the configured timeout`() {
+        assertEquals(300_000L, clampRecordingDurationMs(300_000L, AsrProvider.SHERPA_PARAKEET))
+        assertEquals(300_000L, clampRecordingDurationMs(300_000L, AsrProvider.OPENAI))
+    }
+}

--- a/data/io.speedofsound.SpeedOfSound.gschema.xml
+++ b/data/io.speedofsound.SpeedOfSound.gschema.xml
@@ -56,6 +56,12 @@
       <summary>Stay hidden on activation</summary>
       <description>When enabled, the app starts without showing the main window. The global shortcut still works normally.</description>
     </key>
+    <key name="max-recording-duration-s" type="i">
+      <range min="10" max="300"/>
+      <default>30</default>
+      <summary>Recording timeout (seconds)</summary>
+      <description>Maximum duration of a single recording before it stops automatically. Local Whisper models cannot transcribe more than 30 seconds of audio, so the timeout is capped at 30 seconds while one of them is selected.</description>
+    </key>
 
     <!-- Cloud Credentials page -->
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -82,7 +82,7 @@ language and switch between the two using the `Left Shift` and `Right Shift` key
     this requirement. See [Troubleshooting](troubleshooting.md#non-latin-text-produces-only-spaces-and-punctuation)
     for details.
 
-**Output** — Two settings control how transcribed text is delivered to the active application:
+**Output** — Three settings control how transcribed text is delivered to the active application:
 
 - **Text output method** — Choose between **Keyboard simulation** (default), which simulates keyboard input character by
   character via the XDG Remote Desktop Portal, and **Clipboard**, which copies the text to the clipboard and pastes it
@@ -91,6 +91,11 @@ language and switch between the two using the `Left Shift` and `Right Shift` key
 
 - **Append space after transcription** — Automatically inserts a trailing space after each result, which is useful
   when dictating consecutive sentences independently.
+
+- **Recording Timeout** — How long a single recording runs before it stops on its own, from 10 seconds up to 5 minutes
+  (30 seconds by default). Local Whisper models cannot transcribe more than 30 seconds of audio and discard the rest,
+  so while one of them is selected the timeout is capped at 30 seconds and the setting says so. Switch to Parakeet,
+  Canary, or a cloud provider for longer dictations.
 
 **App Behavior** — Configure the general application flow:
 


### PR DESCRIPTION
## What changed

Adds a **Recording Timeout** preference (General → Output; 10–300 s, default 30) wired through to
`DirectorOptions.maxRecordingDurationMs`, replacing the hardcoded `DEFAULT_MAX_RECORDING_DURATION_MS` as the
effective value.

The value is **clamped per ASR backend**: with a Sherpa Whisper model selected it is capped at 30 s, since
the recognizer discards audio past that point; Parakeet, Canary, OpenAI and custom endpoints get the
configured value. The preferences row states the cap in a warning-styled subtitle that follows the model
selection live, so the setting never silently promises what the active model cannot deliver.

`clampRecordingDurationMs` / `isLimitedToThirtySeconds` are pure functions with unit tests.

## Why

Fixes #147, and tries to answer both objections you raised on #163:

1. *A longer timeout is meaningless while the model truncates at 30 s* — hence the per-backend clamp plus the
   visible explanation, rather than a setting that appears to work and doesn't.
2. *10 minutes is meeting-transcription territory* — the ceiling here is 5 minutes. Happy to lower it.

Deliberately scoped to the timeout: VAD-based segmentation (#18) is untouched. This only stops capping the
backends that never needed the cap.

## Testing instructions

1. Select **Parakeet TDT 0.6B** (or Canary / a cloud provider), set Recording Timeout to e.g. 180 s, dictate
   for more than 30 seconds → recording continues to the configured limit and the full text is typed. The log
   no longer shows `Auto-stop timer triggered after 30000ms` at the 30 s mark.
2. Switch to **Whisper Base** → the row turns amber and reads *"Capped at 30 seconds: the selected Whisper
   model discards longer audio…"*; recording still auto-stops at 30 s regardless of the configured value.
3. Switch back → the note clears and the configured value applies again.
4. `./gradlew check` — includes `RecordingLimitsTest` covering both cap directions and all four backends.

Verified on Fedora Asahi Remix 43 (aarch64), GNOME 49.8/Wayland, Flatpak build. User guide updated in the
same commit. Textual conflicts with my other two PRs in `GeneralPage`/`PreferencesViewModel` — happy to
rebase in whatever order suits you.
