### PR TITLE
fix: release the remote desktop session while idle

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/portals/PortalsSessionManager.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/portals/PortalsSessionManager.kt
@@ -1,12 +1,13 @@
 package com.zugaldia.speedofsound.app.portals
 
-import com.zugaldia.speedofsound.core.desktop.portals.PortalsClient
+import com.zugaldia.speedofsound.core.desktop.portals.PortalsGateway
 import com.zugaldia.stargate.sdk.globalshortcuts.ShortcutActivation
 import com.zugaldia.speedofsound.core.desktop.settings.SettingsClient
 import com.zugaldia.stargate.sdk.isSandboxed
 import com.zugaldia.stargate.sdk.request.PortalRequestException
 import com.zugaldia.stargate.sdk.request.RequestResponse
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -15,10 +16,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 
 class PortalsSessionManager(
-    private val portalsClient: PortalsClient,
+    private val portalsClient: PortalsGateway,
     private val settingsClient: SettingsClient,
     initialSessionDisconnected: Boolean = true,
     initialRemoteDesktopStatus: RemoteDesktopStatus = RemoteDesktopStatus.NeedToken,
@@ -26,6 +28,7 @@ class PortalsSessionManager(
     private val logger = LoggerFactory.getLogger(PortalsSessionManager::class.java)
 
     private var portalsEventsJob: Job? = null
+    private var sessionStartJob: Job? = null
 
     private val _isSessionDisconnected = MutableStateFlow(initialSessionDisconnected)
     val isSessionDisconnected: StateFlow<Boolean> = _isSessionDisconnected.asStateFlow()
@@ -65,16 +68,27 @@ class PortalsSessionManager(
             // We can still use portals even if registration above fails.
             // (Some portals might not work, e.g. Global Shortcuts, or have degraded experience though).
             val token = settingsClient.getPortalsRestoreToken()
-            if (token.isNotBlank()) {
-                startSession(scope, token)
-            } else {
+            if (token.isBlank()) {
                 logger.info("No previous session found.")
+            } else {
+                // The session is restored on demand (see [ensureSession]) rather than here, so that the
+                // desktop does not show a screen sharing indicator while the app sits idle.
+                logger.info("Session will be restored on demand.")
+                _remoteDesktopStatus.value = RemoteDesktopStatus.Ready
             }
         }
     }
 
     fun startSession(scope: CoroutineScope, token: String? = null) {
-        scope.launch {
+        // Starting a session is asynchronous, and both the trigger action and the recording itself ask for
+        // one. Without this guard the two calls race and leave an extra session open, which keeps the
+        // desktop's screen sharing indicator lit.
+        if (sessionStartJob?.isActive == true) {
+            logger.info("A session start is already in progress, skipping.")
+            return
+        }
+
+        sessionStartJob = scope.launch {
             val restoreToken = token?.ifBlank { null }
             logger.info(restoreToken?.let { "Trying to restore previous session: $it" } ?: "Starting a new session")
             portalsClient.startRemoteDesktopSession(restoreToken).onSuccess { response ->
@@ -101,6 +115,34 @@ class PortalsSessionManager(
                 _isSessionDisconnected.value = true
                 settingsClient.setPortalsRestoreToken("")
             }
+        }
+    }
+
+    /**
+     * Makes sure a remote desktop session is available before a dictation starts. This is a no-op unless
+     * the session was released while idle (or closed by the desktop, e.g. after the screen was locked).
+     */
+    fun ensureSession(scope: CoroutineScope) {
+        attemptReconnect(scope)
+    }
+
+    /**
+     * Closes the remote desktop session once a dictation is over, so that the desktop stops showing the
+     * screen sharing indicator. The stored restore token keeps the next session silent (no permission
+     * dialog), so this is transparent to the user.
+     */
+    fun releaseSession(scope: CoroutineScope) {
+        if (_isSessionDisconnected.value) return
+
+        // Publish the state change before the close is dispatched, not after it completes: a dictation
+        // triggered while the close is still in flight reads this flag to decide whether it needs to
+        // restore the session, and would otherwise skip the restore and have nothing to type through.
+        _isSessionDisconnected.value = true
+        portalsEventsJob?.cancel()
+        portalsEventsJob = null
+        scope.launch {
+            withContext(Dispatchers.IO) { portalsClient.stopRemoteDesktopSession() }
+                .onFailure { logger.warn("Failed to close the remote desktop session: {}", it.message) }
         }
     }
 

--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/screens/main/MainViewModel.kt
@@ -151,9 +151,8 @@ class MainViewModel(
             return
         }
 
-        // Check if the portal session needs reconnection. This typically happens when the user locks the screen and
-        // comes back. The remote desktop session is closed in those circumstances for security reasons.
-        portalsSessionManager.attemptReconnect(viewModelScope)
+        // The session is (re)opened by toggleListening once the trigger is known to start a recording.
+        // Doing it here too would open a session that nothing closes when the trigger is debounced away.
         logger.info("Trigger action invoked.")
         toggleListening()
     }
@@ -349,6 +348,10 @@ class MainViewModel(
         lastToggleTime = now
 
         if (state.currentStage() == AppStage.IDLE) {
+            // Restores the remote desktop session if it was released while idle, or closed by the desktop
+            // (e.g. after the screen was locked). Done here rather than right before typing so it happens
+            // in parallel with the recording, and only once the trigger is known to start one.
+            portalsSessionManager.ensureSession(viewModelScope)
             currentPipelineJob = viewModelScope.launch { director.start() }
         } else if (state.currentStage() == AppStage.LISTENING) {
             viewModelScope.launch { director.stop() }
@@ -365,6 +368,7 @@ class MainViewModel(
     private fun onPipelineCompleted(event: DirectorEvent.PipelineCompleted) {
         logger.info("Pipeline completed.")
         if (event.finalResult.isBlank()) {
+            portalsSessionManager.releaseSession(viewModelScope)
             hideAndReset()
             return
         }
@@ -399,10 +403,13 @@ class MainViewModel(
                     logger.error("Error outputting text: ${error.message}")
                     portalsClient.showNotification(body = "Failed to output text: ${error.message ?: "Unknown error"}")
                 }
+
+            portalsSessionManager.releaseSession(viewModelScope)
         }
     }
 
     private fun onPipelineCancelled() {
+        portalsSessionManager.releaseSession(viewModelScope)
         hideAndReset()
     }
 
@@ -414,6 +421,7 @@ class MainViewModel(
             PipelineStage.POLISHING -> "Text processing failed: ${event.error.message ?: "Unknown error"}"
         }
         portalsClient.showNotification(body = body)
+        portalsSessionManager.releaseSession(viewModelScope)
         hideAndReset()
     }
 

--- a/app/src/test/kotlin/com/zugaldia/speedofsound/app/portals/PortalsSessionManagerTest.kt
+++ b/app/src/test/kotlin/com/zugaldia/speedofsound/app/portals/PortalsSessionManagerTest.kt
@@ -1,0 +1,174 @@
+package com.zugaldia.speedofsound.app.portals
+
+import com.zugaldia.speedofsound.core.desktop.portals.PortalsGateway
+import com.zugaldia.speedofsound.core.desktop.settings.KEY_PORTALS_RESTORE_TOKEN
+import com.zugaldia.speedofsound.core.desktop.settings.SettingsClient
+import com.zugaldia.speedofsound.core.desktop.settings.SettingsStore
+import com.zugaldia.stargate.sdk.globalshortcuts.BoundShortcut
+import com.zugaldia.stargate.sdk.globalshortcuts.ShortcutActivation
+import com.zugaldia.stargate.sdk.remotedesktop.StartResponse
+import com.zugaldia.stargate.sdk.session.CreateSessionResponse
+import com.zugaldia.stargate.sdk.session.SessionClosedEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val AWAIT_TIMEOUT_SECONDS = 5L
+private const val SETTLE_TIMEOUT_MS = 2_000L
+private const val POLL_INTERVAL_MS = 10L
+private const val RESTORE_TOKEN = "test-restore-token"
+
+/**
+ * Covers the session lifecycle: the app must hold a remote desktop session while dictating and release it
+ * when idle, without ever ending up with two sessions (the desktop shows a screen sharing indicator for
+ * each) or with none when a dictation is about to type.
+ */
+class PortalsSessionManagerTest {
+
+    private class FakeStore(private val values: MutableMap<String, String> = mutableMapOf()) : SettingsStore {
+        override fun isAvailable(): Boolean = true
+        override fun getString(key: String, defaultValue: String): String = values[key] ?: defaultValue
+        override fun setString(key: String, value: String): Boolean = true.also { values[key] = value }
+        override fun getStringArray(key: String, defaultValue: List<String>): List<String> = defaultValue
+        override fun setStringArray(key: String, value: List<String>): Boolean = true
+        override fun getBoolean(key: String, defaultValue: Boolean): Boolean = defaultValue
+        override fun setBoolean(key: String, value: Boolean): Boolean = true
+        override fun getInt(key: String, defaultValue: Int): Int = defaultValue
+        override fun setInt(key: String, value: Int): Boolean = true
+    }
+
+    /**
+     * Records session starts and stops. [blockStopUntilReleased] holds a stop mid-flight, which is how the
+     * "release still in progress" window is reproduced deterministically.
+     */
+    private class FakeGateway(private val blockStopUntilReleased: Boolean = false) : PortalsGateway {
+        val starts = ConcurrentLinkedQueue<String?>()
+        val stops = AtomicInteger(0)
+        val stopEntered = CountDownLatch(1)
+        private val stopMayFinish = CountDownLatch(1)
+
+        override val sessionClosedEvents: Flow<SessionClosedEvent> = emptyFlow()
+        override suspend fun registerApplication(): Result<Unit> = Result.success(Unit)
+        override suspend fun createGlobalShortcutsSession(): Result<CreateSessionResponse> =
+            Result.failure(UnsupportedOperationException("not used in these tests"))
+        override suspend fun bindGlobalShortcuts(): Result<List<BoundShortcut>> = Result.success(emptyList())
+        override fun observeShortcutActivated(): Flow<ShortcutActivation> = emptyFlow()
+
+        override suspend fun startRemoteDesktopSession(restoreToken: String?): Result<StartResponse> {
+            starts.add(restoreToken)
+            return Result.success(
+                StartResponse(devices = emptySet(), clipboardEnabled = false, restoreToken = RESTORE_TOKEN)
+            )
+        }
+
+        override fun stopRemoteDesktopSession(): Result<Unit> {
+            stops.incrementAndGet()
+            stopEntered.countDown()
+            if (blockStopUntilReleased) stopMayFinish.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            return Result.success(Unit)
+        }
+
+        fun letStopFinish() = stopMayFinish.countDown()
+    }
+
+    private fun managerWith(
+        gateway: PortalsGateway,
+        sessionDisconnected: Boolean,
+    ): Pair<PortalsSessionManager, SettingsClient> {
+        val settingsClient = SettingsClient(FakeStore(mutableMapOf(KEY_PORTALS_RESTORE_TOKEN to RESTORE_TOKEN)))
+        val manager = PortalsSessionManager(
+            portalsClient = gateway,
+            settingsClient = settingsClient,
+            initialSessionDisconnected = sessionDisconnected,
+            initialRemoteDesktopStatus = RemoteDesktopStatus.Ready,
+        )
+        return manager to settingsClient
+    }
+
+    private fun waitUntil(description: String, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + SETTLE_TIMEOUT_MS
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        throw AssertionError("Timed out waiting for: $description")
+    }
+
+    @Test
+    fun `ensureSession starts a session while a release is still in flight`() {
+        val gateway = FakeGateway(blockStopUntilReleased = true)
+        val (manager, _) = managerWith(gateway, sessionDisconnected = false)
+        val scope = CoroutineScope(Dispatchers.Default)
+        try {
+            manager.releaseSession(scope)
+            assertTrue(
+                gateway.stopEntered.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                "the release should have reached the portal call",
+            )
+
+            // The user re-triggers before the close has finished. The session must still be restored,
+            // otherwise the dictation has nothing to type through.
+            manager.ensureSession(scope)
+            waitUntil("a session start to be requested") { gateway.starts.isNotEmpty() }
+            assertEquals(1, gateway.starts.size)
+        } finally {
+            gateway.letStopFinish()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `concurrent session starts open a single session`() {
+        val gateway = FakeGateway()
+        val (manager, _) = managerWith(gateway, sessionDisconnected = true)
+        val scope = CoroutineScope(Dispatchers.Default)
+        try {
+            manager.ensureSession(scope)
+            manager.ensureSession(scope)
+            waitUntil("the first session start") { gateway.starts.isNotEmpty() }
+            Thread.sleep(POLL_INTERVAL_MS * 5) // give a second start a chance to slip through
+            assertEquals(1, gateway.starts.size, "a second session would light a second sharing indicator")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `releasing an already released session does not call the portal again`() {
+        val gateway = FakeGateway()
+        val (manager, _) = managerWith(gateway, sessionDisconnected = true)
+        val scope = CoroutineScope(Dispatchers.Default)
+        try {
+            manager.releaseSession(scope)
+            Thread.sleep(POLL_INTERVAL_MS * 5)
+            assertEquals(0, gateway.stops.get())
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a released session is restored on the next dictation`() {
+        val gateway = FakeGateway()
+        val (manager, _) = managerWith(gateway, sessionDisconnected = false)
+        val scope = CoroutineScope(Dispatchers.Default)
+        try {
+            manager.releaseSession(scope)
+            waitUntil("the session to be closed") { gateway.stops.get() == 1 }
+            manager.ensureSession(scope)
+            waitUntil("the session to be restored") { gateway.starts.isNotEmpty() }
+            assertEquals(listOf(RESTORE_TOKEN), gateway.starts.toList(), "restore must reuse the stored token")
+        } finally {
+            scope.cancel()
+        }
+    }
+}

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsClient.kt
@@ -5,6 +5,7 @@ import com.zugaldia.speedofsound.core.APPLICATION_NAME
 import com.zugaldia.speedofsound.core.APPLICATION_SHORT
 import com.zugaldia.speedofsound.core.APPLICATION_SHORTCUT_TRIGGER
 import com.zugaldia.speedofsound.core.generateUniqueId
+import com.zugaldia.stargate.sdk.BUS_NAME
 import com.zugaldia.stargate.sdk.DesktopPortal
 import com.zugaldia.stargate.sdk.globalshortcuts.BoundShortcut
 import com.zugaldia.stargate.sdk.globalshortcuts.Shortcut
@@ -22,20 +23,26 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.freedesktop.dbus.DBusPath
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
+import org.freedesktop.portal.Session
 import org.slf4j.LoggerFactory
 import kotlin.time.Duration.Companion.milliseconds
 
 private const val SHORTCUT_ID = "$APPLICATION_SHORT-trigger"
 private const val SHORTCUT_DESCRIPTION = "Start or stop voice typing"
 
-class PortalsClient {
+@Suppress("TooManyFunctions")
+class PortalsClient : PortalsGateway {
 
     private val logger = LoggerFactory.getLogger(PortalsClient::class.java)
-    private val portal = DesktopPortal.connect()
+    // The connection is created here (rather than via DesktopPortal.connect()) so that sessions can be
+    // closed explicitly, which the SDK does not expose yet.
+    private val connection = DBusConnectionBuilder.forSessionBus().build()
+    private val portal = DesktopPortal(connection)
     private var shortcutsSessionHandle: DBusPath? = null
     private val shortcutsSessionMutex = Mutex()
 
-    val sessionClosedEvents: Flow<SessionClosedEvent>
+    override val sessionClosedEvents: Flow<SessionClosedEvent>
         get() = portal.remoteDesktop.observeSessionClosed()
 
     /**
@@ -43,7 +50,7 @@ class PortalsClient {
      * This should only be called when not running in a sandboxed environment (Flatpak/Snap),
      * as sandboxed apps are registered automatically.
      */
-    suspend fun registerApplication() =
+    override suspend fun registerApplication() =
         portal.registry.register(APPLICATION_ID)
             .onSuccess { logger.info("Registered application ID: {}", APPLICATION_ID) }
             .onFailure { logger.warn("Failed to register application ID: {} ({})", APPLICATION_ID, it.message) }
@@ -54,12 +61,31 @@ class PortalsClient {
      * @param restoreToken Optional token from a previous session. When provided, the portal will
      * attempt to restore the session without prompting the user for authorization again.
      */
-    suspend fun startRemoteDesktopSession(restoreToken: String?): Result<StartResponse> =
+    override suspend fun startRemoteDesktopSession(restoreToken: String?): Result<StartResponse> =
         portal.remoteDesktop.startSession(
             types = setOf(DeviceType.KEYBOARD),
             restoreToken = restoreToken,
             persistMode = PersistMode.UNTIL_REVOKED
         )
+
+    /**
+     * Closes the active remote desktop session, if any.
+     *
+     * The desktop shows a screen sharing indicator for as long as a remote desktop session is open, so the
+     * session is worth releasing while the app is idle. Note that the SDK's `clearSession()` only drops the
+     * local handle, it does not close the session on the portal side, hence the explicit `Close()` call.
+     */
+    override fun stopRemoteDesktopSession(): Result<Unit> = runCatching {
+        val handle = portal.remoteDesktop.activeSession
+        if (handle == null) {
+            logger.info("No active remote desktop session to close.")
+            return@runCatching
+        }
+
+        connection.getRemoteObject(BUS_NAME, handle.path, Session::class.java).Close()
+        portal.remoteDesktop.clearSession()
+        logger.info("Closed remote desktop session: {}", handle.path)
+    }
 
     /**
      * Sends a desktop notification via the XDG Notification portal.
@@ -94,23 +120,24 @@ class PortalsClient {
      * This is idempotent — if a session already exists, it returns success without creating a new one.
      * This is expected to fail on older desktop environments that do not support the portal.
      */
-    suspend fun createGlobalShortcutsSession(): Result<CreateSessionResponse> = shortcutsSessionMutex.withLock {
-        val existingHandle = shortcutsSessionHandle
-        if (existingHandle != null) {
-            logger.info("Global shortcuts session already exists, skipping creation.")
-            return@withLock Result.success(CreateSessionResponse(existingHandle))
-        }
+    override suspend fun createGlobalShortcutsSession(): Result<CreateSessionResponse> =
+        shortcutsSessionMutex.withLock {
+            val existingHandle = shortcutsSessionHandle
+            if (existingHandle != null) {
+                logger.info("Global shortcuts session already exists, skipping creation.")
+                return@withLock Result.success(CreateSessionResponse(existingHandle))
+            }
 
-        portal.globalShortcuts.createSession()
-            .onSuccess { response -> shortcutsSessionHandle = response.sessionHandle }
-    }
+            portal.globalShortcuts.createSession()
+                .onSuccess { response -> shortcutsSessionHandle = response.sessionHandle }
+        }
 
     /**
      * Returns a Flow that emits a [ShortcutActivation] each time the global shortcut is activated.
      *
      * Filters activations to only the application's shortcut ID and only when activated (not released).
      */
-    fun observeShortcutActivated(): Flow<ShortcutActivation> =
+    override fun observeShortcutActivated(): Flow<ShortcutActivation> =
         portal.globalShortcuts.activations()
             .filter { it.shortcutId == SHORTCUT_ID && it.activated }
 
@@ -145,7 +172,7 @@ class PortalsClient {
     /**
      * Binds the application's global shortcut to the active session.
      */
-    suspend fun bindGlobalShortcuts(): Result<List<BoundShortcut>> {
+    override suspend fun bindGlobalShortcuts(): Result<List<BoundShortcut>> {
         val handle = shortcutsSessionHandle
             ?: return Result.failure(IllegalStateException("No active global shortcuts session"))
         val shortcut = Shortcut(

--- a/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsGateway.kt
+++ b/core/src/main/kotlin/com/zugaldia/speedofsound/core/desktop/portals/PortalsGateway.kt
@@ -1,0 +1,31 @@
+package com.zugaldia.speedofsound.core.desktop.portals
+
+import com.zugaldia.stargate.sdk.globalshortcuts.BoundShortcut
+import com.zugaldia.stargate.sdk.globalshortcuts.ShortcutActivation
+import com.zugaldia.stargate.sdk.remotedesktop.StartResponse
+import com.zugaldia.stargate.sdk.session.CreateSessionResponse
+import com.zugaldia.stargate.sdk.session.SessionClosedEvent
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * The portal operations the session manager depends on.
+ *
+ * [PortalsClient] is the real implementation, which opens a D-Bus connection in its constructor. This
+ * interface exists so the session lifecycle (start, restore on demand, release when idle) can be tested
+ * without a desktop portal.
+ */
+interface PortalsGateway {
+    val sessionClosedEvents: Flow<SessionClosedEvent>
+
+    suspend fun registerApplication(): Result<Unit>
+
+    suspend fun createGlobalShortcutsSession(): Result<CreateSessionResponse>
+
+    suspend fun bindGlobalShortcuts(): Result<List<BoundShortcut>>
+
+    fun observeShortcutActivated(): Flow<ShortcutActivation>
+
+    suspend fun startRemoteDesktopSession(restoreToken: String?): Result<StartResponse>
+
+    fun stopRemoteDesktopSession(): Result<Unit>
+}


### PR DESCRIPTION
## What changed

The XDG RemoteDesktop session is now opened when a dictation starts and closed when the pipeline ends
(including the cancelled and error paths), instead of being restored at startup and held for the app's whole
lifetime.

- `PortalsClient.stopRemoteDesktopSession()` calls `Session.Close()` explicitly — the SDK's `clearSession()`
  only drops the local handle — so `PortalsClient` now owns its `DBusConnection`.
- `PortalsSessionManager` restores on demand (`ensureSession`) and releases (`releaseSession`); it depends on
  a narrow `PortalsGateway` interface so the lifecycle is testable without a portal.
- `toggleListening` is the single owner of the session start.

## Why

Fixes #184. GNOME lights its screen-sharing indicator for as long as a remote-desktop session exists, whether
or not input is being injected — so the indicator sits in the top bar permanently, even though the session is
only needed for the moment a transcription is typed. It also gets worse the longer the app is left running,
which is the intended way to use it.

Restoring is silent: with the stored token and `PersistMode.UNTIL_REVOKED` the portal does not prompt, so
this is invisible to the user apart from the indicator behaving honestly.

If you'd rather have the `Close()` live in Stargate as `RemoteDesktopPortal.closeSession()`, say the word and
I'll move it there and depend on the new SDK version.

## Testing instructions

1. Authorize the portal once, then leave the app idle → no screen-sharing indicator, and
   `busctl --user tree org.gnome.Mutter.RemoteDesktop` lists no session object.
2. Start a dictation → a session appears (indicator on); after the text is typed it disappears again, with
   `Closed remote desktop session: …` in the log. **No permission dialog** on any dictation.
3. Both output methods (keyboard simulation and clipboard) still type into the target app.
4. Lock the screen mid-session, unlock, dictate → the session is restored as before.
5. `./gradlew check` — `PortalsSessionManagerTest` covers the two races found while building this: two starts
   in the same tick left an orphan session (a second indicator that nothing closed), and publishing the
   disconnected state only after the blocking close let a dictation triggered mid-close skip the restore and
   have no session to type through.

Verified on Fedora Asahi Remix 43 (aarch64), GNOME 49.8/Wayland, Flatpak build.

One gap worth flagging: the single-owner change in `MainViewModel.toggleListening` has no automated test,
since `MainViewModel` builds GTK objects and needs a display. It was verified by hand per step 2 above.
