### PR TITLE
fix: do not log the remote desktop restore token

### DIFF
--- a/app/src/main/kotlin/com/zugaldia/speedofsound/app/portals/PortalsSessionManager.kt
+++ b/app/src/main/kotlin/com/zugaldia/speedofsound/app/portals/PortalsSessionManager.kt
@@ -76,11 +76,13 @@ class PortalsSessionManager(
     fun startSession(scope: CoroutineScope, token: String? = null) {
         scope.launch {
             val restoreToken = token?.ifBlank { null }
-            logger.info(restoreToken?.let { "Trying to restore previous session: $it" } ?: "Starting a new session")
+            logger.info(
+                restoreToken?.let { "Trying to restore the previous session" } ?: "Starting a new session"
+            )
             portalsClient.startRemoteDesktopSession(restoreToken).onSuccess { response ->
                 val newToken = response.restoreToken
                 if (!newToken.isNullOrBlank()) {
-                    logger.info("Got a fresh restore token: $newToken")
+                    logger.info("Got a fresh restore token.")
                     settingsClient.setPortalsRestoreToken(newToken)
                 }
                 collectPortalsEvents(scope)


### PR DESCRIPTION
## What changed

Stops writing the remote-desktop restore token into the log. `PortalsSessionManager` logged it at INFO on
every startup and every restore; it now logs that a restore is being attempted, not the value.

## Why

The token is a capability: anyone holding it can reopen a remote-desktop session — i.e. synthesize input —
without the user being prompted. Logs are the wrong place for it: on a Flatpak install it lands in the
journal, and log files travel (bug reports, screenshots of a terminal, log aggregators).

No behaviour change beyond the log text.

## Testing instructions

Start the app with a stored token and check the log: it should read `Trying to restore the previous session`
and `Got a fresh restore token.` with no token value on either line. `./gradlew check` passes.
